### PR TITLE
TEST : add common function for test

### DIFF
--- a/t/coll_bop_mget_1.t
+++ b/t/coll_bop_mget_1.t
@@ -96,41 +96,98 @@ delete bkey2
 =cut
 
 # testBOPSMGetSimple
-$cmd = "get bkey1"; $rst = "END";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-$cmd = "get bkey2"; $rst = "END";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-$cmd = "bop create bkey1 11 0 0"; $rst = "CREATED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-$cmd = "bop insert bkey1 90 6"; $val = "datum9"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-$cmd = "bop insert bkey1 70 6"; $val = "datum7"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-$cmd = "bop insert bkey1 50 6"; $val = "datum5"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-$cmd = "bop insert bkey1 30 6"; $val = "datum3"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-$cmd = "bop insert bkey1 10 6"; $val = "datum1"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-$cmd = "bop create bkey2 12 0 0"; $rst = "CREATED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-$cmd = "bop insert bkey2 100 7"; $val = "datum10"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-$cmd = "bop insert bkey2 80 6"; $val = "datum8"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-$cmd = "bop insert bkey2 60 6"; $val = "datum6"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-$cmd = "bop insert bkey2 40 6"; $val = "datum4"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-$cmd = "bop insert bkey2 20 6"; $val = "datum2"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-bop_get_is($sock, "bkey1 0..100", 11, 5,
-                  "10,30,50,70,90", "datum1,datum3,datum5,datum7,datum9", "END");
-bop_get_is($sock, "bkey2 0..100", 12, 5,
-                  "20,40,60,80,100", "datum2,datum4,datum6,datum8,datum10", "END");
+$cmd = "get bkey1";
+$rst = "END";
+mem_cmd_is($sock, $cmd, "", $rst);
 
-$cmd = "bop mget 11 2 0..100 5"; $val = "bkey1 bkey2";
-$rst = "VALUE bkey1 OK 11 5
+$cmd = "get bkey2";
+$rst = "END";
+mem_cmd_is($sock, $cmd, "", $rst);
+
+$cmd = "bop create bkey1 11 0 0";
+$rst = "CREATED";
+mem_cmd_is($sock, $cmd, "", $rst);
+
+$cmd = "bop insert bkey1 90 6";
+$val = "datum9";
+$rst = "STORED";
+mem_cmd_is($sock, $cmd, $val, $rst);
+
+$cmd = "bop insert bkey1 70 6";
+$val = "datum7";
+$rst = "STORED";
+mem_cmd_is($sock, $cmd, $val, $rst);
+
+$cmd = "bop insert bkey1 50 6";
+$val = "datum5";
+$rst = "STORED";
+mem_cmd_is($sock, $cmd, $val, $rst);
+
+$cmd = "bop insert bkey1 30 6";
+$val = "datum3";
+$rst = "STORED";
+mem_cmd_is($sock, $cmd, $val, $rst);
+
+$cmd = "bop insert bkey1 10 6";
+$val = "datum1";
+$rst = "STORED";
+mem_cmd_is($sock, $cmd, $val, $rst);
+
+$cmd = "bop create bkey2 12 0 0";
+$rst = "CREATED";
+mem_cmd_is($sock, $cmd, "", $rst);
+
+$cmd = "bop insert bkey2 100 7";
+$val = "datum10";
+$rst = "STORED";
+mem_cmd_is($sock, $cmd, $val, $rst);
+
+$cmd = "bop insert bkey2 80 6";
+$val = "datum8";
+$rst = "STORED";
+mem_cmd_is($sock, $cmd, $val, $rst);
+
+$cmd = "bop insert bkey2 60 6";
+$val = "datum6";
+$rst = "STORED";
+mem_cmd_is($sock, $cmd, $val, $rst);
+
+$cmd = "bop insert bkey2 40 6";
+$val = "datum4";
+$rst = "STORED";
+mem_cmd_is($sock, $cmd, $val, $rst);
+
+$cmd = "bop insert bkey2 20 6";
+$val = "datum2";
+$rst = "STORED";
+mem_cmd_is($sock, $cmd, $val, $rst);
+
+$cmd = "bop get bkey1 0..100";
+$rst =
+"VALUE 11 5
+10 6 datum1
+30 6 datum3
+50 6 datum5
+70 6 datum7
+90 6 datum9
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
+
+$cmd = "bop get bkey2 0..100";
+$rst =
+"VALUE 12 5
+20 6 datum2
+40 6 datum4
+60 6 datum6
+80 6 datum8
+100 7 datum10
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
+
+$cmd = "bop mget 11 2 0..100 5";
+$val = "bkey1 bkey2";
+$rst =
+"VALUE bkey1 OK 11 5
 ELEMENT 10 6 datum1
 ELEMENT 30 6 datum3
 ELEMENT 50 6 datum5
