### PR TITLE
Yoo4471/naver space tokenize kv mget

### DIFF
--- a/doc/command-btree-collection.md
+++ b/doc/command-btree-collection.md
@@ -318,11 +318,12 @@ Increment/decrement 수행 후의 데이터 값이다.
 
 ```
 bop mget <lenkeys> <numkeys> <bkey or "bkey range"> [<eflag_filter>] [<offset>] <count>\r\n
-<”comma separated keys”>\r\n
+<”space separated keys”>\r\n
 * <eflag_filter> : <fwhere> [<bitwop> <foperand>] <compop> <fvalue>
 ```
 
-- \<”comma separated keys”\> - 대상 b+tree들의 key list로, 콤마(,)로 구분한다.
+- \<”space separated keys”\> - 대상 b+tree들의 key list로, 스페이스(' ')로 구분한다.
+                             - 하위 호환성(1.10.2 이전)을 위해 콤마(,)도 지원하지만 성능상의 이유로 스페이스(' ') 사용을 권장한다.
 - \<lenkeys\>과 \<numkeys> - key list 문자열의 길이와 key 개수를 나타낸다.
 - \<bkey or "bkey range"\> - 하나의 bkey 또는 bkey range 조회 조건.
                              Bkey range는 "bkey1..bkey2" 형식으로 표현한다.
@@ -378,7 +379,7 @@ flags와 ecount를 포함하여 조회된 element 정보가 생략된다.
 
 - "NOT_SUPPORTED" - 지원하지 않음
 - “CLIENT_ERROR bad command line format” - protocol syntax 틀림
-- “CLIENT_ERROR bad data chunk”	- comma seperated key list의 길이가 \<lenkeys\>와 다르거나 “\r\n”으로 끝나지 않음
+- “CLIENT_ERROR bad data chunk”	- space seperated key list의 길이가 \<lenkeys\>와 다르거나 “\r\n”으로 끝나지 않음
 - “CLIENT_ERROR bad value” - bop mget 명령의 제약 조건을 위배함.
 - “SERVER_ERROR out of memory [writing get response]” - 메모리 부족
 
@@ -416,11 +417,12 @@ smget 동작은 조회 범위와 어떤 b+tree의 trim 영역의 겹침에 대�
 
 ```
 bop smget <lenkeys> <numkeys> <bkey or "bkey range"> [<eflag_filter>] [<offset>] <count> [duplicate|unique]\r\n
-<"comma separated keys">\r\n
+<"space separated keys">\r\n
 * <eflag_filter> : <fwhere> [<bitwop> <foperand>] <compop> <fvalue>
 ```
 
-- \<”comma separated keys”\> - 대상 b+tree들의 key list로, 콤마(,)로 구분한다.
+- \<”space separated keys”\> - 대상 b+tree들의 key list로, 스페이스(' ')로 구분한다.
+                             - 하위 호환성(1.10.2 이전)을 위해 콤마(,)도 지원하지만 성능상의 이유로 스페이스(' ') 사용을 권장한다.
 - \<lenkeys\>과 \<numkeys> - key list 문자열의 길이와 key 개수를 나타낸다.
 - \<bkey or "bkey range"\> - 하나의 bkey 또는 bkey range 조회 조건.
                              Bkey range는 "bkey1..bkey2" 형식으로 표현한다.

--- a/doc/command-key-value.md
+++ b/doc/command-key-value.md
@@ -18,12 +18,20 @@ cas <key> <flags> <exptime> <bytes> <cas unique> [noreply]\r\n<data>\r\n
 
 **retrieval 명령**
 
-get, gets 명령이 있으며, syntax는 다음과 같다.
+get, gets, mget, mgets  명령이 있으며, syntax는 다음과 같다.
 
 ```
 get <key>\r\n
 gets <key>\r\n
+
+mget <lenkeys> <numkeys>
+<"space separated keys">\r\n
+
+mgets <lenkeys> <numkeys>
+<"space separated keys">\r\n
 ```
+- \<”space separated keys”\> - key list로, 스페이스(' ')로 구분한다.
+- \<lenkeys\>과 \<numkeys> - key list 문자열의 길이와 key 개수를 나타낸다.
 
 **deletion 명령**
 

--- a/doc/command-map-collection.md
+++ b/doc/command-map-collection.md
@@ -102,10 +102,11 @@ Map collection에서 하나 이상의 field 이름을 주어, 그에 해당하�
 
 ```
 mop delete <key> <lenfields> <numfields> [drop] [noreply|pipe]\r\n
-[<"comma separated fields">]\r\n
+[<"space separated fields">]\r\n
 ```
 
