### PR TITLE
fix missing break

### DIFF
--- a/cluster_config.c
+++ b/cluster_config.c
@@ -612,24 +612,6 @@ void cluster_config_final(struct cluster_config *config)
     }
 }
 
-uint32_t cluster_config_self_id(struct cluster_config *config)
-{
-    assert(config);
-    return config->self_id;
-}
-
-uint32_t cluster_config_node_count(struct cluster_config *config)
-{
-    assert(config);
-    return config->num_nodes;
-}
-
-uint32_t cluster_config_continuum_size(struct cluster_config *config)
-{
-    assert(config);
-    return config->num_conts;
-}
-
 int cluster_config_reconfigure(struct cluster_config *config,
                                char **node_strs, uint32_t num_nodes)
 {

--- a/cluster_config.c
+++ b/cluster_config.c
@@ -633,7 +633,7 @@ uint32_t cluster_config_continuum_size(struct cluster_config *config)
 int cluster_config_reconfigure(struct cluster_config *config,
                                char **node_strs, uint32_t num_nodes)
 {
-    assert(config && node_strs && num_nodes > 0);
+    assert(config);
     struct node_item **nodearray;
     struct cont_item **continuum;
     int self_id, ret=0;

--- a/cluster_config.h
+++ b/cluster_config.h
@@ -28,10 +28,6 @@ struct cluster_config *cluster_config_init(const char *node_name,
                                            int verbose);
 void cluster_config_final(struct cluster_config *config);
 
-uint32_t cluster_config_self_id(struct cluster_config *config);
-uint32_t cluster_config_node_count(struct cluster_config *config);
-uint32_t cluster_config_continuum_size(struct cluster_config *conifg);
-
 int cluster_config_reconfigure(struct cluster_config *config,
                                char **node_strs, uint32_t num_nodes);
 int cluster_config_key_is_mine(struct cluster_config *config,

--- a/engines/default/items.c
+++ b/engines/default/items.c
@@ -7294,15 +7294,121 @@ ENGINE_ERROR_CODE btree_elem_smget(struct default_engine *engine,
 /*
  * ITEM ATTRIBUTE Interface Functions
  */
+#if 1 // NEW_ATTR_CODE
+static ENGINE_ERROR_CODE
+do_item_getattr(struct default_engine *engine, hash_item *it,
+                ENGINE_ITEM_ATTR *attr_ids, const uint32_t attr_count,
+                item_attr *attr_data)
+{
+    /* item flags */
+    attr_data->flags = it->flags;
+
+    /* human readable expiretime */
+    if (it->exptime == 0) {
+        attr_data->exptime = it->exptime;
+#ifdef ENABLE_STICKY_ITEM
+    } else if (it->exptime == (rel_time_t)-1) {
+        attr_data->exptime = it->exptime;
+#endif
+    } else {
+        rel_time_t current_time = engine->server.core->get_current_time();
+        if (it->exptime <= current_time) {
+            attr_data->exptime = (rel_time_t)-2;
+        } else {
+            attr_data->exptime = it->exptime - current_time;
+        }
+    }
+
+    if (IS_COLL_ITEM(it)) {
+        coll_meta_info *info = (coll_meta_info *)item_get_meta(it);
+        attr_data->type = GET_ITEM_TYPE(it);
+        assert(attr_data->type < ITEM_TYPE_MAX);
+        /* attribute validation check */
+        if (attr_data->type != ITEM_TYPE_BTREE) {
+            for (int i = 0; i < attr_count; i++) {
+                if (attr_ids[i] == ATTR_MAXBKEYRANGE || attr_ids[i] == ATTR_TRIMMED) {
+                    return ENGINE_EBADATTR;
+                }
+            }
+        }
+        /* get collection attributes */
+        attr_data->count = info->ccnt;
+        if (info->mcnt > 0) {
+            attr_data->maxcount = info->mcnt;
+        } else {
+            switch (attr_data->type) {
+              case ITEM_TYPE_LIST:
+                   attr_data->maxcount = max_list_size;
+                   break;
+              case ITEM_TYPE_SET:
+                   attr_data->maxcount = max_set_size;
+                   break;
+              case ITEM_TYPE_MAP:
+                   attr_data->maxcount = max_map_size;
+                   break;
+              case ITEM_TYPE_BTREE:
+                   attr_data->maxcount = max_btree_size;
+                   break;
+              default:
+                   attr_data->maxcount = 0;
+            }
+        }
+        attr_data->ovflaction = info->ovflact;
+        attr_data->readable = (((info->mflags & COLL_META_FLAG_READABLE) != 0) ? 1 : 0);
+
+        if (attr_data->type == ITEM_TYPE_BTREE) {
+            btree_meta_info *binfo = (btree_meta_info *)info;
+            attr_data->maxbkeyrange = binfo->maxbkeyrange;
+            attr_data->trimmed = (((binfo->mflags & COLL_META_FLAG_TRIMMED) != 0) ? 1 : 0);
+            if (info->ccnt > 0) {
+                btree_elem_item *min_bkey_elem = do_btree_get_first_elem(binfo->root);
+                do_btree_get_bkey(min_bkey_elem, &attr_data->minbkey);
+                btree_elem_item *max_bkey_elem = do_btree_get_last_elem(binfo->root);
+                do_btree_get_bkey(max_bkey_elem, &attr_data->maxbkey);
+            }
+        }
+    } else {
+        attr_data->type = ITEM_TYPE_KV;
+        /* attribute validation check */
+        for (int i = 0; i < attr_count; i++) {
+            if (attr_ids[i] == ATTR_COUNT      || attr_ids[i] == ATTR_MAXCOUNT ||
+                attr_ids[i] == ATTR_OVFLACTION || attr_ids[i] == ATTR_READABLE ||
+                attr_ids[i] == ATTR_MAXBKEYRANGE || attr_ids[i] == ATTR_TRIMMED) {
+                return ENGINE_EBADATTR;
+            }
+        }
+    }
+    return ENGINE_SUCCESS;
+}
+#endif
+
 ENGINE_ERROR_CODE item_getattr(struct default_engine *engine,
                                const void* key, const int nkey,
                                ENGINE_ITEM_ATTR *attr_ids, const uint32_t attr_count,
                                item_attr *attr_data)
 {
+#if 1 // NEW_ATTR_CODE
+    hash_item *it;
+    ENGINE_ERROR_CODE ret;
+#else
     ENGINE_ERROR_CODE ret = ENGINE_SUCCESS;
     hash_item *it;
+#endif
 
     pthread_mutex_lock(&engine->cache_lock);
+#if 1 // NEW_ATTR_CODE
+    it = do_item_get(engine, key, nkey, DO_UPDATE);
+    if (it == NULL) {
+        ret = ENGINE_KEY_ENOENT;
+    } else {
+        /* get attrributes of the item */
+        ret = do_item_getattr(engine, it, attr_ids, attr_count, attr_data);
+        if (ret != ENGINE_SUCCESS) {
+            /* what should we do ? nothing */
+        }
+        do_item_release(engine, it);
+    }
+#else
     it = do_item_get(engine, key, nkey, DO_UPDATE);
     if (it == NULL) {
         ret = ENGINE_KEY_ENOENT;
@@ -7388,19 +7494,212 @@ ENGINE_ERROR_CODE item_getattr(struct default_engine *engine,
         }
         do_item_release(engine, it);
     }
+#endif
     pthread_mutex_unlock(&engine->cache_lock);
     return ret;
 }
+
+#if 1 // NEW_ATTR_CODE
+static ENGINE_ERROR_CODE
+do_item_setattr_check(hash_item *it,
+                      ENGINE_ITEM_ATTR *attr_ids, const uint32_t attr_count,
+                      item_attr *attr_data)
+{
+    ENGINE_ERROR_CODE ret = ENGINE_SUCCESS;
+    coll_meta_info *info = NULL;
+    if (IS_COLL_ITEM(it)) {
+        info = (coll_meta_info *)item_get_meta(it);
+    }
+
+    for (int i = 0; i < attr_count; i++) {
+        /* Attributes for all items */
+#ifdef ENABLE_STICKY_ITEM
+        if (attr_ids[i] == ATTR_EXPIRETIME) {
+            /* do not allow sticky toggling */
+            if ((it->exptime == (rel_time_t)-1 && attr_data->exptime != (rel_time_t)-1) ||
+                (it->exptime != (rel_time_t)-1 && attr_data->exptime == (rel_time_t)-1)) {
+                ret = ENGINE_EBADVALUE; break;
+            }
+            continue;
+        }
+#endif
+        /* Attributes for collection items */
+        if (info == NULL) continue;
+        if (attr_ids[i] == ATTR_MAXCOUNT) {
+            attr_data->maxcount = do_coll_real_maxcount(it, attr_data->maxcount);
+            if (attr_data->maxcount > 0 && attr_data->maxcount < info->ccnt) {
+                ret = ENGINE_EBADVALUE; break;
+            }
+            continue;
+        }
+        if (attr_ids[i] == ATTR_OVFLACTION) {
+            if (attr_data->ovflaction == OVFL_ERROR) {
+                /* nothing to check */
+            } else if (attr_data->ovflaction == OVFL_HEAD_TRIM ||
+                       attr_data->ovflaction == OVFL_TAIL_TRIM) {
+                if (! IS_LIST_ITEM(it)) {
+                    ret = ENGINE_EBADVALUE; break;
+                }
+            } else if (attr_data->ovflaction == OVFL_SMALLEST_TRIM ||
+                       attr_data->ovflaction == OVFL_LARGEST_TRIM ||
+                       attr_data->ovflaction == OVFL_SMALLEST_SILENT_TRIM ||
+                       attr_data->ovflaction == OVFL_LARGEST_SILENT_TRIM) {
+                if (! IS_BTREE_ITEM(it)) {
+                    ret = ENGINE_EBADVALUE; break;
+                }
+            } else {
+                ret = ENGINE_EBADVALUE; break;
+            }
+            continue;
+        }
+        if (attr_ids[i] == ATTR_READABLE) {
+            if (attr_data->readable != 1) {
+                ret = ENGINE_EBADVALUE; break;
+            }
+            continue;
+        }
+        /* Attributes for only b+tree items */
+        if (!IS_BTREE_ITEM(it)) continue;
+        if (attr_ids[i] == ATTR_MAXBKEYRANGE) {
+            if (attr_data->maxbkeyrange.len != BKEY_NULL && info->ccnt > 0) {
+                btree_meta_info *binfo = (btree_meta_info *)info;
+                /* check bkey type of maxbkeyrange */
+                if ((binfo->bktype == BKEY_TYPE_UINT64 && attr_data->maxbkeyrange.len >  0) ||
+                    (binfo->bktype == BKEY_TYPE_BINARY && attr_data->maxbkeyrange.len == 0)) {
+                    ret = ENGINE_EBADVALUE; break;
+                }
+                /* New maxbkeyrange must contain the current bkey range */
+                if ((binfo->ccnt >= 2) && /* current key range exists */
+                    (attr_data->maxbkeyrange.len != binfo->maxbkeyrange.len ||
+                     BKEY_ISNE(attr_data->maxbkeyrange.val, attr_data->maxbkeyrange.len,
+                               binfo->maxbkeyrange.val, binfo->maxbkeyrange.len))) {
+                    bkey_t curbkeyrange;
+                    btree_elem_item *min_bkey_elem = do_btree_get_first_elem(binfo->root);
+                    btree_elem_item *max_bkey_elem = do_btree_get_last_elem(binfo->root);
+                    curbkeyrange.len = attr_data->maxbkeyrange.len;
+                    BKEY_DIFF(max_bkey_elem->data, max_bkey_elem->nbkey,
+                              min_bkey_elem->data, min_bkey_elem->nbkey,
+                              curbkeyrange.len, curbkeyrange.val);
+                    if (BKEY_ISGT(curbkeyrange.val, curbkeyrange.len,
+                                  attr_data->maxbkeyrange.val, attr_data->maxbkeyrange.len)) {
+                        ret = ENGINE_EBADVALUE; break;
+                    }
+                }
+            }
+            continue;
+        }
+    }
+    return ret;
+}
+
+static void
+do_item_setattr_exec(struct default_engine *engine, hash_item *it,
+                     ENGINE_ITEM_ATTR *attr_ids, const uint32_t attr_count,
+                     item_attr *attr_data)
+{
+    coll_meta_info *info = NULL;
+    if (IS_COLL_ITEM(it)) {
+        info = (coll_meta_info *)item_get_meta(it);
+    }
+
+    for (int i = 0; i < attr_count; i++) {
+        /* Attributes for all items */
+        if (attr_ids[i] == ATTR_EXPIRETIME) {
+            if (it->exptime != attr_data->exptime) {
+                rel_time_t before_exptime = it->exptime;
+                it->exptime = attr_data->exptime;
+                if (before_exptime == 0 && it->exptime != 0) {
+                    /* exptime: 0 => positive value */
+                    /* When update exptime, the curMK/lowMK of LRU must be considered.
+                     * The item, whose exptime is 0, might be below the lowMK of LRU list.
+                     * If we change only the exptime of the item to a positive value,
+                     * it cannot be reclaimed even if it is expired in the future.
+                     * To make it to be reclaimed after it is expired,
+                     * we move it to to the top of LRU list.
+                     */
+                    do_item_lru_reposition(engine, it);
+                }
+            }
+            continue;
+        }
+        /* Attributes for collection items */
+        if (info == NULL) continue;
+        if (attr_ids[i] == ATTR_MAXCOUNT) {
+            info->mcnt = attr_data->maxcount;
+            continue;
+        }
+        if (attr_ids[i] == ATTR_OVFLACTION) {
+            if (IS_BTREE_ITEM(it)) {
+                btree_meta_info *binfo = (btree_meta_info *)info;
+                if (binfo->ovflact != attr_data->ovflaction) {
+                    binfo->mflags &= ~COLL_META_FLAG_TRIMMED; // clear trimmed
+                }
+            }
+            info->ovflact = attr_data->ovflaction;
+            continue;
+        }
+        if (attr_ids[i] == ATTR_READABLE) {
+            info->mflags |= COLL_META_FLAG_READABLE;
+            continue;
+        }
+        /* Attributes for only b+tree items */
+        if (!IS_BTREE_ITEM(it)) continue;
+        if (attr_ids[i] == ATTR_MAXBKEYRANGE) {
+            btree_meta_info *binfo = (btree_meta_info *)info;
+            if (attr_data->maxbkeyrange.len == BKEY_NULL) {
+                if (binfo->maxbkeyrange.len != BKEY_NULL) {
+                    binfo->maxbkeyrange = attr_data->maxbkeyrange;
+                    if (binfo->ccnt == 0) {
+                        if (binfo->bktype != BKEY_TYPE_UNKNOWN)
+                            binfo->bktype = BKEY_TYPE_UNKNOWN;
+                    }
+                }
+            } else { /* attr_data->maxbkeyrange.len != BKEY_NULL */
+                if (binfo->ccnt == 0) {
+                    /* just reset maxbkeyrange with new value */
+                    binfo->maxbkeyrange = attr_data->maxbkeyrange;
+                    if (attr_data->maxbkeyrange.len == 0) {
+                        binfo->bktype = BKEY_TYPE_UINT64;
+                    } else {
+                        binfo->bktype = BKEY_TYPE_BINARY;
+                    }
+                } else { /* binfo->ccnt > 0 */
+                    binfo->maxbkeyrange = attr_data->maxbkeyrange;
+                }
+            }
+            continue;
+        }
+    }
+}
+#endif
 
 ENGINE_ERROR_CODE item_setattr(struct default_engine *engine,
                                const void* key, const int nkey,
                                ENGINE_ITEM_ATTR *attr_ids, const uint32_t attr_count,
                                item_attr *attr_data)
 {
+#if 1 // NEW_ATTR_CODE
+    hash_item *it;
+    ENGINE_ERROR_CODE ret;
+#else
     ENGINE_ERROR_CODE ret = ENGINE_SUCCESS;
     hash_item *it;
+#endif
 
     pthread_mutex_lock(&engine->cache_lock);
+#if 1 // NEW_ATTR_CODE
+    it = do_item_get(engine, key, nkey, DONT_UPDATE);
+    if (it == NULL) {
+        ret = ENGINE_KEY_ENOENT;
+    } else {
+        ret = do_item_setattr_check(it, attr_ids, attr_count, attr_data);
+        if (ret == ENGINE_SUCCESS) {
+            /* do setattr operation */
+            do_item_setattr_exec(engine, it, attr_ids, attr_count, attr_data);
+        }
+        do_item_release(engine, it);
+    }
+#else
     it = do_item_get(engine, key, nkey, DONT_UPDATE);
     if (it == NULL) {
         ret = ENGINE_KEY_ENOENT;
@@ -7553,6 +7852,7 @@ ENGINE_ERROR_CODE item_setattr(struct default_engine *engine,
         }
         do_item_release(engine, it);
     }
+#endif
     pthread_mutex_unlock(&engine->cache_lock);
     return ret;
 }

--- a/engines/default/items.c
+++ b/engines/default/items.c
@@ -37,15 +37,7 @@ enum item_unlink_cause {
     ITEM_UNLINK_NORMAL = 1, /* unlink by normal request */
     ITEM_UNLINK_EVICT,      /* unlink by eviction */
     ITEM_UNLINK_INVALID,    /* unlink by invalidation such like expiration/flush */
-    ITEM_UNLINK_REPLACE,    /* unlink by replacement of set/replace command,
-                             * simple kv type only
-                             */
-    ITEM_UNLINK_ABORT,      /* unlink by abortion of creating a collection
-                             * collection type only
-                             */
-    ITEM_UNLINK_EMPTY,      /* unlink by empty collection
-                             * collection type only
-                             */
+    ITEM_UNLINK_REPLACE,    /* unlink by replacement of set/replace command */
     ITEM_UNLINK_STALE       /* unlink by staleness */
 };
 
@@ -6432,7 +6424,7 @@ ENGINE_ERROR_CODE list_elem_insert(struct default_engine *engine,
     if (ret == ENGINE_SUCCESS) {
         ret = do_list_elem_insert(engine, it, index, elem, cookie);
         if (ret != ENGINE_SUCCESS && *created) {
-            do_item_unlink(engine, it, ITEM_UNLINK_ABORT);
+            do_item_unlink(engine, it, ITEM_UNLINK_NORMAL);
         }
     }
     if (it != NULL) do_item_release(engine, it);
@@ -6495,7 +6487,7 @@ ENGINE_ERROR_CODE list_elem_delete(struct default_engine *engine,
                                              ELEM_DELETE_NORMAL);
             if (*del_count > 0) {
                 if (info->ccnt == 0 && drop_if_empty) {
-                    do_item_unlink(engine, it, ITEM_UNLINK_EMPTY);
+                    do_item_unlink(engine, it, ITEM_UNLINK_NORMAL);
                     *dropped = true;
                 } else {
                     *dropped = false;
@@ -6540,7 +6532,7 @@ ENGINE_ERROR_CODE list_elem_get(struct default_engine *engine,
                 if (ret == ENGINE_SUCCESS) {
                     if (info->ccnt == 0 && drop_if_empty) {
                         assert(delete == true);
-                        do_item_unlink(engine, it, ITEM_UNLINK_EMPTY);
+                        do_item_unlink(engine, it, ITEM_UNLINK_NORMAL);
                         *dropped = true;
                     } else {
                         *dropped = false;
@@ -6632,7 +6624,7 @@ ENGINE_ERROR_CODE set_elem_insert(struct default_engine *engine, const char *key
     if (ret == ENGINE_SUCCESS) {
         ret = do_set_elem_insert(engine, it, elem, cookie);
         if (ret != ENGINE_SUCCESS && *created) {
-            do_item_unlink(engine, it, ITEM_UNLINK_ABORT);
+            do_item_unlink(engine, it, ITEM_UNLINK_NORMAL);
         }
     }
     if (it != NULL) do_item_release(engine, it);
@@ -6659,7 +6651,7 @@ ENGINE_ERROR_CODE set_elem_delete(struct default_engine *engine,
                                             ELEM_DELETE_NORMAL);
         if (ret == ENGINE_SUCCESS) {
             if (info->ccnt == 0 && drop_if_empty) {
-                do_item_unlink(engine, it, ITEM_UNLINK_EMPTY);
+                do_item_unlink(engine, it, ITEM_UNLINK_NORMAL);
                 *dropped = true;
             }
         }
@@ -6719,7 +6711,7 @@ ENGINE_ERROR_CODE set_elem_get(struct default_engine *engine,
             if (ret == ENGINE_SUCCESS) {
                 if (info->ccnt == 0 && drop_if_empty) {
                     assert(delete == true);
-                    do_item_unlink(engine, it, ITEM_UNLINK_EMPTY);
+                    do_item_unlink(engine, it, ITEM_UNLINK_NORMAL);
                     *dropped = true;
                 } else {
                     *dropped = false;
@@ -6822,7 +6814,7 @@ ENGINE_ERROR_CODE btree_elem_insert(struct default_engine *engine,
         ret = do_btree_elem_insert(engine, it, elem, replace_if_exist, replaced,
                                    trimmed_elems, trimmed_count, cookie);
         if (ret != ENGINE_SUCCESS && *created) {
-            do_item_unlink(engine, it, ITEM_UNLINK_ABORT);
+            do_item_unlink(engine, it, ITEM_UNLINK_NORMAL);
         }
         if (trimmed_elems != NULL && *trimmed_elems != NULL) {
             *trimmed_flags = it->flags;
@@ -6893,7 +6885,7 @@ ENGINE_ERROR_CODE btree_elem_delete(struct default_engine *engine,
             if (*del_count > 0) {
                 if (info->ccnt == 0 && drop_if_empty) {
                     assert(info->root == NULL);
-                    do_item_unlink(engine, it, ITEM_UNLINK_EMPTY);
+                    do_item_unlink(engine, it, ITEM_UNLINK_NORMAL);
                     *dropped = true;
                 } else {
                     *dropped = false;
@@ -6996,7 +6988,7 @@ ENGINE_ERROR_CODE btree_elem_get(struct default_engine *engine,
                 if (delete) {
                     if (info->ccnt == 0 && drop_if_empty) {
                         assert(info->root == NULL);
-                        do_item_unlink(engine, it, ITEM_UNLINK_EMPTY);
+                        do_item_unlink(engine, it, ITEM_UNLINK_NORMAL);
                         *dropped_trimmed = true;
                     } else {
                         *dropped_trimmed = false;
@@ -8949,7 +8941,7 @@ ENGINE_ERROR_CODE map_elem_insert(struct default_engine *engine, const char *key
     if (ret == ENGINE_SUCCESS) {
         ret = do_map_elem_insert(engine, it, elem, false /* replace_if_exist */, cookie);
         if (ret != ENGINE_SUCCESS && *created) {
-            do_item_unlink(engine, it, ITEM_UNLINK_ABORT);
+            do_item_unlink(engine, it, ITEM_UNLINK_NORMAL);
         }
     }
     if (it != NULL) do_item_release(engine, it);
@@ -8993,7 +8985,7 @@ ENGINE_ERROR_CODE map_elem_delete(struct default_engine *engine, const char *key
         if (*del_count > 0) {
             if (info->ccnt == 0 && drop_if_empty) {
                 assert(info->root == NULL);
-                do_item_unlink(engine, it, ITEM_UNLINK_EMPTY);
+                do_item_unlink(engine, it, ITEM_UNLINK_NORMAL);
                 *dropped = true;
             }
         } else {
@@ -9026,7 +9018,7 @@ ENGINE_ERROR_CODE map_elem_get(struct default_engine *engine, const char *key, c
             if (ret == ENGINE_SUCCESS) {
                 if (info->ccnt == 0 && drop_if_empty) {
                     assert(delete == true);
-                    do_item_unlink(engine, it, ITEM_UNLINK_EMPTY);
+                    do_item_unlink(engine, it, ITEM_UNLINK_NORMAL);
                     *dropped = true;
                 } else {
                     *dropped = false;

--- a/engines/default/items.c
+++ b/engines/default/items.c
@@ -7294,7 +7294,6 @@ ENGINE_ERROR_CODE btree_elem_smget(struct default_engine *engine,
 /*
  * ITEM ATTRIBUTE Interface Functions
  */
-#if 1 // NEW_ATTR_CODE
 static ENGINE_ERROR_CODE
 do_item_getattr(struct default_engine *engine, hash_item *it,
                 ENGINE_ITEM_ATTR *attr_ids, const uint32_t attr_count,
@@ -7380,23 +7379,16 @@ do_item_getattr(struct default_engine *engine, hash_item *it,
     }
     return ENGINE_SUCCESS;
 }
-#endif
 
 ENGINE_ERROR_CODE item_getattr(struct default_engine *engine,
                                const void* key, const int nkey,
                                ENGINE_ITEM_ATTR *attr_ids, const uint32_t attr_count,
                                item_attr *attr_data)
 {
-#if 1 // NEW_ATTR_CODE
     hash_item *it;
     ENGINE_ERROR_CODE ret;
-#else
-    ENGINE_ERROR_CODE ret = ENGINE_SUCCESS;
-    hash_item *it;
-#endif
 
     pthread_mutex_lock(&engine->cache_lock);
-#if 1 // NEW_ATTR_CODE
     it = do_item_get(engine, key, nkey, DO_UPDATE);
     if (it == NULL) {
         ret = ENGINE_KEY_ENOENT;
@@ -7408,98 +7400,11 @@ ENGINE_ERROR_CODE item_getattr(struct default_engine *engine,
         }
         do_item_release(engine, it);
     }
-#else
-    it = do_item_get(engine, key, nkey, DO_UPDATE);
-    if (it == NULL) {
-        ret = ENGINE_KEY_ENOENT;
-    } else {
-        /* item flags */
-        attr_data->flags = it->flags;
-
-        /* human readable expiretime */
-        if (it->exptime == 0) {
-            attr_data->exptime = it->exptime;
-#ifdef ENABLE_STICKY_ITEM
-        } else if (it->exptime == (rel_time_t)-1) {
-            attr_data->exptime = it->exptime;
-#endif
-        } else {
-            rel_time_t current_time = engine->server.core->get_current_time();
-            if (it->exptime <= current_time) {
-                attr_data->exptime = (rel_time_t)-2;
-            } else {
-                attr_data->exptime = it->exptime - current_time;
-            }
-        }
-
-        if (IS_COLL_ITEM(it)) {
-            attr_data->type = GET_ITEM_TYPE(it);
-            assert(attr_data->type < ITEM_TYPE_MAX);
-            /* attribute validation check */
-            if (attr_data->type != ITEM_TYPE_BTREE) {
-                for (int i = 0; i < attr_count; i++) {
-                    if (attr_ids[i] == ATTR_MAXBKEYRANGE || attr_ids[i] == ATTR_TRIMMED) {
-                        ret = ENGINE_EBADATTR; break;
-                    }
-                }
-            }
-            /* get collection attributes */
-            if (ret == ENGINE_SUCCESS) {
-                coll_meta_info *info = (coll_meta_info *)item_get_meta(it);
-                attr_data->count      = info->ccnt;
-                if (info->mcnt > 0) {
-                    attr_data->maxcount   = info->mcnt;
-                } else {
-                    switch (attr_data->type) {
-                      case ITEM_TYPE_LIST:
-                           attr_data->maxcount = max_list_size;
-                           break;
-                      case ITEM_TYPE_SET:
-                           attr_data->maxcount = max_set_size;
-                           break;
-                      case ITEM_TYPE_MAP:
-                           attr_data->maxcount = max_map_size;
-                           break;
-                      case ITEM_TYPE_BTREE:
-                           attr_data->maxcount = max_btree_size;
-                           break;
-                      default:
-                           attr_data->maxcount = 0;
-                    }
-                }
-                attr_data->ovflaction = info->ovflact;
-                attr_data->readable   = (((info->mflags & COLL_META_FLAG_READABLE) != 0) ? 1 : 0);
-                if (attr_data->type == ITEM_TYPE_BTREE) {
-                    btree_meta_info *binfo = (btree_meta_info *)info;
-                    attr_data->maxbkeyrange = binfo->maxbkeyrange;
-                    attr_data->trimmed = (((binfo->mflags & COLL_META_FLAG_TRIMMED) != 0) ? 1 : 0);
-                    if (info->ccnt > 0) {
-                        btree_elem_item *min_bkey_elem = do_btree_get_first_elem(binfo->root);
-                        do_btree_get_bkey(min_bkey_elem, &attr_data->minbkey);
-                        btree_elem_item *max_bkey_elem = do_btree_get_last_elem(binfo->root);
-                        do_btree_get_bkey(max_bkey_elem, &attr_data->maxbkey);
-                    }
-                }
-            }
-        } else {
-            attr_data->type = ITEM_TYPE_KV;
-            /* attribute validation check */
-            for (int i = 0; i < attr_count; i++) {
-                if (attr_ids[i] == ATTR_COUNT      || attr_ids[i] == ATTR_MAXCOUNT ||
-                    attr_ids[i] == ATTR_OVFLACTION || attr_ids[i] == ATTR_READABLE ||
-                    attr_ids[i] == ATTR_MAXBKEYRANGE || attr_ids[i] == ATTR_TRIMMED) {
-                    ret = ENGINE_EBADATTR; break;
-                }
-            }
-        }
-        do_item_release(engine, it);
-    }
-#endif
     pthread_mutex_unlock(&engine->cache_lock);
+
     return ret;
 }
 
-#if 1 // NEW_ATTR_CODE
 static ENGINE_ERROR_CODE
 do_item_setattr_check(hash_item *it,
                       ENGINE_ITEM_ATTR *attr_ids, const uint32_t attr_count,
@@ -7671,23 +7576,16 @@ do_item_setattr_exec(struct default_engine *engine, hash_item *it,
         }
     }
 }
-#endif
 
 ENGINE_ERROR_CODE item_setattr(struct default_engine *engine,
                                const void* key, const int nkey,
                                ENGINE_ITEM_ATTR *attr_ids, const uint32_t attr_count,
                                item_attr *attr_data)
 {
-#if 1 // NEW_ATTR_CODE
     hash_item *it;
     ENGINE_ERROR_CODE ret;
-#else
-    ENGINE_ERROR_CODE ret = ENGINE_SUCCESS;
-    hash_item *it;
-#endif
 
     pthread_mutex_lock(&engine->cache_lock);
-#if 1 // NEW_ATTR_CODE
     it = do_item_get(engine, key, nkey, DONT_UPDATE);
     if (it == NULL) {
         ret = ENGINE_KEY_ENOENT;
@@ -7699,161 +7597,8 @@ ENGINE_ERROR_CODE item_setattr(struct default_engine *engine,
         }
         do_item_release(engine, it);
     }
-#else
-    it = do_item_get(engine, key, nkey, DONT_UPDATE);
-    if (it == NULL) {
-        ret = ENGINE_KEY_ENOENT;
-    } else {
-        int i;
-        coll_meta_info *info = NULL;
-        if (IS_COLL_ITEM(it)) {
-            info = (coll_meta_info *)item_get_meta(it);
-        }
-        for (i = 0; i < attr_count; i++) {
-#ifdef ENABLE_STICKY_ITEM
-            if (attr_ids[i] == ATTR_EXPIRETIME) {
-                /* do not allow sticky toggling */
-                if ((it->exptime == (rel_time_t)-1 && attr_data->exptime != (rel_time_t)-1) ||
-                    (it->exptime != (rel_time_t)-1 && attr_data->exptime == (rel_time_t)-1)) {
-                    ret = ENGINE_EBADVALUE; break;
-                }
-                continue;
-            }
-#endif
-            /* other attributes : collection attributes */
-            if (info == NULL) { /* k/v item */
-                ret = ENGINE_EBADATTR; break;
-            }
-            if (attr_ids[i] == ATTR_MAXCOUNT) {
-                attr_data->maxcount = do_coll_real_maxcount(it, attr_data->maxcount);
-                if (attr_data->maxcount > 0 && attr_data->maxcount < info->ccnt) {
-                    ret = ENGINE_EBADVALUE; break;
-                }
-            } else if (attr_ids[i] == ATTR_OVFLACTION) {
-                if (attr_data->ovflaction == OVFL_ERROR) {
-                    /* nothing to check */
-                } else if (attr_data->ovflaction == OVFL_HEAD_TRIM ||
-                           attr_data->ovflaction == OVFL_TAIL_TRIM) {
-                    if (! IS_LIST_ITEM(it)) {
-                        ret = ENGINE_EBADVALUE; break;
-                    }
-                } else if (attr_data->ovflaction == OVFL_SMALLEST_TRIM ||
-                           attr_data->ovflaction == OVFL_LARGEST_TRIM ||
-                           attr_data->ovflaction == OVFL_SMALLEST_SILENT_TRIM ||
-                           attr_data->ovflaction == OVFL_LARGEST_SILENT_TRIM) {
-                    if (! IS_BTREE_ITEM(it)) {
-                        ret = ENGINE_EBADVALUE; break;
-                    }
-                } else {
-                    ret = ENGINE_EBADVALUE; break;
-                }
-            } else if (attr_ids[i] == ATTR_READABLE) {
-                if (attr_data->readable != 1) {
-                    ret = ENGINE_EBADVALUE; break;
-                }
-            } else if (attr_ids[i] == ATTR_MAXBKEYRANGE) {
-                if (! IS_BTREE_ITEM(it)) {
-                    ret = ENGINE_EBADATTR; break;
-                }
-                btree_meta_info *binfo = (btree_meta_info *)info;
-                if (attr_data->maxbkeyrange.len == BKEY_NULL) {
-                    /* nothing to check */
-                } else { /* attr_data->maxbkeyrange.len != BKEY_NULL */
-                    if (binfo->ccnt == 0) {
-                        /* nothing to check */
-                    } else { /* binfo->ccnt > 0 */
-                        /* check bkey type of maxbkeyrange */
-                        if ((binfo->bktype == BKEY_TYPE_UINT64 && attr_data->maxbkeyrange.len >  0) ||
-                            (binfo->bktype == BKEY_TYPE_BINARY && attr_data->maxbkeyrange.len == 0)) {
-                            ret = ENGINE_EBADVALUE; break;
-                        }
-                        if (binfo->ccnt >= 2) { /* two or more elements where key range exists. */
-                            /* check if current bkey range can be contained within new maxbkeyrange */
-                            if (attr_data->maxbkeyrange.len != binfo->maxbkeyrange.len ||
-                                BKEY_ISNE(attr_data->maxbkeyrange.val, attr_data->maxbkeyrange.len,
-                                          binfo->maxbkeyrange.val, binfo->maxbkeyrange.len)) {
-                                bkey_t curbkeyrange;
-                                btree_elem_item *min_bkey_elem = do_btree_get_first_elem(binfo->root);
-                                btree_elem_item *max_bkey_elem = do_btree_get_last_elem(binfo->root);
-                                curbkeyrange.len = attr_data->maxbkeyrange.len;
-                                BKEY_DIFF(max_bkey_elem->data, max_bkey_elem->nbkey, min_bkey_elem->data, min_bkey_elem->nbkey,
-                                          curbkeyrange.len, curbkeyrange.val);
-                                if (BKEY_ISGT(curbkeyrange.val, curbkeyrange.len,
-                                              attr_data->maxbkeyrange.val, attr_data->maxbkeyrange.len)) {
-                                    ret = ENGINE_EBADVALUE; break;
-                                }
-                            }
-                        } else { /* binfo->ccnt == 1 */
-                            /* nothing to check bkey range */
-                        }
-                    }
-                }
-            }
-        }
-        if (ret == ENGINE_SUCCESS) {
-            for (i = 0; i < attr_count; i++) {
-                if (attr_ids[i] == ATTR_EXPIRETIME) {
-                    if (it->exptime != attr_data->exptime) {
-                        rel_time_t before_exptime = it->exptime;
-                        it->exptime = attr_data->exptime;
-                        if (before_exptime == 0 && it->exptime != 0) {
-                            /* exptime: 0 => positive value */
-                            /* When update exptime, the curMK/lowMK of LRU must be considered.
-                             * The item, whose exptime is 0, might be below the lowMK of LRU list.
-                             * If we change only the exptime of the item to a positive value,
-                             * it cannot be reclaimed even if it is expired in the future.
-                             * To make it to be reclaimed after it is expired,
-                             * we move it to to the top of LRU list.
-                             */
-                            do_item_lru_reposition(engine, it);
-                        }
-                    }
-                }
-                else if (attr_ids[i] == ATTR_MAXCOUNT) {
-                    info->mcnt = attr_data->maxcount;
-                }
-                else if (attr_ids[i] == ATTR_OVFLACTION) {
-                    if (IS_BTREE_ITEM(it)) {
-                        btree_meta_info *binfo = (btree_meta_info *)info;
-                        if (binfo->ovflact != attr_data->ovflaction) {
-                            binfo->mflags &= ~COLL_META_FLAG_TRIMMED; // clear trimmed
-                        }
-                    }
-                    info->ovflact = attr_data->ovflaction;
-                }
-                else if (attr_ids[i] == ATTR_READABLE) {
-                    info->mflags |= COLL_META_FLAG_READABLE;
-                }
-                else if (attr_ids[i] == ATTR_MAXBKEYRANGE) {
-                    btree_meta_info *binfo = (btree_meta_info *)info;
-                    if (attr_data->maxbkeyrange.len == BKEY_NULL) {
-                        if (binfo->maxbkeyrange.len != BKEY_NULL) {
-                            binfo->maxbkeyrange = attr_data->maxbkeyrange;
-                            if (binfo->ccnt == 0) {
-                                if (binfo->bktype != BKEY_TYPE_UNKNOWN)
-                                    binfo->bktype = BKEY_TYPE_UNKNOWN;
-                            }
-                        }
-                    } else { /* attr_data->maxbkeyrange.len != BKEY_NULL */
-                        if (binfo->ccnt == 0) {
-                            /* just reset maxbkeyrange with new value */
-                            binfo->maxbkeyrange = attr_data->maxbkeyrange;
-                            if (attr_data->maxbkeyrange.len == 0) {
-                                binfo->bktype = BKEY_TYPE_UINT64;
-                            } else {
-                                binfo->bktype = BKEY_TYPE_BINARY;
-                            }
-                        } else { /* binfo->ccnt > 0 */
-                            binfo->maxbkeyrange = attr_data->maxbkeyrange;
-                        }
-                    }
-                }
-            }
-        }
-        do_item_release(engine, it);
-    }
-#endif
     pthread_mutex_unlock(&engine->cache_lock);
+
     return ret;
 }
 

--- a/lqdetect.c
+++ b/lqdetect.c
@@ -282,6 +282,7 @@ static void lqdetect_write(char client_ip[], char *key, enum lq_detect_command c
         } else {
             snprintf(bufptr, length, "%s %s\n", key, arg->range);
         }
+        break;
     case LQCMD_LOP_GET:
         if (arg->delete_or_drop != 0) {
             snprintf(bufptr, length, "%s %s %s\n", key, arg->range,


### PR DESCRIPTION
I found a missing break.

if it is intended, it will run duplicated code.

for example
if LQCMD_LOP_DELETE and arg->delete_or_drop = 2
first below code will run.
```c
snprintf(bufptr, length, "%s %s %s\n", key, arg->range, "drop");
```

and below code will rerun.
```c
if (arg->delete_or_drop != 0) {
            snprintf(bufptr, length, "%s %s %s\n", key, arg->range,
                       (arg->delete_or_drop == 2 ? "drop" : "delete"));
}
```
