### PR TITLE
Add Config api

### DIFF
--- a/engines/demo/demo_engine.c
+++ b/engines/demo/demo_engine.c
@@ -703,6 +703,15 @@ Demo_get_prefix_stats(ENGINE_HANDLE* handle, const void* cookie,
  * Config API
  */
 
+#ifdef CONFIG_API
+static ENGINE_ERROR_CODE
+Demo_set_config(ENGINE_HANDLE* handle, const void* cookie,
+                const char* config_type, const void* config_value)
+{
+    return ENGINE_ENOTSUP;
+}
+#endif
+
 /*
  * Unknown Command API
  */
@@ -819,6 +828,9 @@ create_instance(uint64_t interface, GET_SERVER_API get_server_api,
          .get_prefix_stats = Demo_get_prefix_stats,
          /* Dump API */
          /* Config API */
+#ifdef CONFIG_API
+         .set_config       = Demo_set_config,
+#endif
          /* Unknown Command API */
          /* Info API */
          .get_item_info    = Demo_get_item_info,

--- a/include/memcached/engine.h
+++ b/include/memcached/engine.h
@@ -652,6 +652,11 @@ extern "C" {
                                               const void* key, const int nkey,
                                               void *prefix_data);
 
+#ifdef CONFIG_API
+        ENGINE_ERROR_CODE (*set_config)(ENGINE_HANDLE* handle, const void* cookie,
+                                        const char* config_key, const void* config_value);
+#else
+
         ENGINE_ERROR_CODE (*set_memlimit)(ENGINE_HANDLE* handle, const void *cookie,
                                           const size_t memlimit);
 
@@ -659,11 +664,12 @@ extern "C" {
         ENGINE_ERROR_CODE (*set_maxcollsize)(ENGINE_HANDLE* handle, const void *cookie,
                                           const int coll_type, int *maxsize);
 #endif
+#endif
 
         void (*set_verbose) (ENGINE_HANDLE* handle, const void* cookie,
                              const size_t verbose);
 
-       char *(*cachedump)(ENGINE_HANDLE* handle, const void *cookie,
+        char *(*cachedump)(ENGINE_HANDLE* handle, const void *cookie,
                           const unsigned int slabs_clsid,
                           const unsigned int limit,
                           const bool forward,

--- a/include/memcached/types.h
+++ b/include/memcached/types.h
@@ -31,6 +31,7 @@ struct iovec {
 #include <sys/uio.h>
 #endif
 
+#define CONFIG_API
 #define MAP_COLLECTION_SUPPORT
 #define SUPPORT_BOP_MGET
 #define SUPPORT_BOP_SMGET


### PR DESCRIPTION
대표님께서 verbose value 는 memcached 코어에서 사용하므로 valid check를 해서 값만 engine에 넘겨주라고  말씀하셔서 코어에서 verbosity 만 따로 filtering하여 valid check하도록 수정하였습니다.

First reviewer
- [x] @minkikim89 
- [x] @MinWooJin 

Final reviewer
- [x] @jhpark816 