@@ -143,10 +200,12 @@ ELEMENT 60 6 datum6
 ELEMENT 80 6 datum8
 ELEMENT 100 7 datum10
 END";
-mem_cmd_val_is($sock, $cmd, $val, $rst);
+mem_cmd_is($sock, $cmd, $val, $rst);
 
-$cmd = "bop mget 11 2 100..0 10"; $val = "bkey1 bkey2";
-$rst = "VALUE bkey1 OK 11 5
+$cmd = "bop mget 11 2 100..0 10";
+$val = "bkey1 bkey2";
+$rst =
+"VALUE bkey1 OK 11 5
 ELEMENT 90 6 datum9
 ELEMENT 70 6 datum7
 ELEMENT 50 6 datum5
@@ -159,10 +218,12 @@ ELEMENT 60 6 datum6
 ELEMENT 40 6 datum4
 ELEMENT 20 6 datum2
 END";
-mem_cmd_val_is($sock, $cmd, $val, $rst);
+mem_cmd_is($sock, $cmd, $val, $rst);
 
-$cmd = "bop mget 23 4 0..100 2 6"; $val = "bkey2 bkey3 bkey1 bkey4";
-$rst = "VALUE bkey2 OK 12 3
+$cmd = "bop mget 23 4 0..100 2 6";
+$val = "bkey2 bkey3 bkey1 bkey4";
+$rst =
+"VALUE bkey2 OK 12 3
 ELEMENT 60 6 datum6
 ELEMENT 80 6 datum8
 ELEMENT 100 7 datum10
@@ -173,10 +234,12 @@ ELEMENT 70 6 datum7
 ELEMENT 90 6 datum9
 VALUE bkey4 NOT_FOUND
 END";
-mem_cmd_val_is($sock, $cmd, $val, $rst);
+mem_cmd_is($sock, $cmd, $val, $rst);
 
-$cmd = "bop mget 23 4 90..30 2 9"; $val = "bkey2 bkey3 bkey1 bkey4";
-$rst = "VALUE bkey2 OK 12 1
+$cmd = "bop mget 23 4 90..30 2 9";
+$val = "bkey2 bkey3 bkey1 bkey4";
+$rst =
+"VALUE bkey2 OK 12 1
 ELEMENT 40 6 datum4
 VALUE bkey3 NOT_FOUND
 VALUE bkey1 OK 11 2
@@ -184,24 +247,32 @@ ELEMENT 50 6 datum5
 ELEMENT 30 6 datum3
 VALUE bkey4 NOT_FOUND
 END";
-mem_cmd_val_is($sock, $cmd, $val, $rst);
+mem_cmd_is($sock, $cmd, $val, $rst);
 
-$cmd = "bop mget 23 4 200..300 2 6"; $val = "bkey2 bkey3 bkey1 bkey4";
-$rst = "VALUE bkey2 NOT_FOUND_ELEMENT
+$cmd = "bop mget 23 4 200..300 2 6";
+$val = "bkey2 bkey3 bkey1 bkey4";
+$rst =
+"VALUE bkey2 NOT_FOUND_ELEMENT
 VALUE bkey3 NOT_FOUND
 VALUE bkey1 NOT_FOUND_ELEMENT
 VALUE bkey4 NOT_FOUND
 END";
-mem_cmd_val_is($sock, $cmd, $val, $rst);
+mem_cmd_is($sock, $cmd, $val, $rst);
 
-$cmd = "set keyx 19 5 10"; $val = "some value"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+$cmd = "set keyx 19 5 10";
+$val = "some value";
+$rst = "STORED";
+mem_cmd_is($sock, $cmd, $val, $rst);
 
