### PR TITLE
Fix typos on docs: colleciton->collection etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Important start options are here.
 - The scrub command is provided as an ASCII command extension.
   To use the command, use `-X` to specify the location of ascii_scrub.so library.
 
-To see details on arcus-memcached start options, run memcache with -h option like below.
+To see details on arcus-memcached start options, run memcached with -h option like below.
 ```
 $ <arcus_install_path>/bin/memcached -h
 ```

--- a/doc/arcus-ascii-protocol.md
+++ b/doc/arcus-ascii-protocol.md
@@ -56,7 +56,7 @@ Collection 일부 명령들은 command pipelining 처리가 가능하며,
 Item Attributes 기능
 --------------------
 
-Colleciton 지원으로 인해 item 유형이 다양해 졌으며, 다양한 item 유형에 따라 item attributes도 확장되었다.
+Collection 지원으로 인해 item 유형이 다양해 졌으며, 다양한 item 유형에 따라 item attributes도 확장되었다.
 이러한 item attributes를 조회하거나 변경하기 위하여
 [Item Attribute 명령](/doc/command-item-attribute.md)을 제공한다.
 

--- a/doc/arcus-basic-concept.md
+++ b/doc/arcus-basic-concept.md
@@ -2,12 +2,12 @@ Arcus Basic Concept
 -------------------
 
 Arcus cache server는 하나의 데이터만을 value로 가지는 simple key-value 외에도
-여러 데이터를 구조화된 형태로 저장하는 colleciton을 하나의 value로 가지는
+여러 데이터를 구조화된 형태로 저장하는 collection을 하나의 value로 가지는
 확장된 key-value 데이터 모델을 제공한다.
 
 ### 기본 제약 사항
 
-Arcus caceh server의 key-value 모델은 아래의 기본 제약 사항을 가진다.
+Arcus cache server의 key-value 모델은 아래의 기본 제약 사항을 가진다.
 
 - 기존 key-value 모델의 제약 사항
   - Key의 최대 크기는 250 character이다.
@@ -48,7 +48,7 @@ Arcus cache server는 simple key-value 외에 collection 지원으로 다양한 
 
 ### Expiration, Eviction, and Sticky
 
-각 cache item은 expireation time 속성을 가지며,
+각 cache item은 expiration time 속성을 가지며,
 이 값의 설정을 통해 expire되지 않는 item 또는 특정 시간 이후에 자동 expire될 item을 지정할 수 있다.
 이에 대한 자세한 설명은 [Item Attribute 설명](/doc/arcus-item-attribute.md)을 참고 바란다.
 
@@ -93,7 +93,7 @@ Slab allocator는 메모리 크기 별로 메모리 공간을 나누어 관리�
   
 **Small Memory Allocator**
 
-Colleciton 지원으로 인해 작은 메모리 공간의 할당과 반환 요청이 많아졌다.
+Collection 지원으로 인해 작은 메모리 공간의 할당과 반환 요청이 많아졌다.
 이러한 작은 메모리 공간을 효율적으로 관리하기 위하여
 small memory allocator를 새로 개발하여 사용하고 있다.
 8000 바이트 이하의 메모리 공간은 small memory allocator가 담당하며,

--- a/doc/arcus-collection-concept.md
+++ b/doc/arcus-collection-concept.md
@@ -3,28 +3,28 @@ Collection Concept
 
 ### Collection 구조와 특징
 
-Colleciton 유형과 그 구조 및 특징은 아래와 같다.
+Collection 유형과 그 구조 및 특징은 아래와 같다.
 
 **List** - linked list
 
 > Element들의 doubly linked list 구조를 가진다.
-  Head element와 tail element 정보를 유지하면서, head/tail에서 시작하여 forward/backwad 방향으로
+  Head element와 tail element 정보를 유지하면서, head/tail에서 시작하여 forward/backward 방향으로
   특정 위치에 있는 element를 접근할 수 있다.
-  많은 elelment를 가진 list에서 중간 위치의 임의 element 접근 시에 성능 이슈가 있으므로,
+  많은 element를 가진 list에서 중간 위치의 임의 element 접근 시에 성능 이슈가 있으므로,
   list를 queue 개념으로 사용하길 권한다.
   
 **Set** - unordered set of unique value
 
