### PR TITLE
fix missing break

### DIFF
--- a/lqdetect.c
+++ b/lqdetect.c
@@ -282,6 +282,7 @@ static void lqdetect_write(char client_ip[], char *key, enum lq_detect_command c
         } else {
             snprintf(bufptr, length, "%s %s\n", key, arg->range);
         }
+        break;
     case LQCMD_LOP_GET:
         if (arg->delete_or_drop != 0) {
             snprintf(bufptr, length, "%s %s %s\n", key, arg->range,


### PR DESCRIPTION
I found a missing break.

if it is intended, it will run duplicated code.

for example
if LQCMD_LOP_DELETE and arg->delete_or_drop = 2
first below code will run.

```c
snprintf(bufptr, length, "%s %s %s\n", key, arg->range, "drop");
```

and below code will rerun.

```c
if (arg->delete_or_drop != 0) {
            snprintf(bufptr, length, "%s %s %s\n", key, arg->range,
                       (arg->delete_or_drop == 2 ? "drop" : "delete"));
}
```