### PR TITLE
Dockerize arcus-memcached.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM alpine:3.4
+
+RUN addgroup -S memcached
+RUN adduser -S -D -H -s /sbin/nologin -G memcached -g memcached memcached
+
+COPY . /arcus-memcached
+
+RUN apk add --no-cache libevent-dev \
+    autoconf automake libtool cppunit build-base \
+    perl git \
+    && cd /arcus-memcached \
+    && tar xzf zookeeper-3.4.5.tar.gz \
+    && cd zookeeper-3.4.5/src/c \
+    && ./configure && make && make install \
+    && cd /arcus-memcached \
+    && ./config/autorun.sh \
+    && ./configure --enable-zk-integration \
+    && make && make install \
+    && apk del autoconf automake libtool cppunit build-base perl git libevent-dev \
+    && cd / && rm -rf /arcus-memcached \
+    && apk add --no-cache libevent
+
+CMD ["memcached", "-u", "memcached", "-E", "/usr/local/lib/default_engine.so"]


### PR DESCRIPTION
- Based on the alpine linux for the small size image.
- Builds with zookeeper c client which is precompiled.
- Installs dependencies from the package manager. (do not specify zookeeper lib directory and libevent directory)

Usage:

``` bash
# Build
$ docker build -t arcus/arcus-memcached .

# Run standalone
$ docker run -p 11211:11211 arcus/arcus-memcached

# Run with zookeeper
$ docker run -p 11211:11211 arcus/arcus-memcached memcached -u memcached -E /usr/local/lib/default_engine.so -z <zookeeper host>:<zookeeper port>
```
