### PR TITLE
FEATURE: proxy server support

### DIFF
--- a/arcus_zk.h
+++ b/arcus_zk.h
@@ -40,7 +40,11 @@ extern volatile sig_atomic_t arcus_zk_shutdown;
 
 void arcus_zk_init(char *ensemble_list, int zk_to,
                    EXTENSION_LOGGER_DESCRIPTOR *logger,
+#ifdef PROXY_SUPPORT
+                   int verbose, size_t maxbytes, int port, char *proxy,
+#else
                    int verbose, size_t maxbytes, int port,
+#endif
                    ENGINE_HANDLE_V1 *engine);
 void arcus_zk_final(const char *msg);
 void arcus_zk_destroy(void);

--- a/include/memcached/types.h
+++ b/include/memcached/types.h
@@ -31,6 +31,7 @@ struct iovec {
 #include <sys/uio.h>
 #endif
 
+#define PROXY_SUPPORT
 #define BOP_COUNT_OPTIMIZE
 #define SUPPORT_BOP_MGET
 #define SUPPORT_BOP_SMGET

--- a/memcached.c
+++ b/memcached.c
@@ -14490,6 +14490,9 @@ static void usage(void) {
 #ifdef ENABLE_ZK_INTEGRATION
     printf("-z ip:port list Zookeeper ensemble cluster servers\n");
     printf("-o <secs>     Zookeeper session timeout in seconds\n");
+#ifdef PROXY_SUPPORT
+    printf("-x ip:port    Proxy server ip:port\n");
+#endif
 #endif
     printf("\nEnvironment variables:\n"
            "MEMCACHED_PORT_FILENAME   File to write port information to\n"
@@ -15163,6 +15166,9 @@ int main (int argc, char **argv) {
 
 #ifdef ENABLE_ZK_INTEGRATION
     int  arcus_zk_to=0;
+#ifdef PROXY_SUPPORT
+    char *arcus_proxy_cfg = NULL;
+#endif
 #endif
 
     if (!sanitycheck()) {
@@ -15218,6 +15224,9 @@ int main (int argc, char **argv) {
 #ifdef ENABLE_ZK_INTEGRATION
           "z:"  /* Arcus Zookeeper */
           "o:"  /* Arcus Zookeeper session timeout option (sec) */
+#ifdef PROXY_SUPPORT
+          "x:"  /* Proxy server ip:port */
+#endif
 #endif
         ))) {
         switch (c) {
@@ -15458,6 +15467,14 @@ int main (int argc, char **argv) {
 
             arcus_zk_to = atoi(optarg); // this value is in seconds
             break;
+
+#ifdef PROXY_SUPPORT
+        case 'x': /* configure for proxy server */
+
+            arcus_proxy_cfg = strdup(optarg);
+            break;
+#endif
+
 #endif
 
         default:
@@ -15832,7 +15849,11 @@ int main (int argc, char **argv) {
     // initialize Arcus ZK cluster connection
     if (arcus_zk_cfg) {
         arcus_zk_init(arcus_zk_cfg, arcus_zk_to, mc_logger,
+#ifdef PROXY_SUPPORT
+                      settings.verbose, settings.maxbytes, settings.port, arcus_proxy_cfg,
+#else
                       settings.verbose, settings.maxbytes, settings.port,
+#endif
                       mc_engine.v1);
     }
 #endif


### PR DESCRIPTION
proxy server 지원에 관한 PR입니다.
znode_name과 mc_ipport에 proxy 정보를 입력시켜 실제 ipport는 자신의 것을 사용하지만
proxy의 ipport를 사용하는 것처럼 동작합니다.
실행시에는 -x옵션에 proxy 서버의 ip:port를 넣으면 됩니다. hostname도 사용가능하도록 구현했습니다.

현재 구현이 복잡한지를 따져보고, arcus_zk_init에 proxy를 파라미터로 넣는 현재 구현이 이상하면,
proxy_zk_init 처럼 따로 initial 함수를 떼어내서 구현하는 방법도 있을 것 같습니다.

@jhpark816 
리뷰 부탁드립니다.