### PR TITLE
Found Typos

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,7 +8,7 @@
 2017-09-01 [version 1.10.3]
 	* [Feature] leave and rejoin when cache_list znode is deleted.
 	* [Feature] Change the name of mcfailstop to zkfailstop.
-	* [Fix] the miscaculated checked value in tokenize_command().
+	* [Fix] the miscalculated checked value in tokenize_command().
 
 2017-07-28 [version 1.10.2]
 	* [Feature] Add memcached failstop on/off configuration.
@@ -75,7 +75,7 @@
 	* Update manual to have commnag logging usage.
 
 2015-11-09 [version 1.9.2]
-	* Support cahe key dump by prefix.
+	* Support cache key dump by prefix.
 	* Fix the bug that "SERVER_ERROR internal" is returned
 	  when unique condition is given in smget operation.
 
@@ -86,7 +86,7 @@
 
 2015-10-26 [version 1.9.0]
 	* Hash table expansion by worker threads. Don't create a daemon thread.
-	* Compute elemeent access overhead in bop delete/count/get/mget.
+	* Compute element access overhead in bop delete/count/get/mget.
 	* Swallow the remaining data when command pipeling fails. 
 	* Do more delicate synchronization when close ZK.
 	* Support command logging. 


### PR DESCRIPTION
I found some Typos while reading ChangeLog.

miscaculated -> miscalculated
cahe -> cache
elemeent -> element

Thanks.