-> Set 자료 구조는 membership checking에 적합니다.
+> Set 자료 구조는 membership checking에 적합하다.
   Unordered set of unique value 저장을 위해 내부적으로 hash table 구조를 사용한다.
-  하나의 set에 들어가는 elments 개수에 비례하여 hash table 전체 크기를 동적으로 조정하기 위해,
+  하나의 set에 들어가는 elements 개수에 비례하여 hash table 전체 크기를 동적으로 조정하기 위해,
   일반적인 tree 구조와 유사하게 여러 depth로 구성되는 hash table 구조를 가진다.
 
 **Map** - unordered set of \<field, value\>
 
 > Map 자료 구조는 \<field, value\> 쌍을 저장한다.
   Field 값의 유일성 보장과 field 기준으로 해당 element 탐색을 빠르게 하기 위한 hash table 구조를 사용한다.
-  하나의 map에 들어가는 elments 개수에 비례하여 hash table 전체 크기를 동적으로 조정하기 위해,
+  하나의 map에 들어가는 elements 개수에 비례하여 hash table 전체 크기를 동적으로 조정하기 위해,
   일반적인 tree 구조와 유사하게 여러 depth로 구성되는 hash table 구조를 가진다.
 
 
@@ -36,15 +36,15 @@ Colleciton 유형과 그 구조 및 특징은 아래와 같다.
   그 외에, b+tree의 nonleaf node는 각 하위 node 중심의 sub-tree에 저장된 element 개수 정보를
   담고 있도록 해서, 특정 element의 position 조회 및 position 기반의 element 조회 기능도 제공한다.
   
-Collection item은 \<key, "colleciton meta info"\> 구조를 가진다.
-Colleciton meta info는 collection 유형에 따른 속성 정보를 가지며,
+Collection item은 \<key, "collection meta info"\> 구조를 가진다.
+Collection meta info는 collection 유형에 따른 속성 정보를 가지며,
 해당 collection의 elements에 신속히 접근하기 정보를 가진다.
 예를 들어, list의 head/tail element 주소, set의 최상위 hash table 주소,
 map의 최상위 hash table 구조, b+tree의 root node 주소가 이에 해당된다.
 
 ### Element 구조
 
-Colleciton 유형에 따른 element 구조는 아래와 같다.
+Collection 유형에 따른 element 구조는 아래와 같다.
 
 - list/set element : \< data \>
 

--- a/doc/arcus-item-attribute.md
+++ b/doc/arcus-item-attribute.md
@@ -1,7 +1,7 @@
 Item Attribute 설명
 ------------------
 
-Arcus cache server는 colletion 기능 지원으로 인해,
+Arcus cache server는 collection 기능 지원으로 인해,
 기존 key-value item 유형 외에 list, set, map, b+tree item 유형을 가진다.
 각 item 유형에 따라 설정/조회 가능한 속성들(attributes)이 구분되며, 이들의 개요는 아래 표와 같다.
 아래 표에서 각 속성이 적용되는 item 유형, 속성의 간단한 설명, 허용가능한 값들과 디폴트 값을 나타낸다.

--- a/doc/command-list-collection.md
+++ b/doc/command-list-collection.md
@@ -59,7 +59,7 @@ Response string과 그 의미는 아래와 같다.
 - "STROED" - 성공 (element만 삽입)
 - “CREATED_STORED” - 성공 (collection 생성하고 element 삽입)
 - “NOT_FOUND” - key miss
-- “TYPE_MISMATCH” - 해당 item이 list colleciton이 아님
+- “TYPE_MISMATCH” - 해당 item이 list collection이 아님
 - “OVERFLOWED” - overflow 발생
 - “OUT_OF_RANGE” - 삽입 위치가 list의 현재 element index 범위를 넘어섬,
                    예를 들어, 10개 element가 있는 상태에서 삽입 위치가 20인 경우임
@@ -96,7 +96,7 @@ Response string과 그 의미는 아래와 같다.
 - “DELETED_DROPPED” - 성공 (element 삭제하고 list를 drop한 상태)
 - “NOT_FOUND” - key miss
 - “NOT_FOUND_ELEMENT” - element miss (single index or index range에 해당하는 element가 없음)
-- “TYPE_MISMATCH” - 해당 item이 list colleciton이 아님
+- “TYPE_MISMATCH” - 해당 item이 list collection이 아님
 - "NOT_SUPPORTED" - 지원하지 않음
 - “CLIENT_ERROR bad command line format” - protocol syntax 틀림
 

