### PR TITLE
add _run_memcached_solo.sh

### DIFF
--- a/_run_memcached_solo.sh
+++ b/_run_memcached_solo.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+./memcached -E .libs/default_engine.so -X .libs/syslog_logger.so -X .libs/ascii_scrub.so $@


### PR DESCRIPTION
I think adding run_script for arcus-memcached.
because arcus run_script in arcus repository so. it is hard to learn how to run arucs-memcached.
so, I just add run_script to run arcus-memcached. 
