### PR TITLE
fix config/autorun.sh for arcus build

### DIFF
--- a/config/autorun.sh
+++ b/config/autorun.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 die() { echo "$@"; exit 1; }
 
@@ -40,7 +40,7 @@ fi
 
 mkdir -p m4
 
-if [ -d .git ]
+if [[ -d .git || -f .git ]]
 then
   perl config/version.pl || die "Failed to run config/version.pl"
 fi


### PR DESCRIPTION
arcus 빌드가 진행되면서 submodule이 업데이트 될 때
arcus-memcached의 폴더에 있는 .git 이 폴더가 아니라 파일이어서
해당 명령어가 실행되지 않는 사항을 수정하였습니다.