### PR TITLE
TEST : modified release_memcached subroutine

### DIFF
--- a/t/00-startup.t
+++ b/t/00-startup.t
@@ -83,4 +83,4 @@ eval {
 ok($@, "Died with illegal 0 thread count");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/64bit.t
+++ b/t/64bit.t
@@ -49,4 +49,4 @@ $slabs = mem_stats($sock, 'slabs');
 is($slabs->{'active_slabs'}, 1, "1 active slab");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/arcus_ping_test.t
+++ b/t/arcus_ping_test.t
@@ -67,4 +67,4 @@ for (0..1) {
 }
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/ascii_ext_protocol.t
+++ b/t/ascii_ext_protocol.t
@@ -223,4 +223,4 @@ $server->stop();
 
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/binary-get.t
+++ b/t/binary-get.t
@@ -23,4 +23,4 @@ foreach my $blob ("mooo\0", "mumble\0\0\0\0\r\rblarg", "\0", "\r") {
 }
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/binary-sasl.t.in
+++ b/t/binary-sasl.t.in
@@ -279,7 +279,7 @@ $empty->('x');
 # my %stats = $mc->stats('detail dump');
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);
 
 # ######################################################################
 # Test ends around here.

--- a/t/binary.t
+++ b/t/binary.t
@@ -452,7 +452,7 @@ my %stats = $mc->stats('detail dump');
 }
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);
 
 # ######################################################################
 # Test ends around here.

--- a/t/binary_crash.t
+++ b/t/binary_crash.t
@@ -18,4 +18,4 @@ sleep 0.5;
 ok($server->new_sock, "failed to open new socket");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/bogus-commands.t
+++ b/t/bogus-commands.t
@@ -14,4 +14,4 @@ print $sock "boguscommand slkdsldkfjsd\r\n";
 is(scalar <$sock>, "ERROR unknown command\r\n", "got error back");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/cas.t
+++ b/t/cas.t
@@ -159,4 +159,4 @@ is(scalar <$sock>, "END\r\n","gets bug15 END");
 ok($bug15_cas != $next_bug15_cas, "CAS changed");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/cmd_extensions.t
+++ b/t/cmd_extensions.t
@@ -28,4 +28,4 @@ print $sock "echo 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8\r\n";
 is(scalar <$sock>, "ERROR too many arguments\r\n", "args truncated");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/coll_bkeymismatch_test.t
+++ b/t/coll_bkeymismatch_test.t
@@ -92,4 +92,4 @@ $cmd = "delete bkey1"; $rst = "DELETED";
 print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/coll_bkeyoor_test.t
+++ b/t/coll_bkeyoor_test.t
@@ -287,4 +287,4 @@ print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/coll_bop_attr_min_max_bkey.t
+++ b/t/coll_bop_attr_min_max_bkey.t
@@ -106,4 +106,4 @@ $cmd = "delete minbkey1"; $rst = "DELETED";
 print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/coll_bop_count.t
+++ b/t/coll_bop_count.t
@@ -80,4 +80,4 @@ print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/coll_bop_delete.t
+++ b/t/coll_bop_delete.t
@@ -193,4 +193,4 @@ print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 # # print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/coll_bop_eflag.t
+++ b/t/coll_bop_eflag.t
@@ -107,4 +107,4 @@ print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "deleted");
 
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/coll_bop_get.t
+++ b/t/coll_bop_get.t
@@ -240,4 +240,4 @@ print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/coll_bop_incrdecr.t
+++ b/t/coll_bop_incrdecr.t
@@ -211,4 +211,4 @@ print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/coll_bop_insert.t
+++ b/t/coll_bop_insert.t
@@ -155,4 +155,4 @@ print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/coll_bop_insert_getrim.t
+++ b/t/coll_bop_insert_getrim.t
@@ -149,4 +149,4 @@ print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/coll_bop_mget_1.t
+++ b/t/coll_bop_mget_1.t
@@ -354,4 +354,4 @@ $cmd = "delete bkey2"; $rst = "DELETED";
 print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/coll_bop_mget_2.t
