### PR TITLE
CLEANUP: hash function optimization for long keys.

### DIFF
--- a/include/memcached/types.h
+++ b/include/memcached/types.h
@@ -31,6 +31,7 @@ struct iovec {
 #include <sys/uio.h>
 #endif
 
+#define OPTIMIZE_HASH
 #define CONFIG_FAILSTOP
 #define CHANGE_STANDARD_FREE_AVAIL
 #define SUPPORT_BOP_MGET


### PR DESCRIPTION
Reviewer
- [ ] @jhpark816 

long key일 때 last 250 character만 가지고
hash value를 계산하도록 hash 함수를 최적화 한 PR입니다.
확인 요청 드립니다.