### PR TITLE
LONG_KEY_SUPPORT: add hash value for reduce hash function call

### DIFF
--- a/assoc.c
+++ b/assoc.c
@@ -114,8 +114,12 @@ static void redistribute(struct default_engine *engine, unsigned int bucket)
          prev = &assoc->roottable[ii].hashtable[bucket];
          while (*prev != NULL) {
              it = *prev;
+#ifdef LONG_KEY_SUPPORT
+             tabidx = GET_HASH_TABIDX(it->hval, assoc->hashpower, hashmask(assoc->rootpower));
+#else
              tabidx = GET_HASH_TABIDX(engine->server.core->hash(item_get_key(it), it->nkey, 0),
                                       assoc->hashpower, hashmask(assoc->rootpower));
+#endif
              if (tabidx == ii) {
                  prev = &it->h_next;
              } else {
@@ -141,7 +145,11 @@ hash_item *assoc_find(struct default_engine *engine, uint32_t hash,
 
     it = assoc->roottable[tabidx].hashtable[bucket];
     while (it) {
+#ifdef LONG_KEY_SUPPORT
+        if ((nkey == it->nkey) && (hash == it->hval) && (memcmp(key, item_get_key(it), nkey) == 0)) {
+#else
         if ((nkey == it->nkey) && (memcmp(key, item_get_key(it), nkey) == 0)) {
+#endif
             ret = it;
             break;
         }

--- a/items.c
+++ b/items.c
@@ -892,7 +892,12 @@ static ENGINE_ERROR_CODE do_item_link(struct default_engine *engine, hash_item *
     /* link the item to the hash table */
     it->iflag |= ITEM_LINKED;
     it->time = engine->server.core->get_current_time();
+#ifdef LONG_KEY_SUPPORT
+    it->hval = engine->server.core->hash(key, it->nkey, 0);
+    assoc_insert(engine, it->hval, it);
+#else
     assoc_insert(engine, engine->server.core->hash(key, it->nkey, 0), it);
+#endif
 
     /* link the item to LRU list */
     item_link_q(engine, it);
@@ -927,8 +932,12 @@ static void do_item_unlink(struct default_engine *engine, hash_item *it,
         item_unlink_q(engine, it);
 
         /* unlink the item from hash table */
+#ifdef LONG_KEY_SUPPORT
+        assoc_delete(engine, it->hval, key, it->nkey);
+#else
         assoc_delete(engine, engine->server.core->hash(key, it->nkey, 0),
                      key, it->nkey);
+#endif
         it->iflag &= ~ITEM_LINKED;
 
         /* unlink the item from prefix info */

--- a/items.h
+++ b/items.h
@@ -37,7 +37,7 @@ typedef struct _hash_item {
     uint16_t nkey;      /* The total length of the key (in bytes) */
     uint16_t nprefix;   /* The prefix length of the key (in bytes) */
     uint16_t dummy16;
-    uint32_t dummy32;
+    uint32_t hval;      /* hash value */
 #else
     uint8_t  nkey;      /* The total length of the key (in bytes) */
     uint8_t  nprefix;   /* The prefix length of the key (in bytes) */


### PR DESCRIPTION
Long key support를 위한 사전작업으로 hash_item structure에 hash value를 추가하고,
hash function call을 줄이는 내용입니다.

First reviewer
- [ ] @minkikim89

Final reviewer
- [x] @jhpark816
