### PR TITLE
CLEANUP: add zk_connected, mc_failstop stats

### DIFF
--- a/arcus_zk.c
+++ b/arcus_zk.c
@@ -1704,7 +1704,14 @@ int arcus_zk_get_hbfailstop(void)
 
 void arcus_zk_get_stats(arcus_zk_stats *stats)
 {
+#ifdef CONFIG_FAILSTOP
+    stats->zk_connected = main_zk != NULL ?
+                          (main_zk->zh != NULL ? true : false) : false;
+#endif
     stats->zk_timeout = arcus_conf.zk_timeout;
+#ifdef CONFIG_FAILSTOP
+    stats->mc_failstop = arcus_conf.mc_failstop;
+#endif
     stats->hb_timeout = arcus_conf.hb_timeout;
     stats->hb_failstop = arcus_conf.hb_failstop;
     stats->hb_count = azk_stat.hb_count;

--- a/arcus_zk.h
+++ b/arcus_zk.h
@@ -25,7 +25,13 @@
 #ifdef ENABLE_ZK_INTEGRATION
 
 typedef struct {
+#ifdef CONFIG_FAILSTOP
+    bool     zk_connected;  // ZooKeeper-memcached connection state
+#endif
     uint32_t zk_timeout;    // Zookeeper session timeout (unit: ms)
+#ifdef CONFIG_FAILSTOP
+    bool     mc_failstop;   // memcached automatic failstop
+#endif
     uint32_t hb_timeout;    // memcached heartbeat timeout (unit: ms)
     uint32_t hb_failstop;   // memcached heartbeat failstop (unit: ms)
     uint64_t hb_count;      // heartbeat accumulated count

--- a/memcached.h
+++ b/memcached.h
@@ -370,6 +370,9 @@ struct mc_stats {
 struct settings {
     size_t maxbytes;
     int maxconns;
+#ifdef CONFIG_FAILSTOP
+    bool mc_failstop;
+#endif
     int port;
     int udpport;
     size_t sticky_limit;


### PR DESCRIPTION
arcus_zk.c에서 이미 zk_connected를 사용하고 있었기 때문에
stats.zk_connected에 해당 변수를 사용하려고 했지만

변수가 ENABLE_SUICIDE_UPON_DISCONNECT 코드태그로 감싸져있다는 점,
그리고 해당 변수를 ENABLE_SUICIDE_UPON_DISCONNECT에서는
connecting 중일 때에도 false로 설정한다는 점이 mcfailstop 설정하고는 맞지 않아서

rejoin할 때의 기준인 main_zk->zh 의 설정 여부를 기준으로 zk_connected를 판단했습니다.