### PR TITLE
LONG_KEY_SUPPORT: increase max key and prefix size 250 to 65530

### DIFF
--- a/assoc.h
+++ b/assoc.h
@@ -21,7 +21,11 @@
 typedef struct _prefix_t prefix_t;
 
 struct _prefix_t {
+#ifdef LONG_KEY_SUPPORT
+    uint16_t nprefix;
+#else
     uint8_t nprefix;
+#endif
 
     uint32_t prefix_items;
     uint64_t list_hash_items;

--- a/include/memcached/types.h
+++ b/include/memcached/types.h
@@ -38,6 +38,7 @@ struct iovec {
 #define MAX_EFLAG_COMPARE_COUNT 100
 
 #define JHPARK_KEY_DUMP
+//#define LONG_KEY_SUPPORT
 
 #ifdef __cplusplus
 extern "C" {

--- a/items.c
+++ b/items.c
@@ -1496,7 +1496,11 @@ static hash_item *do_list_item_alloc(struct default_engine *engine,
         if (attrp->exptime == (rel_time_t)(-1)) info->mflags |= COLL_META_FLAG_STICKY;
 #endif
         if (attrp->readable == 1)               info->mflags |= COLL_META_FLAG_READABLE;
+#ifdef LONG_KEY_SUPPORT
+        info->itdist  = (uint16_t)((size_t*)info-(size_t*)it);
+#else
         info->itdist  = (uint8_t)((size_t*)info-(size_t*)it);
+#endif
         info->stotal  = 0;
         info->prefix  = NULL;
         info->head = info->tail = NULL;
@@ -1791,7 +1795,11 @@ static hash_item *do_set_item_alloc(struct default_engine *engine,
         if (attrp->exptime == (rel_time_t)(-1)) info->mflags |= COLL_META_FLAG_STICKY;
 #endif
         if (attrp->readable == 1)               info->mflags |= COLL_META_FLAG_READABLE;
+#ifdef LONG_KEY_SUPPORT
+        info->itdist  = (uint16_t)((size_t*)info-(size_t*)it);
+#else
         info->itdist  = (uint8_t)((size_t*)info-(size_t*)it);
+#endif
         info->stotal  = 0;
         info->prefix  = NULL;
         info->root    = NULL;
@@ -2353,10 +2361,17 @@ static hash_item *do_btree_item_alloc(struct default_engine *engine,
         if (attrp->exptime == (rel_time_t)(-1)) info->mflags |= COLL_META_FLAG_STICKY;
 #endif
         if (attrp->readable == 1)               info->mflags |= COLL_META_FLAG_READABLE;
+#ifdef LONG_KEY_SUPPORT
+        info->itdist  = (uint16_t)((size_t*)info-(size_t*)it);
+        info->stotal  = 0;
+        info->prefix  = NULL;
+        info->bktype  = BKEY_TYPE_UNKNOWN;
+#else
         info->itdist  = (uint8_t)((size_t*)info-(size_t*)it);
         info->bktype  = BKEY_TYPE_UNKNOWN;
         info->stotal  = 0;
         info->prefix  = NULL;
+#endif
         info->maxbkeyrange.len = BKEY_NULL;
         info->root    = NULL;
         assert(do_coll_get_hash_item((coll_meta_info*)info) == it);

--- a/items.h
+++ b/items.h
@@ -33,8 +33,15 @@ typedef struct _hash_item {
                          * Lower 8 bits are reserved for the core server,
                          * Upper 8 bits are reserved for engine implementation.
                          */
+#ifdef LONG_KEY_SUPPORT
+    uint16_t nkey;      /* The total length of the key (in bytes) */
+    uint16_t nprefix;   /* The prefix length of the key (in bytes) */
+    uint16_t dummy16;
+    uint32_t dummy32;
+#else
     uint8_t  nkey;      /* The total length of the key (in bytes) */
     uint8_t  nprefix;   /* The prefix length of the key (in bytes) */
+#endif
     uint32_t nbytes;    /* The total length of the data (in bytes) */
 } hash_item;
 
@@ -85,8 +92,12 @@ typedef struct _list_meta_info {
     int32_t  ccnt;      /* current count */
     uint8_t  ovflact;   /* overflow action */
     uint8_t  mflags;    /* sticky, readable flags */
+#ifdef LONG_KEY_SUPPORT
+    uint16_t itdist;    /* distance from hash item (unit: sizeof(size_t)) */
+#else
     uint8_t  itdist;    /* distance from hash item (unit: sizeof(size_t)) */
     uint8_t  reserved;
+#endif
     uint32_t stotal;    /* total space */
     void    *prefix;    /* pointer to prefix meta info */
     list_elem_item *head;
@@ -113,8 +124,12 @@ typedef struct _set_meta_info {
     int32_t  ccnt;      /* current count */
     uint8_t  ovflact;   /* overflow action */
     uint8_t  mflags;    /* sticky, readable flags */
+#ifdef LONG_KEY_SUPPORT
+    uint16_t itdist;    /* distance from hash item (unit: sizeof(size_t)) */
+#else
     uint8_t  itdist;    /* distance from hash item (unit: sizeof(size_t)) */
     uint8_t  reserved;
+#endif
     uint32_t stotal;    /* total space */
     void    *prefix;    /* pointer to prefix meta info */
     set_hash_node *root;
@@ -152,10 +167,18 @@ typedef struct _btree_meta_info {
     int32_t  ccnt;      /* current count */
     uint8_t  ovflact;   /* overflow action */
     uint8_t  mflags;    /* sticky, readable, trimmed flags */
+#ifdef LONG_KEY_SUPPORT
+    uint16_t itdist;    /* distance from hash item (unit: sizeof(size_t)) */
+    uint32_t stotal;    /* total space */
+    void    *prefix;    /* pointer to prefix meta info */
+    uint8_t  bktype;    /* bkey type : BKEY_TYPE_UINT64 or BKEY_TYPE_BINARY */
+    uint8_t  dummy[7];  /* reserved space */
+#else
     uint8_t  itdist;    /* distance from hash item (unit: sizeof(size_t)) */
     uint8_t  bktype;    /* bkey type : BKEY_TYPE_UINT64 or BKEY_TYPE_BINARY */
     uint32_t stotal;    /* total space */
     void    *prefix;    /* pointer to prefix meta info */
+#endif
     bkey_t   maxbkeyrange;
     btree_indx_node *root;
 } btree_meta_info;
@@ -184,8 +207,12 @@ typedef struct _coll_meta_info {
     int32_t  ccnt;      /* current count */
     uint8_t  ovflact;   /* overflow action */
     uint8_t  mflags;    /* sticky, readable flags */
+#ifdef LONG_KEY_SUPPORT
+    uint16_t itdist;    /* distance from hash item (unit: sizeof(size_t)) */
+#else
     uint8_t  itdist;    /* distance from hash item (unit: sizeof(size_t)) */
     uint8_t  reserved;
+#endif
     uint32_t stotal;    /* total space */
     void    *prefix;    /* pointer to prefix meta info */
 } coll_meta_info;


### PR DESCRIPTION
Long key support를 위한 사전작업으로 key, prefix를 2bytes로 늘리는 작업입니다.

First reviewer
- [ ] @minkikim89

Final reviewer
- [ ] @jhpark816
