### PR TITLE
Refactor: print format

### DIFF
--- a/arcus_zk.c
+++ b/arcus_zk.c
@@ -771,9 +771,8 @@ hb_thread(void *arg)
         } else {
             elapsed_msec = 0; /* Ignore this failure */
             arcus_conf.logger->log(EXTENSION_LOG_WARNING, NULL,
-                "hb_thread: Clock has gone backwards? start_msec=%llu"
-                " end_msec=%llu\n", (unsigned long long)start_msec,
-                (unsigned long long)end_msec);
+                "hb_thread: Clock has gone backwards? start_msec=%"PRIu64
+                " end_msec=%"PRIu64"\n", start_msec, end_msec);
         }
 
         azk_stat.hb_count += 1;
@@ -785,9 +784,9 @@ hb_thread(void *arg)
              * analysis, etc.
              */
             arcus_conf.logger->log(EXTENSION_LOG_WARNING, NULL,
-                "Heartbeat failure. hb_timeout=%d hb_latency=%llu "
-                "accumulated_hb_latency=%d\n", cur_hb_timeout,
-                (unsigned long long)elapsed_msec, acc_hb_latency);
+                "Heartbeat failure. hb_timeout=%d hb_latency=%"PRIu64
+                " accumulated_hb_latency=%d\n", cur_hb_timeout,
+                elapsed_msec, acc_hb_latency);
 
             if (acc_hb_latency > cur_hb_failstop) {
                 /* Do not bother calling memcached.c:shutdown_server.
@@ -1651,8 +1650,7 @@ sm_timer_thread(void *arg)
                  */
                 arcus_conf.logger->log(EXTENSION_LOG_WARNING, NULL,
                     "Disconnected from ZK for too long. Terminating... "
-                    "duration_msec=%llu\n",
-                    (long long unsigned)(now_msec - start_msec));
+                    "duration_msec=%"PRIu64"\n", now_msec - start_msec);
                 shutdown_by_me = true;
                 break;
                 /* Do we have to kill the slave too?  Or, only the master?

--- a/engines/default/slabs.c
+++ b/engines/default/slabs.c
@@ -1200,7 +1200,7 @@ static void do_slabs_stats(struct default_engine *engine, ADD_STAT add_stats, co
             add_statistics(cookie, add_stats, NULL, i, "used_chunks", "%u", (slabs*perslab)-p->sl_curr-p->end_page_free);
             add_statistics(cookie, add_stats, NULL, i, "free_chunks", "%u", p->sl_curr);
             add_statistics(cookie, add_stats, NULL, i, "free_chunks_end", "%u", p->end_page_free);
-            add_statistics(cookie, add_stats, NULL, i, "mem_requested", "%zu", p->requested);
+            add_statistics(cookie, add_stats, NULL, i, "mem_requested", "%llu", (unsigned long long)p->requested);
 #ifdef FUTURE
             add_statistics(cookie, add_stats, NULL, i, "get_hits", "%"PRIu64, thread_stats.slab_stats[i].get_hits);
             add_statistics(cookie, add_stats, NULL, i, "cmd_set", "%"PRIu64, thread_stats.slab_stats[i].set_cmds);
@@ -1214,8 +1214,8 @@ static void do_slabs_stats(struct default_engine *engine, ADD_STAT add_stats, co
 
     /* add overall slab stats and append terminator */
     add_statistics(cookie, add_stats, NULL, -1, "active_slabs", "%d", total);
-    add_statistics(cookie, add_stats, NULL, -1, "memory_limit", "%zu", engine->slabs.mem_limit);
-    add_statistics(cookie, add_stats, NULL, -1, "total_malloced", "%zu", engine->slabs.mem_malloced);
+    add_statistics(cookie, add_stats, NULL, -1, "memory_limit", "%llu", (unsigned long long)engine->slabs.mem_limit);
+    add_statistics(cookie, add_stats, NULL, -1, "total_malloced", "%llu", (unsigned long long)engine->slabs.mem_malloced);
 }
 
 static void *memory_allocate(struct default_engine *engine, size_t size)

