### PR TITLE
TEST : correction of some test script for ee version testing

### DIFF
--- a/t/cas.t
+++ b/t/cas.t
@@ -17,21 +17,14 @@ my @result2;
 
 ok($sock != $sock2, "have two different connections open");
 
-sub check_args {
-    my ($line, $name) = @_;
-
-    my $svr = get_memcached($engine);
-    my $s = $svr->sock;
-
-    print $s $line;
-    is(scalar <$s>, "CLIENT_ERROR bad command line format\r\n", $name);
-    undef $svr;
-}
-
-check_args "cas bad blah 0 0 0\r\n\r\n", "bad flags";
-check_args "cas bad 0 blah 0 0\r\n\r\n", "bad exp";
-check_args "cas bad 0 0 blah 0\r\n\r\n", "bad cas";
-check_args "cas bad 0 0 0 blah\r\n\r\n", "bad size";
+print $sock "cas bad blah 0 0 0\r\n";
+is(scalar <$sock>, "CLIENT_ERROR bad command line format\r\n", "bad flags");
+print $sock "cas bad 0 blah 0 0\r\n";
+is(scalar <$sock>, "CLIENT_ERROR bad command line format\r\n", "bad exp");
+print $sock "cas bad 0 0 blah 0\r\n";
+is(scalar <$sock>, "CLIENT_ERROR bad command line format\r\n", "bad cas");
+print $sock "cas bad 0 0 0 blah\r\n";
+is(scalar <$sock>, "CLIENT_ERROR bad command line format\r\n", "bad size");
 
 # gets foo (should not exist)
 print $sock "gets foo\r\n";

--- a/t/udp.t
+++ b/t/udp.t
@@ -61,6 +61,9 @@ for my $prot (::IS_ASCII,::IS_BINARY) {
     udp_delete_test($prot,45,"aval$prot");
 }
 
+# after test
+release_memcached($engine, $server);
+
 sub udp_set_test {
     my ($protocol, $req_id, $key, $value, $flags, $exp) = @_;
     my $req = "";
@@ -260,5 +263,3 @@ __END__
 $host = gethostbyaddr($hisiaddr, AF_INET);
 $histime = unpack("N", $rtime) - $SECS_of_70_YEARS ;
 
-# after test
-release_memcached($engine, $server);


### PR DESCRIPTION
squall, gust engine 테스트를 위한 테스트 스크립트 수정 PR입니다.

t/cas.t
- 한 테스트 내에서 get_memcached를 연속해서 호출하게되면 db 1개를 여러 memcached process에서 공유하게 되는 형태가되어서 원하는 테스트 동작이 이루어 지지않음.

t/udp.t
- release_memcached를 필요한 스크립트내의 마지막 줄에 일괄적으로 추가하였는데 해당 테스트의 경우 그 부분이 주석처리되어 있어서 위치변경.