### PR TITLE
Refactor: sticky_ratio -> sticky_limit

### DIFF
--- a/engines/default/default_engine.c
+++ b/engines/default/default_engine.c
@@ -1154,12 +1154,29 @@ default_set_config(ENGINE_HANDLE* handle, const void* cookie,
     if (strcmp(config_key, "memlimit") == 0) {
         size_t new_maxbytes = *(size_t*)config_value;
         pthread_mutex_lock(&engine->cache_lock);
-        ret = slabs_set_memlimit(engine, new_maxbytes);
-        if (ret == ENGINE_SUCCESS) {
-            engine->config.maxbytes = new_maxbytes;
+        if (new_maxbytes >= engine->config.sticky_limit) {
+            ret = slabs_set_memlimit(engine, new_maxbytes);
+            if (ret == ENGINE_SUCCESS) {
+                engine->config.maxbytes = new_maxbytes;
+            }
+        } else {
+            ret = ENGINE_EBADVALUE;
         }
         pthread_mutex_unlock(&engine->cache_lock);
     }
+#ifdef ENABLE_STICKY_ITEM
+    else if (strcmp(config_key, "sticky_limit") == 0) {
+        size_t new_sticky_limit = *(size_t*)config_value;
+        pthread_mutex_lock(&engine->cache_lock);
+        if (new_sticky_limit >= engine->stats.sticky_bytes &&
+            new_sticky_limit <= engine->config.maxbytes) {
+            engine->config.sticky_limit = new_sticky_limit;
+        } else {
+            ret = ENGINE_EBADVALUE;
+        }
+        pthread_mutex_unlock(&engine->cache_lock);
+    }
+#endif
 #ifdef CONFIG_MAX_COLLECTION_SIZE
     else if (strcmp(config_key, "max_list_size") == 0) {
         ret = item_conf_set_maxcollsize(engine, ITEM_TYPE_LIST, (int*)config_value);

--- a/engines/default/default_engine.c
+++ b/engines/default/default_engine.c
@@ -122,9 +122,9 @@ initialize_configuration(struct default_engine *se, const char *cfg_str)
               .datatype = DT_SIZE,
               .value.dt_size = &se->config.maxbytes },
 #ifdef ENABLE_STICKY_ITEM
-            { .key = "sticky_ratio",
+            { .key = "sticky_limit",
               .datatype = DT_SIZE,
-              .value.dt_size = &se->config.sticky_ratio},
+              .value.dt_size = &se->config.sticky_limit},
 #endif
             { .key = "preallocate",
               .datatype = DT_BOOL,
@@ -168,11 +168,6 @@ initialize_configuration(struct default_engine *se, const char *cfg_str)
         if (se->server.core->parse_config(cfg_str, items, stderr) != 0) {
             return ENGINE_FAILED;
         }
-#ifdef ENABLE_STICKY_ITEM
-        if (se->config.sticky_ratio > 0) {
-            se->config.sticky_limit = (se->config.maxbytes / 100) * se->config.sticky_ratio;
-        }
-#endif
     }
 
     if (se->config.vb0) {
@@ -1162,11 +1157,6 @@ default_set_config(ENGINE_HANDLE* handle, const void* cookie,
         ret = slabs_set_memlimit(engine, new_maxbytes);
         if (ret == ENGINE_SUCCESS) {
             engine->config.maxbytes = new_maxbytes;
-#ifdef ENABLE_STICKY_ITEM
-            if (engine->config.sticky_ratio > 0) {
-                engine->config.sticky_limit = (new_maxbytes / 100) * engine->config.sticky_ratio;
-            }
-#endif
         }
         pthread_mutex_unlock(&engine->cache_lock);
     }
@@ -1574,7 +1564,6 @@ create_instance(uint64_t interface, GET_SERVER_API get_server_api,
          .evict_to_free = true,
          .num_threads = 0,
          .maxbytes = 64 * 1024 * 1024,
-         .sticky_ratio = 0,
          .sticky_limit = 0,
          .preallocate = false,
          .factor = 1.25,

--- a/engines/default/default_engine.h
+++ b/engines/default/default_engine.h
@@ -50,7 +50,6 @@ struct engine_config {
    bool   evict_to_free;
    size_t num_threads;
    size_t maxbytes;
-   size_t sticky_ratio;
    size_t sticky_limit;
    bool   preallocate;
    float  factor;

--- a/engines/demo/demo_engine.c
+++ b/engines/demo/demo_engine.c
@@ -82,9 +82,9 @@ initialize_configuration(struct demo_engine *se, const char *cfg_str)
               .datatype = DT_SIZE,
               .value.dt_size = &se->config.maxbytes },
 #ifdef ENABLE_STICKY_ITEM
-            { .key = "sticky_ratio",
+            { .key = "sticky_limit",
               .datatype = DT_SIZE,
-              .value.dt_size = &se->config.sticky_ratio},
+              .value.dt_size = &se->config.sticky_limit},
 #endif
             { .key = "preallocate",
               .datatype = DT_BOOL,
@@ -128,11 +128,6 @@ initialize_configuration(struct demo_engine *se, const char *cfg_str)
         if (se->server.core->parse_config(cfg_str, items, stderr) != 0) {
             return ENGINE_FAILED;
         }
-#ifdef ENABLE_STICKY_ITEM
-        if (se->config.sticky_ratio > 0) {
-            se->config.sticky_limit = (se->config.maxbytes / 100) * se->config.sticky_ratio;
-        }
-#endif
     }
     return ENGINE_SUCCESS;
 }
@@ -849,7 +844,6 @@ create_instance(uint64_t interface, GET_SERVER_API get_server_api,
          .evict_to_free = true,
          .num_threads = 0,
          .maxbytes = 64 * 1024 * 1024,
-         .sticky_ratio = 0,
          .sticky_limit = 0,
          .preallocate = false,
          .factor = 1.25,

--- a/engines/demo/demo_engine.h
+++ b/engines/demo/demo_engine.h
@@ -48,7 +48,6 @@ struct engine_config {
    bool   evict_to_free;
    size_t num_threads;
    size_t maxbytes;
-   size_t sticky_ratio;
    size_t sticky_limit;
    bool   preallocate;
    float  factor;

--- a/memcached.c
+++ b/memcached.c
@@ -8690,6 +8690,40 @@ static void process_memlimit_command(conn *c, token_t *tokens, const size_t ntok
     }
 }
 
+#ifdef ENABLE_STICKY_ITEM
+static void process_stickylimit_command(conn *c, token_t *tokens, const size_t ntokens)
+{
+    assert(c != NULL);
+    char *config_key = tokens[SUBCOMMAND_TOKEN].value;
+    char *config_val = tokens[SUBCOMMAND_TOKEN+1].value;
+    unsigned int sticky_limit;
+
+    if (ntokens == 3) {
+        char buf[50];
+        sprintf(buf, "sticky_limit %u\r\nEND", (int)(settings.sticky_limit / (1024 * 1024)));
+        out_string(c, buf);
+    } else if (ntokens == 4 && safe_strtoul(config_val, &sticky_limit)) {
+        ENGINE_ERROR_CODE ret;
+        size_t new_sticky_limit = (size_t)sticky_limit * 1024 * 1024;
+        SETTING_LOCK();
+        ret = mc_engine.v1->set_config(mc_engine.v0, c, config_key, (void*)&new_sticky_limit);
+        if (ret == ENGINE_SUCCESS) {
+            settings.sticky_limit = new_sticky_limit;
+        }
+        SETTING_UNLOCK();
+        if (ret == ENGINE_SUCCESS) {
+            out_string(c, "END");
+        } else if (ret == ENGINE_ENOTSUP) {
+            out_string(c, "NOT_SUPPORTED");
+        } else { /* ENGINE_EBADVALUE */
+            out_string(c, "CLIENT_ERROR bad value");
+        }
+    } else {
+        out_string(c, "CLIENT_ERROR bad command line format");
+    }
+}
+#endif
+
 #ifdef CONFIG_MAX_COLLECTION_SIZE
 static void process_maxcollsize_command(conn *c, token_t *tokens, const size_t ntokens,
                                         int coll_type)
@@ -8817,6 +8851,13 @@ static void process_config_command(conn *c, token_t *tokens, const size_t ntoken
     {
         process_memlimit_command(c, tokens, ntokens);
     }
+#ifdef ENABLE_STICKY_ITEM
+    else if ((ntokens == 3 || ntokens == 4) &&
+             (strcmp(tokens[SUBCOMMAND_TOKEN].value, "sticky_limit") == 0))
+    {
+        process_stickylimit_command(c, tokens, ntokens);
+    }
+#endif
 #ifdef CONFIG_MAX_COLLECTION_SIZE
     else if ((ntokens == 3 || ntokens == 4) &&
              (strcmp(tokens[SUBCOMMAND_TOKEN].value, "max_list_size") == 0))
@@ -9051,6 +9092,9 @@ static void process_help_command(conn *c, token_t *tokens, const size_t ntokens)
         "\n"
         "\t" "config verbosity [<verbose>]\\r\\n" "\n"
         "\t" "config memlimit [<memsize(MB)>]\\r\\n" "\n"
+#ifdef ENABLE_STICKY_ITEM
+        "\t" "config sticky_limit [<stickylimit(MB)>]\\r\\n" "\n"
+#endif
         "\t" "config maxconns [<maxconn>]\\r\\n" "\n"
 #ifdef CONFIG_MAX_COLLECTION_SIZE
         "\t" "config max_list_size [<maxsize>]\\r\\n" "\n"

--- a/memcached.h
+++ b/memcached.h
@@ -376,7 +376,7 @@ struct settings {
     int maxconns;
     int port;
     int udpport;
-    int sticky_ratio;
+    size_t sticky_limit;
     char *inter;
     int verbose;
     rel_time_t oldest_live; /* ignore existing items older than this */


### PR DESCRIPTION
- [x] @MinWooJin 
- [x] @jhpark816 

sticky에 대한 설정을 기존 sticky_ratio 설정으로 계산하는 것을 sticky_limit 그대로 적용되도록 하고 sticky_limit을 런타임에 변경할 수 있도록 하는 변경입니다.

첫 번째 커밋은 sticky_ratio로 sticky_limit을 계산하던 기존 코드를 sticky_limit 그대로 사용하도록 하는 변경입니다.
두 번째 커밋은 sticky_limit을 변경할 수 있도록 하는 api 추가입니다.
