### PR TITLE
Fix failing autorun.sh on dash

### DIFF
--- a/config/autorun.sh
+++ b/config/autorun.sh
@@ -40,7 +40,7 @@ fi
 
 mkdir -p m4
 
-if [[ -d .git || -f .git ]]
+if [ -d .git ]
 then
   perl config/version.pl || die "Failed to run config/version.pl"
 fi


### PR DESCRIPTION
Changed autorun.sh to run on dash (on debian distributions).
Refer to https://github.com/naver/arcus-memcached/pull/30