-$cmd = "bop mget 23 2 0..100 2 6"; $val = "bkey2 bkey3 bkey1 bkey4"; $rst = "CLIENT_ERROR bad data chunk";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+$cmd = "bop mget 23 2 0..100 2 6";
+$val = "bkey2 bkey3 bkey1 bkey4";
+$rst = "CLIENT_ERROR bad data chunk";
+mem_cmd_is($sock, $cmd, $val, $rst);
 
-$cmd = "bop mget 28 5 0..100 2 6"; $val = "bkey2 bkey3 bkey1 bkey4 keyx";
-$rst = "VALUE bkey2 OK 12 3
+$cmd = "bop mget 28 5 0..100 2 6";
+$val = "bkey2 bkey3 bkey1 bkey4 keyx";
+$rst =
+"VALUE bkey2 OK 12 3
 ELEMENT 60 6 datum6
 ELEMENT 80 6 datum8
 ELEMENT 100 7 datum10
@@ -213,10 +284,12 @@ ELEMENT 90 6 datum9
 VALUE bkey4 NOT_FOUND
 VALUE keyx TYPE_MISMATCH
 END";
-mem_cmd_val_is($sock, $cmd, $val, $rst);
+mem_cmd_is($sock, $cmd, $val, $rst);
 
-$cmd = "bop mget 29 5 0..100 2 6"; $val = "bkey2 bkey3 bkey1 bkey4 bkey1";
-$rst = "VALUE bkey2 OK 12 3
+$cmd = "bop mget 29 5 0..100 2 6";
+$val = "bkey2 bkey3 bkey1 bkey4 bkey1";
+$rst =
+"VALUE bkey2 OK 12 3
 ELEMENT 60 6 datum6
 ELEMENT 80 6 datum8
 ELEMENT 100 7 datum10
@@ -231,10 +304,12 @@ ELEMENT 50 6 datum5
 ELEMENT 70 6 datum7
 ELEMENT 90 6 datum9
 END";
-mem_cmd_val_is($sock, $cmd, $val, $rst);
+mem_cmd_is($sock, $cmd, $val, $rst);
 
-$cmd = "bop mget 29 5 0..100 2 6"; $val = "bkey2 bkey3 bkey1 bkey4 bkey3";
-$rst = "VALUE bkey2 OK 12 3
+$cmd = "bop mget 29 5 0..100 2 6";
+$val = "bkey2 bkey3 bkey1 bkey4 bkey3";
+$rst =
+"VALUE bkey2 OK 12 3
 ELEMENT 60 6 datum6
 ELEMENT 80 6 datum8
 ELEMENT 100 7 datum10
@@ -246,37 +321,72 @@ ELEMENT 90 6 datum9
 VALUE bkey4 NOT_FOUND
 VALUE bkey3 NOT_FOUND
 END";
-mem_cmd_val_is($sock, $cmd, $val, $rst);
+mem_cmd_is($sock, $cmd, $val, $rst);
 
-$cmd = "delete keyx"; $rst = "DELETED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-$cmd = "delete bkey1"; $rst = "DELETED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-$cmd = "delete bkey2"; $rst = "DELETED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+$cmd = "delete keyx";
+$rst = "DELETED";
+mem_cmd_is($sock, $cmd, "", $rst);
 
-$cmd = "bop create bkey1 11 0 0"; $rst = "CREATED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-$cmd = "bop create bkey2 12 0 0"; $rst = "CREATED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-$cmd = "bop insert bkey2 100 7"; $val = "datum10"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-$cmd = "bop insert bkey2 80 6"; $val = "datum8"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-$cmd = "bop insert bkey2 60 6"; $val = "datum6"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-$cmd = "bop insert bkey2 40 6"; $val = "datum4"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-$cmd = "bop insert bkey2 20 6"; $val = "datum2"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+$cmd = "delete bkey1";
+$rst = "DELETED";
+mem_cmd_is($sock, $cmd, "", $rst);
 