-- "comma separated fields" - 대상 map의 field list로, 콤마(,)로 구분한다.
+- "space separated fields" - 대상 map의 field list로, 스페이스(' ')로 구분한다.
+                           - 하위 호환성(1.10.2 이전)을 위해 콤마(,)도 지원하지만 성능상의 이유로 스페이스(' ') 사용을 권장한다.
 - \<key\> - 대상 item의 key string
 - \<lenfields>\과 \<numfields>\ - field list 문자열의 길이와 field 개수를 나타낸다. 0이면 전체 field, element를 의미한다.
 - drop - field, element 삭제로 인해 empty map이 될 경우, 그 map을 drop할 것인지를 지정한다.
@@ -128,10 +129,11 @@ Map collection에서 하나 이상의 field 이름을 주어, 그에 해당하�
 
 ```
 mop get <key> <lenfields> <numfields> [delete|drop]\r\n
-[<"comma separated fields">]\r\n
+[<"space separated fields">]\r\n
 ```
 
-- "comma separated fields" - 대상 map의 field list로, 콤마(,)로 구분한다.
+- "space separated fields" - 대상 map의 field list로, 스페이스(' ')로 구분한다.
+                           - 하위 호환성(1.10.2 이전)을 위해 콤마(,)도 지원하지만 성능상의 이유로 스페이스(' ') 사용을 권장한다.
 - \<key\> - 대상 item의 key string
 - \<lenfields\> 과 \<numfields>\ - field list 문자열의 길이와 field 개수를 나타낸다. 0이면 전체 field, element를 의미한다.
 - delete or drop - field, element 조회하면서 그 field, element를 delete할 것인지

