### PR TITLE
Refactor : update cmd_delete stats.

### DIFF
--- a/memcached.h
+++ b/memcached.h
@@ -211,6 +211,7 @@ struct thread_stats {
 #ifdef UPDATE_INCR_DECR
     uint64_t          cmd_incr;
     uint64_t          cmd_decr;
+    uint64_t          cmd_delete;
 #endif
     uint64_t          get_misses;
     uint64_t          delete_misses;

--- a/thread.c
+++ b/thread.c
@@ -528,7 +528,9 @@ void threadlocal_stats_clear(struct thread_stats *stats) {
 #ifdef UPDATE_INCR_DECR
     stats->cmd_incr = 0;
     stats->cmd_decr = 0;
+
 #endif
+    stats->cmd_delete = 0;
     stats->get_misses = 0;
     stats->delete_misses = 0;
     stats->incr_misses = 0;
@@ -653,6 +655,7 @@ void threadlocal_stats_aggregate(struct thread_stats *thread_stats, struct threa
         stats->cmd_incr += thread_stats[ii].cmd_incr;
         stats->cmd_decr += thread_stats[ii].cmd_decr;
 #endif
+        stats->cmd_delete += thread_stats[ii].cmd_delete;
         stats->get_misses += thread_stats[ii].get_misses;
         stats->delete_misses += thread_stats[ii].delete_misses;
         stats->decr_misses += thread_stats[ii].decr_misses;


### PR DESCRIPTION
@jhpark816 다시 PR 요청드립니다.

code tag없이 추가하려고 하였으나, code tag를 하지 않으면 에러가 발생하여
불가피하게 이전 cmd_incr, cmd_decr 추가에 사용했던 code tag를 사용하였습니다. 

binary protocol부분은 확인 결과 delete는 따로 count를 하지 않아 추가하지 않았습니다.