-$cmd = "bop get bkey1 0..100"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-bop_get_is($sock, "bkey2 0..100", 12, 5,
-                  "20,40,60,80,100", "datum2,datum4,datum6,datum8,datum10", "END");
+$cmd = "delete bkey2";
+$rst = "DELETED";
+mem_cmd_is($sock, $cmd, "", $rst);
 
-$cmd = "bop mget 11 2 0..100 5"; $val = "bkey1 bkey2";
-$rst = "VALUE bkey1 NOT_FOUND_ELEMENT
+$cmd = "bop create bkey1 11 0 0";
+$rst = "CREATED";
+mem_cmd_is($sock, $cmd, "", $rst);
+
+$cmd = "bop create bkey2 12 0 0";
+$rst = "CREATED";
+mem_cmd_is($sock, $cmd, "", $rst);
+
+$cmd = "bop insert bkey2 100 7";
+$val = "datum10";
+$rst = "STORED";
+mem_cmd_is($sock, $cmd, $val, $rst);
+
+$cmd = "bop insert bkey2 80 6";
+$val = "datum8";
+$rst = "STORED";
+mem_cmd_is($sock, $cmd, $val, $rst);
+
+$cmd = "bop insert bkey2 60 6";
+$val = "datum6";
+$rst = "STORED";
+mem_cmd_is($sock, $cmd, $val, $rst);
+
+$cmd = "bop insert bkey2 40 6";
+$val = "datum4";
+$rst = "STORED";
+mem_cmd_is($sock, $cmd, $val, $rst);
+
+$cmd = "bop insert bkey2 20 6";
+$val = "datum2";
+$rst = "STORED";
+mem_cmd_is($sock, $cmd, $val, $rst);
+
+$cmd = "bop get bkey1 0..100";
+$rst = "NOT_FOUND_ELEMENT";
+mem_cmd_is($sock, $cmd, "", $rst);
+
+$cmd = "bop get bkey2 0..100";
+$rst =
+"VALUE 12 5
+20 6 datum2
+40 6 datum4
+60 6 datum6
+80 6 datum8
+100 7 datum10
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
+
+$cmd = "bop mget 11 2 0..100 5";
+$val = "bkey1 bkey2";
+$rst =
+"VALUE bkey1 NOT_FOUND_ELEMENT
 VALUE bkey2 OK 12 5
 ELEMENT 20 6 datum2
 ELEMENT 40 6 datum4
@@ -284,10 +394,16 @@ ELEMENT 60 6 datum6
 ELEMENT 80 6 datum8
 ELEMENT 100 7 datum10
 END";
-mem_cmd_val_is($sock, $cmd, $val, $rst);
+mem_cmd_is($sock, $cmd, $val, $rst);
 
-$cmd = "bop mget 146 21 0..100000 10"; $val = "KEY_11 KEY_12 KEY_13 KEY_14 KEY_15 KEY_16 KEY_17 KEY_18 KEY_19 KEY_20 KEY_21 KEY_22 KEY_23 KEY_24 KEY_25 KEY_26 KEY_27 KEY_28 KEY_29 KEY_30 KEY_16";
-$rst = "VALUE KEY_11 NOT_FOUND
+$cmd = "bop mget 146 21 0..100000 10";
+$val = "KEY_11 KEY_12 KEY_13 KEY_14 "
+     . "KEY_15 KEY_16 KEY_17 KEY_18 "
+     . "KEY_19 KEY_20 KEY_21 KEY_22 "
+     . "KEY_23 KEY_24 KEY_25 KEY_26 "
+     . "KEY_27 KEY_28 KEY_29 KEY_30 KEY_16";
+$rst =
+"VALUE KEY_11 NOT_FOUND
 VALUE KEY_12 NOT_FOUND
 VALUE KEY_13 NOT_FOUND
 VALUE KEY_14 NOT_FOUND
@@ -309,49 +425,76 @@ VALUE KEY_29 NOT_FOUND
 VALUE KEY_30 NOT_FOUND
 VALUE KEY_16 NOT_FOUND
 END";
-mem_cmd_val_is($sock, $cmd, $val, $rst);
+mem_cmd_is($sock, $cmd, $val, $rst);
 