--- a/doc/command-map-collection.md
+++ b/doc/command-map-collection.md
@@ -118,7 +118,7 @@ Response string과 그 의미는 아래와 같다.
 - “DELETED_DROPPED” - 성공 (전체 또는 일부 field, element 삭제하고 collection을 drop한 상태)
 - “NOT_FOUND” - key miss
 - “NOT_FOUND_ELEMENT” - field miss (삭제할 field, element가 없음. 모든 field가 없을 시에만 리턴)
-- “TYPE_MISMATCH” - 해당 item이 map colleciton이 아님
+- “TYPE_MISMATCH” - 해당 item이 map collection이 아님
 - "NOT_SUPPORTED" - 지원하지 않음
 - “CLIENT_ERROR bad command line format” - protocol syntax 틀림
 

--- a/doc/command-set-collection.md
+++ b/doc/command-set-collection.md
@@ -57,7 +57,7 @@ Response string과 그 의미는 아래와 같다.
 - "STROED" - 성공 (element만 삽입)
 - “CREATED_STORED” - 성공 (collection 생성하고 element 삽입)
 - “NOT_FOUND” - key miss
-- “TYPE_MISMATCH” - 해당 item이 set colleciton이 아님
+- “TYPE_MISMATCH” - 해당 item이 set collection이 아님
 - “OVERFLOWED” - overflow 발생
 - "ELEMENT_EXISTS" - 동일 데이터를 가진 element가 존재. set uniqueness 위배
 - "NOT_SUPPORTED" - 지원하지 않음
@@ -87,7 +87,7 @@ Response string과 그 의미는 아래와 같다.
 - “DELETED_DROPPED” - 성공 (element 삭제하고 collection을 drop한 상태)
 - “NOT_FOUND” - key miss
 - “NOT_FOUND_ELEMENT” - element miss (삭제할 element가 없음)
-- “TYPE_MISMATCH” - 해당 item이 set colleciton이 아님
+- “TYPE_MISMATCH” - 해당 item이 set collection이 아님
 - "NOT_SUPPORTED" - 지원하지 않음
 - “CLIENT_ERROR bad command line format” - protocol syntax 틀림
 - “CLIENT_ERROR too large value” - 삭제할 데이터가 4KB 보다 큼
@@ -140,20 +140,20 @@ sop exist <key> <bytes> [pipe]\r\n<data>\r\n
 ```
 
 - \<key\> - 대상 item의 key string
-- \<bytes\>와 \<data\> - 존재 유무를 검사할 데이터의 길의와 데이터 그 자체 (최대 4KB)
+- \<bytes\>와 \<data\> - 존재 유무를 검사할 데이터의 길이와 데이터 그 자체 (최대 4KB)
 - pipe - 명시하면, response string을 전달받지 않는다. 
          [Command Pipelining](/doc/command-pipelining.md)을 참조 바란다.
 
 Response string과 그 의미는 아래와 같다.
 
 - “EXIST" - 성공 (주어진 데이터가 set에 존재)
-- "NOT_EXIST" - 성공 (주어진 데이타가 set에 존재하지 않음)
+- "NOT_EXIST" - 성공 (주어진 데이터가 set에 존재하지 않음)
 - “NOT_FOUND”	- key miss
 - “TYPE_MISMATCH”	- 해당 item이 set collection이 아님
 - “UNREADABLE” - 해당 item이 unreadable item임
 - "NOT_SUPPORTED" - 지원하지 않음
 - “CLIENT_ERROR bad command line format” - protocol syntax 틀림
-- “CLIENT_ERROR too large value” : 주어진 데이타가 4KB 보다 큼
-- “CLIENT_ERROR bad data chunk” : 주어진 데이티의 길이가 \<bytes\>와 다르거나 “\r\n”으로 끝나지 않음
+- “CLIENT_ERROR too large value” : 주어진 데이터가 4KB 보다 큼
+- “CLIENT_ERROR bad data chunk” : 주어진 데이터의 길이가 \<bytes\>와 다르거나 “\r\n”으로 끝나지 않음
  
 


### PR DESCRIPTION
#95 를 develop 브랜치에 적용하였습니다.

It corrects several repeated typos found on the docs:
* colleciton -> collection
* 데이타, 데이티 -> 데이터
* And more