+++ b/t/coll_bop_mget_2.t
@@ -398,4 +398,4 @@ print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/coll_bop_smget_1.t
+++ b/t/coll_bop_smget_1.t
@@ -398,4 +398,4 @@ $cmd = "delete bkey2"; $rst = "DELETED";
 print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/coll_bop_smget_2.t
+++ b/t/coll_bop_smget_2.t
@@ -466,4 +466,4 @@ print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/coll_bop_smget_3.t
+++ b/t/coll_bop_smget_3.t
@@ -483,4 +483,4 @@ $cmd = "delete bkey2"; $rst = "DELETED";
 print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/coll_bop_smget_4.t
+++ b/t/coll_bop_smget_4.t
@@ -483,4 +483,4 @@ $cmd = "delete key2"; $rst = "DELETED";
 print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/coll_bop_smget_5.t
+++ b/t/coll_bop_smget_5.t
@@ -123,4 +123,4 @@ print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/coll_bop_smget_trim.t
+++ b/t/coll_bop_smget_trim.t
@@ -625,4 +625,4 @@ $cmd = "delete bkey4"; $rst = "DELETED";
 print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/coll_bop_smget_unique.t
+++ b/t/coll_bop_smget_unique.t
@@ -439,4 +439,4 @@ $cmd = "delete bkey2"; $rst = "DELETED";
 print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/coll_bop_trimmed_test.t
+++ b/t/coll_bop_trimmed_test.t
@@ -238,4 +238,4 @@ $cmd = "delete bkey2"; $rst = "DELETED";
 print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/coll_bop_unittest.t
+++ b/t/coll_bop_unittest.t
@@ -566,4 +566,4 @@ $cmd = "get bkey"; $rst = "END";
 print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/coll_bop_update.t
+++ b/t/coll_bop_update.t
@@ -248,4 +248,4 @@ print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/coll_bop_upsert.t
+++ b/t/coll_bop_upsert.t
@@ -158,4 +158,4 @@ print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/coll_lop_unittest.t
+++ b/t/coll_lop_unittest.t
@@ -376,4 +376,4 @@ print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/coll_mop_delete.t
+++ b/t/coll_mop_delete.t
@@ -99,4 +99,4 @@ print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/coll_mop_get.t
+++ b/t/coll_mop_get.t
@@ -78,4 +78,4 @@ $cmd = "delete mkey1"; $rst = "DELETED";
 print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/coll_mop_insert.t
+++ b/t/coll_mop_insert.t
@@ -71,4 +71,4 @@ $cmd = "delete mkey1"; $rst = "DELETED";
 print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/coll_mop_update.t
+++ b/t/coll_mop_update.t
@@ -69,4 +69,4 @@ $cmd = "delete mkey1"; $rst = "DELETED";
 print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/coll_pipeline_general.t
+++ b/t/coll_pipeline_general.t
@@ -100,4 +100,4 @@ print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/coll_pipeline_sop_exist.t
+++ b/t/coll_pipeline_sop_exist.t
@@ -153,4 +153,4 @@ print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/coll_readable_attr.t
+++ b/t/coll_readable_attr.t
@@ -112,4 +112,4 @@ print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/coll_sop_segfault_p012611.t
+++ b/t/coll_sop_segfault_p012611.t
@@ -85,4 +85,4 @@ print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/coll_sop_unittest.t
+++ b/t/coll_sop_unittest.t
@@ -386,4 +386,4 @@ print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/daemonize.t
+++ b/t/daemonize.t
@@ -34,4 +34,4 @@ sleep 0.5;
 ok(! $server->new_sock, "failed to open new socket");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/dash-M.t