-$cmd = "delete bkey1"; $rst = "DELETED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-$cmd = "delete bkey2"; $rst = "DELETED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+$cmd = "delete bkey1";
+$rst = "DELETED";
+mem_cmd_is($sock, $cmd, "", $rst);
+
+$cmd = "delete bkey2";
+$rst = "DELETED";
+mem_cmd_is($sock, $cmd, "", $rst);
 
 # EFlag Filter test
-$cmd = "bop insert bkey1 0x0090 0x11FF 6 create 3 0 0"; $val = "datum9"; $rst = "CREATED_STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-$cmd = "bop insert bkey1 0x0070 0x01FF 6"; $val = "datum7"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-$cmd = "bop insert bkey1 0x0050 0x00FF 6"; $val = "datum5"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-$cmd = "bop insert bkey2 0x0080 0x11FF 6 create 3 0 0"; $val = "datum8"; $rst = "CREATED_STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-$cmd = "bop insert bkey2 0x0060 0x01FF 6"; $val = "datum6"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-$cmd = "bop insert bkey2 0x0040 0x00FF 6"; $val = "datum4"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+$cmd = "bop insert bkey1 0x0090 0x11FF 6 create 3 0 0";
+$val = "datum9";
+$rst = "CREATED_STORED";
+mem_cmd_is($sock, $cmd, $val, $rst);
 
-$cmd = "bop mget 11 2 0x00..0x1000 0 EQ 0x11FF,0x01FF 6"; $val = "bkey1 bkey2";
-$rst = "VALUE bkey1 OK 3 2
+$cmd = "bop insert bkey1 0x0070 0x01FF 6";
+$val = "datum7";
+$rst = "STORED";
+mem_cmd_is($sock, $cmd, $val, $rst);
+
+$cmd = "bop insert bkey1 0x0050 0x00FF 6";
+$val = "datum5";
+$rst = "STORED";
+mem_cmd_is($sock, $cmd, $val, $rst);
+
+$cmd = "bop insert bkey2 0x0080 0x11FF 6 create 3 0 0";
+$val = "datum8";
+$rst = "CREATED_STORED";
+mem_cmd_is($sock, $cmd, $val, $rst);
+
+$cmd = "bop insert bkey2 0x0060 0x01FF 6";
+$val = "datum6";
+$rst = "STORED";
+mem_cmd_is($sock, $cmd, $val, $rst);
+
+$cmd = "bop insert bkey2 0x0040 0x00FF 6";
+$val = "datum4";
+$rst = "STORED";
+mem_cmd_is($sock, $cmd, $val, $rst);
+
+$cmd = "bop mget 11 2 0x00..0x1000 0 EQ 0x11FF,0x01FF 6";
+$val = "bkey1 bkey2";
+$rst =
+"VALUE bkey1 OK 3 2
 ELEMENT 0x0070 0x01FF 6 datum7
 ELEMENT 0x0090 0x11FF 6 datum9
 VALUE bkey2 OK 3 2
 ELEMENT 0x0060 0x01FF 6 datum6
 ELEMENT 0x0080 0x11FF 6 datum8
 END";
-mem_cmd_val_is($sock, $cmd, $val, $rst);
+mem_cmd_is($sock, $cmd, $val, $rst);
 
-$cmd = "bop mget 11 2 0x00..0x1000 0 NE 0x00FF,0x11FF 6"; $val = "bkey1 bkey2";
-$rst = "VALUE bkey1 OK 3 1
+$cmd = "bop mget 11 2 0x00..0x1000 0 NE 0x00FF,0x11FF 6";
+$val = "bkey1 bkey2";
+$rst =
+"VALUE bkey1 OK 3 1
 ELEMENT 0x0070 0x01FF 6 datum7
 VALUE bkey2 OK 3 1
 ELEMENT 0x0060 0x01FF 6 datum6
 END";
-mem_cmd_val_is($sock, $cmd, $val, $rst);
+mem_cmd_is($sock, $cmd, $val, $rst);
 
-$cmd = "delete bkey1"; $rst = "DELETED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-$cmd = "delete bkey2"; $rst = "DELETED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+$cmd = "delete bkey1";
+$rst = "DELETED";
+mem_cmd_is($sock, $cmd, "", $rst);
+
+$cmd = "delete bkey2";
+$rst = "DELETED";
+mem_cmd_is($sock, $cmd, "", $rst);
 
 # after test
 release_memcached($engine, $server);