--- a/memcached.c
+++ b/memcached.c
@@ -7803,11 +7803,11 @@ static void server_stats(ADD_STAT add_stats, conn *c, bool aggregate) {
 
 static void process_stat_settings(ADD_STAT add_stats, void *c) {
     assert(add_stats);
-    APPEND_STAT("maxbytes", "%lu", (unsigned long)settings.maxbytes);
+    APPEND_STAT("maxbytes", "%llu", (unsigned long long)settings.maxbytes);
     APPEND_STAT("maxconns", "%d", settings.maxconns);
     APPEND_STAT("tcpport", "%d", settings.port);
     APPEND_STAT("udpport", "%d", settings.udpport);
-    APPEND_STAT("sticky_limit", "%lu", (unsigned long)settings.sticky_limit);
+    APPEND_STAT("sticky_limit", "%llu", (unsigned long long)settings.sticky_limit);
     APPEND_STAT("inter", "%s", settings.inter ? settings.inter : "NULL");
     APPEND_STAT("verbosity", "%d", settings.verbose);
     APPEND_STAT("oldest", "%lu", (unsigned long)settings.oldest_live);
@@ -7842,7 +7842,7 @@ static void process_stat_settings(ADD_STAT add_stats, void *c) {
     APPEND_STAT("auth_sasl_engine", "%s", "none");
 #endif
     APPEND_STAT("auth_required_sasl", "%s", settings.require_sasl ? "yes" : "no");
-    APPEND_STAT("item_size_max", "%d", settings.item_size_max);
+    APPEND_STAT("item_size_max", "%llu", settings.item_size_max);
     APPEND_STAT("max_list_size", "%d", settings.max_list_size);
     APPEND_STAT("max_set_size", "%d", settings.max_set_size);
 #ifdef MAP_COLLECTION_SUPPORT
@@ -14694,8 +14694,8 @@ int main (int argc, char **argv) {
                     " greater than 0 and sticky_limit.\n");
                 return 1;
             }
-            old_opts += sprintf(old_opts, "cache_size=%lu;",
-                                 (unsigned long)settings.maxbytes);
+            old_opts += sprintf(old_opts, "cache_size=%llu;",
+                                 (unsigned long long)settings.maxbytes);
             break;
         case 'M':
             settings.evict_to_free = 0;
@@ -14711,8 +14711,8 @@ int main (int argc, char **argv) {
                     " greater than 0 and less than memlimit.\n");
                 return 1;
             }
-            old_opts += sprintf(old_opts, "sticky_limit=%lu;",
-                                (unsigned long)settings.sticky_limit);
+            old_opts += sprintf(old_opts, "sticky_limit=%llu;",
+                                (unsigned long long)settings.sticky_limit);
             break;
 #endif
         case 'c':
@@ -14858,13 +14858,8 @@ int main (int argc, char **argv) {
                     " and will decrease your memory efficiency.\n"
                 );
             }
-#ifndef __WIN32__
-            old_opts += sprintf(old_opts, "item_size_max=%zu;",
+            old_opts += sprintf(old_opts, "item_size_max=%llu;", (unsigned long long)
                                 settings.item_size_max);
-#else
-            old_opts += sprintf(old_opts, "item_size_max=%lu;", (long unsigned)
-                                settings.item_size_max);
-#endif
             break;
         case 'E':
             engine = optarg;


### PR DESCRIPTION
- [x] @MinWooJin 
- [x] @jhpark816 

print format에  대한 리팩토링입니다.
size_t 출력에 대해 %llu를, (C99에서는 size_t에 대해 %zu를 사용하기를 권고하지만 VC에서 지원하지 않는다고 하여 더 이식성 좋은 코드를 위해 llu를 사용합니다. 참고로, 현재 lu를 사용해도 되지만 현재 memcached 최신 코드도 llu를 사용하고 있어 이를 따라가려 합니다.)
uint64_t 출력에 대해 %PRIu64를 쓰도록 통일하였습니다.