### PR TITLE
Fix an uninitialized error in items.c

### DIFF
--- a/items.c
+++ b/items.c
@@ -1955,7 +1955,7 @@ static ENGINE_ERROR_CODE do_set_elem_link(struct default_engine *engine,
     assert(info->root != NULL);
     set_hash_node *node = info->root;
     set_elem_item *find;
-    int hidx;
+    int hidx = -1;
 
     /* set hash value */
     elem->hval = genhash_string_hash(elem->value, elem->nbytes);
@@ -1967,6 +1967,7 @@ static ENGINE_ERROR_CODE do_set_elem_link(struct default_engine *engine,
         node = node->htab[hidx];
     }
     assert(node != NULL);
+    assert(hidx != -1);
 
     for (find = node->htab[hidx]; find != NULL; find = find->next) {
         if (set_hash_eq(elem->hval, elem->value, elem->nbytes,


### PR DESCRIPTION
alpine linux 3.4 에서 빌드하려니 에러가 발생했습니다. 어떻게 에러 코드를 처리해야 할지 모르겠어서 일단 제너릭 오류로 처리했습니다.

```
items.c: In function 'set_elem_insert':
items.c:1971:15: error: 'hidx' may be used uninitialized in this function [-Werror=maybe-uninitialized]
     for (find = node->htab[hidx]; find != NULL; find = find->next) {
               ^
items.c:1958:9: note: 'hidx' was declared here
     int hidx;
         ^
```