--- a/t/lib/MemcachedTest.pm
+++ b/t/lib/MemcachedTest.pm
@@ -13,7 +13,7 @@ my $builddir = getcwd;
 
 
 @EXPORT = qw(get_memcached sleep release_memcached
-             mem_get_is mem_gets mem_gets_is mem_stats mem_cmd_val_is
+             mem_get_is mem_gets mem_gets_is mem_stats mem_cmd_val_is mem_cmd_is
              getattr_is lop_get_is sop_get_is mop_get_is bop_get_is bop_gbp_is bop_pwg_is bop_smget_is
              bop_ext_get_is bop_ext_smget_is bop_new_smget_is bop_old_smget_is
              stats_prefixes_is stats_noprefix_is stats_prefix_is
@@ -36,6 +36,52 @@ sub mem_stats {
         $stats->{$2} = $3;
     }
     return $stats;
+}
+
+sub mem_cmd_is {
+    # works on single-line values only.  no newlines in value.
+    my ($sock_opts, $cmd, $val, $rst, $msg) = @_;
+    my @response_list = ("ATTR_MISMATCH", "BKEY_MISMATCH", "CREATED", "CREATED_STORED"
+        , "DELETED", "DELETED_DROPPED", "DUPLICATED", "DUPLICATED_TRIMMED"
+        , "EFLAG_MISMATCH", "ELEMENT_EXISTS", "END", "EXISTS", "NOT_EXIST", "NOT_FOUND"
+        , "NOT_FOUND_ELEMENT", "NOT_STORED", "NOT_SUPPORTED", "NOTHING_TO_UPDATE", "OK"
+        , "OUT_OF_RANGE", "OVERFLOWED", "REPLACED", "RESET", "STORED", "TRIMMED"
+        , "TYPE_MISMATCH", "UNREADABLE", "UPDATED"
+        , "ATTR_ERROR", "CLIENT_ERROR", "ERROR", "PREFIX_ERROR", "SERVER_ERROR");
+
+    my @prdct_response = split('\n', $rst);
+    my $count = $#prdct_response + 1;
+    my $last_response = pop @prdct_response;
+
+    my $opts = ref $sock_opts eq "HASH" ? $sock_opts : {};
+    my $sock = ref $sock_opts eq "HASH" ? $opts->{sock} : $sock_opts;
+
+    # send command
+    if ("$val" eq "") {
+        $msg = $cmd;
+        print $sock "$cmd\r\n";
+    } else {
+        $msg = $cmd . " " . $val;
+        print $sock "$cmd\r\n$val\r\n";
+    }
+
+    my $resp = "";
+    my $line;
+
+    while ($count--) {
+        $line = scalar <$sock>;
+        $resp = $resp . (substr $line, 0, length($line)-2);
+        if ($count eq 0) {
+            last;
+        }
+        $resp = $resp . "\n";
+    }
+
+    if (grep $line =~ /^$_/, @response_list) {
+        Test::More::is("$resp", "$rst", $msg);
+    } else {
+        croak("# Test failed. < test name : $msg >");
+    }
 }
 
 sub mem_get_is {


### PR DESCRIPTION
@jhpark816
jam2in/arcus-memcached-EE#557
에 대한 PR입니다. 임시로 비교를 위해 테스트 파일 일부분만 수정하였습니다.

---
참고용으로 
각 케이스별로 10만건에 대한 테스트 수행속도를 측정.

case 1(변경된 형태)
```
mem_cmd_is($sock, $cmd, $rst);
```

case 2(변경전 형태)
```
print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
or
mem_cmd_val_is($sock, $cmd, $val, $rst);
```


testcase1.pl : 변경된 형태로 작성 simple kv response 속도
testcase2.pl : 변경 후 형태로 작성 simple kv response 속도
testcase3.pl : 변경된 형태로 작성 bop mget response 속도
testcase4.pl : 변경 후 형태로 작성 bop mget response 속도

![image](https://user-images.githubusercontent.com/24535164/39565929-c326b3d0-4ef4-11e8-9436-1c867c1bbdac.png)

수행속도는 비슷한 것 같습니다.
