### PR TITLE
Uninitialized variable in lqdetect_dupcheck

### DIFF
--- a/lqdetect.c
+++ b/lqdetect.c
@@ -199,7 +199,7 @@ void lqdetect_buffer_release(int bufcnt)
 
 static bool lqdetect_dupcheck(char *key, enum lq_detect_command cmd, struct lq_detect_argument *arg)
 {
-    int ii;
+    int ii = 0;
     int count = lqdetect.buffer[cmd].nsaved;
 
     switch (cmd) {


### PR DESCRIPTION
Build fails because of an uninitialized variable in `lqdetect.c`, `lqdetect_dupcheck()`. Here's the error message.

```
gcc -std=gnu99 -DHAVE_CONFIG_H -I.   -I./include  -fvisibility=hidden -pthread -g -O2 -Wall -Werror -pedantic -Wmissing-prototypes -Wmissing-declarations -Wredundant-decls  -MT memcached-lqdetect.o -MD -MP -MF .deps/memcached-lqdetect.Tpo -c -o memcached-lqdetect.o `test -f 'lqdetect.c' || echo './'`lqdetect.c
lqdetect.c: In function ‘lqdetect_save_cmd’:
lqdetect.c:244:27: error: ‘ii’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
     lqdetect.arg[cmd][ii] = *arg;
                           ^
lqdetect.c:202:9: note: ‘ii’ was declared here
     int ii;
         ^
cc1: all warnings being treated as errors
make[2]: *** [memcached-lqdetect.o] Error 1
```

I'm using gcc 4.8.5, on Ubuntu 14.04 LTS x86_64.