### PR TITLE
Refactor: key can be NULL in do_item_alloc function

### DIFF
--- a/engines/default/items.c
+++ b/engines/default/items.c
@@ -710,7 +710,9 @@ static hash_item *do_item_alloc(struct default_engine *engine,
     it->nkey = nkey;
     it->nbytes = nbytes;
     it->flags = flags;
-    memcpy((void*)item_get_key(it), key, nkey);
+    if (key != NULL) {
+        memcpy((void*)item_get_key(it), key, nkey);
+    }
     it->exptime = exptime;
     it->nprefix = 0;
     return it;
@@ -5926,6 +5928,7 @@ hash_item *item_alloc(struct default_engine *engine,
 {
     hash_item *it;
     pthread_mutex_lock(&engine->cache_lock);
+    /* key can be NULL */
     it = do_item_alloc(engine, key, nkey, flags, exptime, nbytes, cookie);
     pthread_mutex_unlock(&engine->cache_lock);
     return it;

--- a/include/memcached/engine.h
+++ b/include/memcached/engine.h
@@ -223,7 +223,7 @@ extern "C" {
          * @param handle the engine handle
          * @param cookie The cookie provided by the frontend
          * @param output variable that will receive the item
-         * @param key the item's key
+         * @param key the item's key (can be NULL)
          * @param nkey the length of the key
          * @param nbytes the number of bytes that will make up the
          *        value of this item.


### PR DESCRIPTION
first reviewer
- [ ] @MinWooJin 

final reviewer
- [x] @jhpark816 