### PR TITLE
disable udp by default

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -16003,7 +16003,7 @@ int main (int argc, char **argv) {
         }
     }
 
-    if (udp_specified && settings.udpport != 0 && !tcp_specified) {
+    if (udp_specified && !tcp_specified) {
         settings.port = settings.udpport;
     }
 

--- a/memcached.c
+++ b/memcached.c
@@ -319,7 +319,7 @@ static void settings_init(void) {
     settings.use_cas = true;
     settings.access = 0700;
     settings.port = 11211;
-    settings.udpport = 11211;
+    settings.udpport = 0;
     /* By default this string should be NULL for getaddrinfo() */
     settings.inter = NULL;
     settings.maxbytes = 64 * 1024 * 1024; /* default is 64MB */
@@ -16003,9 +16003,7 @@ int main (int argc, char **argv) {
         }
     }
 
-    if (tcp_specified && !udp_specified) {
-        settings.udpport = settings.port;
-    } else if (udp_specified && !tcp_specified) {
+    if (udp_specified && settings.udpport != 0 && !tcp_specified) {
         settings.port = settings.udpport;
     }
 

--- a/t/issue_67.t
+++ b/t/issue_67.t
@@ -75,8 +75,8 @@ sub when {
 # when('no arguments', '', 11211, 11211);
 ### [ARCUS] CHANGED FOLLOWING TEST ###
 # Because of 11212 bind error in hudson server environment.
-#when('specifying tcp port', '-p 11212', 11212, 11212);
-when('specifying tcp port', '-p 11292', 11292, 11292);
+#when('specifying tcp port', '-p 11212', 11212, -1);
+when('specifying tcp port', '-p 11292', 11292, -1);
 ######################################
 when('specifying udp port', '-U 11222', 11222, 11222);
 when('specifying tcp ephemeral port', '-p -1', 0, 0);


### PR DESCRIPTION
There is a issue by binidng udp port as default.

ref: https://blog.cloudflare.com/memcrashed-major-amplification-attacks-from-port-11211/

Arcus also will be affected.

and this is the same patch with original memcached https://github.com/memcached/memcached/commit/dbb7a8af90054bf4ef51f5814ef7ceb17d83d974

I tested after applying this patch, Binding udp port is disabled. 