+++ b/t/dash-M.t
@@ -35,4 +35,4 @@ for($key = 0; $key < $max_stored; $key++) {
 }
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/evictions.t
+++ b/t/evictions.t
@@ -32,4 +32,4 @@ my $evicted_nonzero = $stats->{"items:31:evicted_nonzero"};
 isnt($evicted_nonzero, "0", "check evicted_nonzero");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/expirations.t
+++ b/t/expirations.t
@@ -65,4 +65,4 @@ is(scalar <$sock>, "STORED\r\n", "stored add again");
 mem_get_is($sock, "add", "addval3");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/flags.t
+++ b/t/flags.t
@@ -19,4 +19,4 @@ for my $flags (0, 123, 2**16-1) {
 }
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/flush-all.t
+++ b/t/flush-all.t
@@ -45,4 +45,4 @@ sleep(2.2);
 mem_get_is($sock, "foo", undef);
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/getset.t
+++ b/t/getset.t
@@ -100,4 +100,4 @@ while ($len < 1024*1028) {
 
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/incrdecr.t
+++ b/t/incrdecr.t
@@ -96,4 +96,4 @@ mem_get_is($sock, "noexists", 19);
 
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/issue_104.t
+++ b/t/issue_104.t
@@ -25,4 +25,4 @@ is($stats->{get_hits}, 1, "Should have 1 hit");
 is($stats->{get_misses}, 1, "Should have 1 miss");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/issue_108.t
+++ b/t/issue_108.t
@@ -28,4 +28,4 @@ is (scalar <$sock>, "STORED\r\n", "Add succeeded after quiet deletion.");
 
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/issue_14.t
+++ b/t/issue_14.t
@@ -35,4 +35,4 @@ my $second_malloc = $second_stats->{total_malloced};
 is ($second_malloc, $first_malloc, "Memory grows..");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/issue_152.t
+++ b/t/issue_152.t
@@ -20,4 +20,4 @@ print $sock "get a $key\r\n";
 is (scalar <$sock>, "CLIENT_ERROR bad command line format\r\n", "illegal key");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/issue_163.t
+++ b/t/issue_163.t
@@ -42,4 +42,4 @@ my $requested2 = $stats->{"31:mem_requested"};
 is ($requested2, $requested, "we've not allocated and freed the same amont");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/issue_22.t
+++ b/t/issue_22.t
@@ -56,4 +56,4 @@ my $last_evicted = $last_stats->{"items:31:evicted"};
 is ($last_evicted, "40", "check evicted");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/issue_29.t
+++ b/t/issue_29.t
@@ -42,4 +42,4 @@ is(1, $second_used, "Used still one chunk");
 ######################################
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/issue_3.t
+++ b/t/issue_3.t
@@ -48,4 +48,4 @@ is (scalar <$sock>, "STORED\r\n", "Add succeeded after deletion.");
 
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/issue_41.t
+++ b/t/issue_41.t
@@ -40,4 +40,4 @@ my $v = scalar <$sock>;
 ok(defined $v && length($v), "memcached didn't respond");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/issue_42.t
+++ b/t/issue_42.t
@@ -29,4 +29,4 @@ ok ($req == "262144", "Check allocated size");
 ######################################
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/issue_50.t
+++ b/t/issue_50.t
@@ -17,4 +17,4 @@ my $rv = <$sock>;
 ok(1, "Either the above worked and quit, or hung forever.");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/issue_61.t
+++ b/t/issue_61.t
@@ -21,4 +21,4 @@ my $stats = mem_stats($sock);
 is ($stats->{"conn_yields"}, "5", "Got a decent number of yields");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/issue_68.t
+++ b/t/issue_68.t
@@ -21,4 +21,4 @@ for (my $keyi = 1; $keyi < 250; $keyi++) {
 }
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/issue_70.t
+++ b/t/issue_70.t
@@ -23,4 +23,4 @@ print $sock "set issue70 0 0 2147483647\r\nscoobyscoobydoo";
 is (scalar <$sock>, "CLIENT_ERROR bad command line format\r\n");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/issue_arcus_151.t
+++ b/t/issue_arcus_151.t
@@ -133,4 +133,4 @@ sub stress {
 }
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/item_size_max.t
+++ b/t/item_size_max.t
@@ -69,4 +69,4 @@ $server->stop();
 
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/longkey.t
+++ b/t/longkey.t
@@ -283,4 +283,4 @@ delete_keyset_in_memory($kcount);
 assert_collection_test($kcount);
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/lru.t
+++ b/t/lru.t
@@ -59,4 +59,4 @@ for (my $i = $evictions - 1; $i < $evictions + 4; $i++) {
 }
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/maxconns.t
+++ b/t/maxconns.t
@@ -27,4 +27,4 @@ foreach my $conn (1..10) {
 }
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/mget.t
+++ b/t/mget.t
@@ -181,4 +181,4 @@ print $sock "delete key5\r\n";
 is(scalar <$sock>, "DELETED\r\n", "deleted key5");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/mget2.t
+++ b/t/mget2.t
@@ -88,4 +88,4 @@ assert_kv_mget_old($key_len, $key_cnt, $key_str);
 assert_kv_mget_new($key_len, $key_cnt, $key_str);
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/multiversioning.t
+++ b/t/multiversioning.t
@@ -47,4 +47,4 @@ like($buf, qr/abcde\]/, "buf now closes");
 mem_get_is($sock, "big", $bigval2, "big value2 got correctly from sock1");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/noreply.t
