### PR TITLE
FEATURE: cache_list ephemeral znode deleted action

### DIFF
--- a/include/memcached/types.h
+++ b/include/memcached/types.h
@@ -31,6 +31,7 @@ struct iovec {
 #include <sys/uio.h>
 #endif
 
+#define DELETED_ZNODE
 #define OPTIMIZE_HASH
 #define CONFIG_FAILSTOP
 #define CHANGE_STANDARD_FREE_AVAIL


### PR DESCRIPTION
main reviewer:
- [ ] @MinWooJin  

final reviewer:
- [ ] @jhpark816


운영자 실수로 인한 ephemeral znode 삭제 대응 코드입니다.
cache_list가 지워졌을 시에는 항상 zk와 연결을 끊고 rejoin 가능한 상태로 대기합니다.


