### PR TITLE
Define PREFIX_MAX_LENGTH constant.

### DIFF
--- a/memcached.h
+++ b/memcached.h
@@ -46,6 +46,7 @@
 
 /** Maximum length of a key. */
 #define KEY_MAX_LENGTH 250
+#define PREFIX_MAX_LENGTH (KEY_MAX_LENGTH - 1)
 
 /** Size of an incr buf. */
 #define INCR_MAX_STORAGE_LEN 24


### PR DESCRIPTION
PREFIX_MAX_LENGTH used, but not defined. Build fails.