### PR TITLE
Change script runners from /bin/sh to /bin/bash.

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -25,7 +25,7 @@ The pre-commit hook can be used to ensure that your tree passes tests
 before allowing a commit.  To do so, add the following to
 .git/hooks/pre-commit (which must be executable):
 
-    #!/bin/sh
+    #!/bin/bash
     make test
 
 ** Post Commit Hook
@@ -35,7 +35,7 @@ post commit hook to update the version number after each commit so as
 to keep the reporting accurate.  To do so, add the following to
 .git/hooks/post-commit (which must be executable)
 
-    #!/bin/sh
+    #!/bin/bash
     ./version.sh
 
 ** Running memcached in gdb for tests.

--- a/_run_memcached_solo.sh
+++ b/_run_memcached_solo.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/bin/bash
 
 ./memcached -E .libs/default_engine.so -X .libs/syslog_logger.so -X .libs/ascii_scrub.so $@

--- a/config/autorun.sh
+++ b/config/autorun.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 die() { echo "$@"; exit 1; }
 

--- a/devtools/maketags.sh
+++ b/devtools/maketags.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 find ../ -name "*[cht]" > ./cscope.files
 ctags --extra=+q -L ./cscope.files -f ./tags
 rm ./cscope.files

--- a/scripts/memcached-init
+++ b/scripts/memcached-init
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 #
 # skeleton  example file to build /etc/init.d/ scripts.
 #       This file should be used to construct scripts for /etc/init.d.

--- a/scripts/memcached.sysv
+++ b/scripts/memcached.sysv
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 #
 # chkconfig: - 55 45
 # description:  The memcached daemon is a network memory cache service.

--- a/win32/config.sh
+++ b/win32/config.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 MEMC_VERSION=`git describe | tr '-' '_'`;
 cat > .libs/config_version.h << EOF
 #ifndef CONFIG_VERSION_H


### PR DESCRIPTION
I cannot build arcus-memcached on the debian jessie. Some linux distribution uses different shell for `/bin/sh`, for example `dash`, so there would be error like '[[: not found` which seems not supported on dash. To make the build environment consistent, `/bin/bash` seems appropriate.

It is not explicitly mentioned, memcached also [changed](https://github.com/memcached/memcached/commit/1e52a2543fe02fc48e3396456d487e6a07065453) to `bin/bash` for `script/memcached-init` file.