--- a/include/memcached/types.h
+++ b/include/memcached/types.h
@@ -31,6 +31,7 @@ struct iovec {
 #include <sys/uio.h>
 #endif
 
+#define TOKENIZE_SPACE
 #define OPTIMIZE_HASH
 #define CONFIG_FAILSTOP
 #define CHANGE_STANDARD_FREE_AVAIL

--- a/include/memcached/types.h
+++ b/include/memcached/types.h
@@ -31,6 +31,7 @@ struct iovec {
 #include <sys/uio.h>
 #endif
 
+#define SUPPORT_KV_MGET
 #define TOKENIZE_SPACE
 #define OPTIMIZE_HASH
 #define CONFIG_FAILSTOP
@@ -136,7 +137,10 @@ extern "C" {
         // SUPPORT_BOP_MGET
         OPERATION_BOP_MGET,          /**< B+tree operation with mget(multiple get) element semantics */
         // SUPPORT_BOP_SMGET
-        OPERATION_BOP_SMGET          /**< B+tree operation with smget(sort-merge get) element semantics */
+        OPERATION_BOP_SMGET,         /**< B+tree operation with smget(sort-merge get) element semantics */
+#ifdef SUPPORT_KV_MGET
+        OPERATION_MGET = 0x90
+#endif
     } ENGINE_COLL_OPERATION;
 
     /* item type */

--- a/memcached.c
+++ b/memcached.c
@@ -813,6 +813,12 @@ static void conn_coll_eitem_free(conn *c) {
         free(c->coll_strkeys); c->coll_strkeys = NULL;
         break;
 #endif
+#ifdef SUPPORT_KV_MGET
+      case OPERATION_MGET:
+        free(c->coll_eitem);
+        free(c->coll_strkeys); c->coll_strkeys = NULL;
+        break;
+#endif
       default:
         assert(0); /* This case must not happen */
     }
@@ -2177,9 +2183,7 @@ static void process_bop_mget_complete(conn *c) {
 #endif
     {
         ret = ENGINE_EBADVALUE;
-    }
-    else /* valid key_tokens */
-    {
+    } else { /* valid key_tokens */
         uint32_t cur_elem_count = 0;
         uint32_t cur_access_count = 0;
         uint32_t flags, k, e;
@@ -2704,6 +2708,181 @@ static void process_bop_smget_complete(conn *c) {
 }
 #endif
 
+/**
+ * Get a suffix buffer and insert it into the list of used suffix buffers
+ * @param c the connection object
+ * @return a pointer to a new suffix buffer or NULL if allocation failed
+ */
+static char *get_suffix_buffer(conn *c) {
+    if (c->suffixleft == c->suffixsize) {
+        char **new_suffix_list;
+        size_t sz = sizeof(char*) * c->suffixsize * 2;
+
+        new_suffix_list = realloc(c->suffixlist, sz);
+        if (new_suffix_list) {
+            c->suffixsize *= 2;
+            c->suffixlist = new_suffix_list;
+        } else {
+            if (settings.verbose > 1) {
+                mc_logger->log(EXTENSION_LOG_DEBUG, c,
+                        "=%d Failed to resize suffix buffer\n", c->sfd);
+            }
+
+            return NULL;
+        }
+    }
+
+    char *suffix = cache_alloc(c->thread->suffix_cache);
+    if (suffix != NULL) {
+        *(c->suffixlist + c->suffixleft) = suffix;
+        ++c->suffixleft;
+    }
+
+    return suffix;
+}
+
+
+#ifdef SUPPORT_KV_MGET
+static void process_mget_complete(conn *c)
+{
+    assert(c->coll_op == OPERATION_MGET);
+    assert(c->coll_eitem != NULL);
+
+    ENGINE_ERROR_CODE ret = ENGINE_SUCCESS;
+    int nhit;
+    item **item_array = (item **)c->coll_eitem;
+    token_t *key_tokens = (token_t *)((char*)c->coll_strkeys + GET_8ALIGN_SIZE(c->coll_lenkeys));
+
+    if ((strncmp((char*)c->coll_strkeys + c->coll_lenkeys - 2, "\r\n", 2) != 0) ||
+        (tokenize_keys((char*)c->coll_strkeys, c->coll_lenkeys, ' ', c->coll_numkeys, key_tokens) == -1))
+    {
+        ret = ENGINE_EBADVALUE;
+    } else { /* valid key_tokens */
+        item *it;
+        uint32_t k;
+        nhit = 0;
+        for (k = 0; k < c->coll_numkeys; k++) {
+
+            if (key_tokens[k].length > KEY_MAX_LENGTH) {
+                out_string(c, "CLIENT_ERROR bad command line format");
+                return;
+            }
+
+            ret = mc_engine.v1->get(mc_engine.v0, c, &it, key_tokens[k].value, key_tokens[k].length, 0);
+            if (ret != ENGINE_SUCCESS) {
+                it = NULL;
+            }
+
+            if (settings.detail_enabled) {
+                stats_prefix_record_get(key_tokens[k].value, key_tokens[k].length, NULL != it);
+            }
+
+            if (it) {
+                item_info info = { .nvalue = 1 };
+                if (!mc_engine.v1->get_item_info(mc_engine.v0, c, it, &info)) {
+                    mc_engine.v1->release(mc_engine.v0, c, it);
+                    out_string(c, "SERVER_ERROR error getting item data");
+                    break;
+                }
+
+                assert(memcmp((char*)info.value[0].iov_base + info.nbytes - 2, "\r\n", 2) == 0);
+
+                /* Rebuild the suffix */
+                char *suffix = get_suffix_buffer(c);
+                if (suffix == NULL) {
+                    out_string(c, "SERVER_ERROR out of memory rebuilding suffix");
+                    mc_engine.v1->release(mc_engine.v0, c, it);
+                    return;
+                }
+                int suffix_len = snprintf(suffix, SUFFIX_SIZE,
+                                          " %u %u\r\n", htonl(info.flags),
+                                          info.nbytes - 2);
+
+                MEMCACHED_COMMAND_GET(c->sfd, info.key, info.nkey,info.nbytes, info.cas);
+                if (c->return_cas)
+                {
+                  char *cas = get_suffix_buffer(c);
+                  if (cas == NULL) {
+                    out_string(c, "SERVER_ERROR out of memory making CAS suffix");
+                    mc_engine.v1->release(mc_engine.v0, c, it);
+                    return;
+                  }
+                  int cas_len = snprintf(cas, SUFFIX_SIZE, " %"PRIu64"\r\n",
+                                         info.cas);
+                  if (add_iov(c, "VALUE ", 6) != 0 ||
+                      add_iov(c, info.key, info.nkey) != 0 ||
+                      add_iov(c, suffix, suffix_len - 2) != 0 ||
+                      add_iov(c, cas, cas_len) != 0 ||
+                      add_iov(c, info.value[0].iov_base, info.value[0].iov_len) != 0)
+                      {
+                          mc_engine.v1->release(mc_engine.v0, c, it);
+                          break;
+                      }
+                } else {
+                  if (add_iov(c, "VALUE ", 6) != 0 ||
+                      add_iov(c, info.key, info.nkey) != 0 ||
+                      add_iov(c, suffix, suffix_len) != 0 ||
+                      add_iov(c, info.value[0].iov_base, info.value[0].iov_len) != 0)
+                      {
+                          mc_engine.v1->release(mc_engine.v0, c, it);
+                          break;
+                      }
+                }
+
+                 if (settings.verbose > 1) {
+                      mc_logger->log(EXTENSION_LOG_DEBUG, c,
+                              ">%d sending key %s\n", c->sfd, (char*)info.key);
+                 }
+
+                  /* item_get() has incremented it->refcount for us */
+                  STATS_HIT(c, get, key_tokens[k].value, key_tokens[k].length);
+                  *(item_array + nhit) = it;
+                  nhit++;
+            } else {
+                STATS_MISS(c, get, key_tokens[k].value, key_tokens[k].length);
+                MEMCACHED_COMMAND_GET(c->sfd, key_tokens[k].value, key_tokens[k].length, -1, 0);
+            }
+        }
+
+        if (settings.verbose > 1) {
+            mc_logger->log(EXTENSION_LOG_DEBUG, c, ">%d END\n", c->sfd);
+        }
+
+        if (k != c->coll_numkeys || add_iov(c, "END\r\n", 5) != 0
+            || (IS_UDP(c->transport) && build_udp_headers(c) != 0)) {
+            out_string(c, "SERVER_ERROR out of memory writing get response");
+        }
+        else {
+            ret = ENGINE_SUCCESS;
+        }
+    }
+    switch(ret) {
+      case ENGINE_SUCCESS:
+        c->icurr = (item*)c->coll_eitem;
+        c->ileft = nhit;
+        c->suffixcurr = c->suffixlist;
+        conn_set_state(c, conn_mwrite);
+        c->msgcurr = 0;
+        break;
+     default:
+        if (ret == ENGINE_EBADVALUE) out_string(c, "CLIENT_ERROR bad data chunk");
+        else handle_unexpected_errorcode_ascii(c, ret);
+    }
+
+    if (ret != ENGINE_SUCCESS) {
+        if (c->coll_strkeys != NULL) {
+            free((void *)c->coll_strkeys);
+            c->coll_strkeys = NULL;
+        }
+        if (c->coll_eitem != NULL) {
+            free((void *)c->coll_eitem);
+            c->coll_eitem = NULL;
+        }
+    }
+
+}
+#endif
+
 static void complete_update_ascii(conn *c) {
     assert(c != NULL);
     assert(c->ewouldblock == false);
@@ -2728,6 +2907,9 @@ static void complete_update_ascii(conn *c) {
 #endif
 #ifdef SUPPORT_BOP_SMGET
         else if (c->coll_op == OPERATION_BOP_SMGET) process_bop_smget_complete(c);
+#endif
+#ifdef SUPPORT_KV_MGET
+        else if (c->coll_op == OPERATION_MGET) process_mget_complete(c);
 #endif
         return;
     }
@@ -8096,39 +8278,6 @@ static void process_stat(conn *c, token_t *tokens, const size_t ntokens) {
     }
 }
 
-/**
- * Get a suffix buffer and insert it into the list of used suffix buffers
- * @param c the connection object
- * @return a pointer to a new suffix buffer or NULL if allocation failed
- */
-static char *get_suffix_buffer(conn *c) {
-    if (c->suffixleft == c->suffixsize) {
-        char **new_suffix_list;
-        size_t sz = sizeof(char*) * c->suffixsize * 2;
-
-        new_suffix_list = realloc(c->suffixlist, sz);
-        if (new_suffix_list) {
-            c->suffixsize *= 2;
-            c->suffixlist = new_suffix_list;
-        } else {
-            if (settings.verbose > 1) {
-                mc_logger->log(EXTENSION_LOG_DEBUG, c,
-                        "=%d Failed to resize suffix buffer\n", c->sfd);
-            }
-
-            return NULL;
-        }
-    }
-
-    char *suffix = cache_alloc(c->thread->suffix_cache);
-    if (suffix != NULL) {
-        *(c->suffixlist + c->suffixleft) = suffix;
-        ++c->suffixleft;
-    }
-
-    return suffix;
-}
-
 /* ntokens is overwritten here... shrug.. */
 static inline void process_get_command(conn *c, token_t *tokens, size_t ntokens, bool return_cas)
 {
@@ -8291,7 +8440,75 @@ static inline void process_get_command(conn *c, token_t *tokens, size_t ntokens,
 
     return;
 }
+#ifdef SUPPORT_KV_MGET
+static void process_prepare_nread_keys(conn *c, uint32_t vlen, uint32_t kcnt, bool return_cas)
+{
+    /* kcnt is not used */
+    item *it = NULL;
+    ENGINE_ERROR_CODE ret = ENGINE_SUCCESS;
+    int need_size = 0;
 
+    int item_array_size = c->coll_numkeys * sizeof(item*);
+    int respon_hdr_size = c->coll_numkeys * ((lenstr_size*2)+30);
+    int respon_bdy_size = c->coll_numkeys * ((KEY_MAX_LENGTH*2+2)+lenstr_size+15);
+
+    need_size = item_array_size + respon_hdr_size + respon_bdy_size;
+
+    assert(need_size > 0);
+
+    if ((it = (item *)malloc(need_size)) == NULL) {
+        ret = ENGINE_ENOMEM;
+    } else {
+        int kmem_size = GET_8ALIGN_SIZE(vlen)
+                      + (sizeof(token_t) * c->coll_numkeys);
+        if ((c->coll_strkeys = malloc(kmem_size)) == NULL) {
+            free((void*)it);
+            ret = ENGINE_ENOMEM;
+        }
+    }
+
+    switch (ret) {
+    case ENGINE_SUCCESS:
+        {
+        c->return_cas  = return_cas;
+        c->ritem       = (char *)c->coll_strkeys;
+        c->rlbytes     = vlen;
+        c->coll_eitem  = (void *)it;
+        c->coll_op     = OPERATION_MGET;
+        conn_set_state(c, conn_nread);
+        }
+        break;
+    default:
+        out_string(c, "SERVER_ERROR out of memory");
+
+        c->write_and_go = conn_swallow;
+        c->sbytes = vlen;
+    }
+}
+
+static inline void process_mget_command(conn *c, token_t *tokens, const size_t ntokens, bool return_cas)
+{
+    uint32_t lenkeys, numkeys;
+
+    if ((! safe_strtoul(tokens[COMMAND_TOKEN+1].value, &lenkeys)) ||
+        (! safe_strtoul(tokens[COMMAND_TOKEN+2].value, &numkeys))) {
+        print_invalid_command(c, tokens, ntokens);
+        out_string(c, "CLIENT_ERROR bad command line format");
+        return;
+    }
+
+    if (lenkeys < 1 || numkeys < 1) {
+        /* ENGINE_EBADVALUE */
+        out_string(c, "CLIENT_ERROR bad value"); return;
+    }
+    lenkeys += 2;
+
+    c->coll_numkeys = numkeys;
+    c->coll_lenkeys = lenkeys;
+
+    process_prepare_nread_keys(c, lenkeys, numkeys, return_cas);
+}
+#endif
 static void process_update_command(conn *c, token_t *tokens, const size_t ntokens, ENGINE_STORE_OPERATION store_op, bool handle_cas) {
     char *key;
     size_t nkey;
@@ -12860,6 +13077,16 @@ static void process_command(conn *c, char *command, int cmdlen)
     {
         process_get_command(c, tokens, ntokens, true);
     }
+#ifdef SUPPORT_KV_MGET
+    else if ((ntokens == 4) && (strcmp(tokens[COMMAND_TOKEN].value, "mget") == 0))
+    {
+        process_mget_command(c, tokens, ntokens, false);
+    }
+    else if ((ntokens == 4) && (strcmp(tokens[COMMAND_TOKEN].value, "mgets") == 0))
+    {
+        process_mget_command(c, tokens, ntokens, true);
+    }
+#endif
     else if ((ntokens == 6 || ntokens == 7) &&
         ((strcmp(tokens[COMMAND_TOKEN].value, "add"    ) == 0 && (comm = (int)OPERATION_ADD)) ||
          (strcmp(tokens[COMMAND_TOKEN].value, "set"    ) == 0 && (comm = (int)OPERATION_SET)) ||

--- a/memcached.h
+++ b/memcached.h
@@ -492,6 +492,10 @@ struct conn {
     char   *ritem;  /** when we read in an item's value, it goes here */
     uint32_t    rlbytes;
 
+#ifdef SUPPORT_KV_MGET
+    /* kv processing fields */
+    bool    return_cas;
+#endif
     /* collection processing fields */
     void        *coll_eitem;
     char        *coll_resps;


### PR DESCRIPTION
Main reviewer
- [ ] @minkikim89 

Final reviewer
- [ ] @jhpark816

기존의
```
c->coll_eitem
c->coll_lenkeys
c->coll_strkeys
c->coll_numkeys
```

를 사용해서 KV mget(s)를 구현하였습니다.

(1) collection과 공통으로 사용 - 변수명 유지
(2) collection과 공통으로 사용 - 변수명 변경
(3) KV 전용 변수 추가

중 선택해야 한다고 생각합니다. 