+++ b/t/noreply.t
@@ -44,4 +44,4 @@ mem_get_is($sock, "noreply:foo");
 
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/readable_expiretime.t
+++ b/t/readable_expiretime.t
@@ -59,4 +59,4 @@ print $sock "delete foo\r\n";
 is(scalar <$sock>, "DELETED\r\n", "deleted foo");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/scrub.t
+++ b/t/scrub.t
@@ -33,4 +33,4 @@ is ($visited, "80", "visited");
 is ($cleaned, "40", "cleaned");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/set_with_largest_slab.t
+++ b/t/set_with_largest_slab.t
@@ -32,4 +32,4 @@ while ($len < 1024*1028) {
 }
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/stats-detail.t
+++ b/t/stats-detail.t
@@ -74,4 +74,4 @@ is(scalar <$sock>, "PREFIX foo get 1 hit 1 set 0 del 0 inc 0 dec 0 lcs 0 lis 0 l
 is(scalar <$sock>, "END\r\n", "end of details");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/stats.t
+++ b/t/stats.t
@@ -323,4 +323,4 @@ my $stats = mem_stats($sock);
 is($stats->{cmd_flush}, 1, "after one flush cmd_flush is 1");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/stats_prefixes.t
+++ b/t/stats_prefixes.t
@@ -305,4 +305,4 @@ stats_prefixes_is($sock, "");
 
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/topkeys.t
+++ b/t/topkeys.t
@@ -116,4 +116,4 @@ is($stats->{'foo100'}->{'cmd_set'}, 1);
 is($stats->{'foo199'}->{'cmd_set'}, 1);
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/udp.t
+++ b/t/udp.t
@@ -261,4 +261,4 @@ $host = gethostbyaddr($hisiaddr, AF_INET);
 $histime = unpack("N", $rtime) - $SECS_of_70_YEARS ;
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/unixsocket.t
+++ b/t/unixsocket.t
@@ -25,4 +25,4 @@ unlink($filename);
 ## Just some basic stuff for now...
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);

--- a/t/verbosity.t
+++ b/t/verbosity.t
@@ -34,4 +34,4 @@ print $sock "config verbosity 100\r\n";
 is(scalar <$sock>, "SERVER_ERROR cannot change the verbosity over the limit\r\n", "Over the max value");
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);


### PR DESCRIPTION
Enterprise Edition에서의 pid handling으로 인해 release시에 $server도 함께 넘겨주어야 함.
```
release_memcached($engine) -> release_memcached($engine, $server)
```
use for
- $server->{pid}
- $server->stop