### PR TITLE
TEST : apply common function 1

### DIFF
--- a/t/arcus_ping_test.t
+++ b/t/arcus_ping_test.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 use strict;
-use Test::More tests => 26;
+use Test::More tests => 32;
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
@@ -38,32 +38,54 @@ my $rst;
 
 for (0..1) {
     $cmd = "get arcus-ping:qos_kv"; $rst = "END";
-    print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+    mem_cmd_is($sock, $cmd, "", $rst);
     $cmd = "set arcus-ping:qos_kv 0 3 4"; $val = "DATA"; $rst = "STORED";
-    print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+    mem_cmd_is($sock, $cmd, $val, $rst);
     mem_get_is($sock, "arcus-ping:qos_kv", "DATA");
 
+    # lop test
     $cmd = "lop insert arcus-ping:qos_lop 0 4 create 0 3 10"; $val = "DATA"; $rst = "CREATED_STORED";
-    print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-    lop_get_is($sock, "arcus-ping:qos_lop 0..10",  0, 1, "DATA");
+    mem_cmd_is($sock, $cmd, $val, $rst);
+    $cmd = "lop get arcus-ping:qos_lop 0..10";
+    $rst =
+    "VALUE 0 1\n"
+  . "4 DATA\n"
+  . "END";
+    mem_cmd_is($sock, $cmd, "", $rst);
     $cmd = "lop delete arcus-ping:qos_lop 0..10 drop"; $rst = "DELETED_DROPPED";
-    print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+    mem_cmd_is($sock, $cmd, "", $rst);
 
+    # sop test
     $cmd = "sop insert arcus-ping:qos_sop 4 create 0 3 10"; $val = "DATA"; $rst = "CREATED_STORED";
-    print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+    mem_cmd_is($sock, $cmd, $val, $rst);
     $cmd = "sop exist arcus-ping:qos_sop 4"; $val="DATA"; $rst = "EXIST";
-    print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+    mem_cmd_is($sock, $cmd, $val, $rst);
     $cmd = "sop delete arcus-ping:qos_sop 4 drop"; $val="DATA"; $rst = "DELETED_DROPPED";
-    print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+    mem_cmd_is($sock, $cmd, $val, $rst);
 
+
+    # mop test
+    $cmd = "mop insert arcus-ping:qos_mop 2 4 create 0 3 10"; $val = "DATA"; $rst = "CREATED_STORED";
+    mem_cmd_is($sock, $cmd, $val, $rst);
+    $cmd = "mop update arcus-ping:qos_mop 2 10"; $val = "UPDATEDATA"; $rst = "UPDATED";
+    mem_cmd_is($sock, $cmd, $val, $rst);
+    $cmd = "mop delete arcus-ping:qos_mop 1 1 drop"; $val = "2"; $rst = "DELETED_DROPPED";
+    mem_cmd_is($sock, $cmd, $val, $rst);
+
+    # bop test
     $cmd = "bop insert arcus-ping:qos_bop 1 4 create 0 3 10"; $val = "DATA"; $rst = "CREATED_STORED";
-    print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-    bop_get_is($sock, "arcus-ping:qos_bop 1..10", 0, 1, "1", "DATA", "END");
+    mem_cmd_is($sock, $cmd, $val, $rst);
+    $cmd = "bop get arcus-ping:qos_bop 1..10";
+    $rst =
+    "VALUE 0 1\n"
+  . "1 4 DATA\n"
+  . "END";
+    mem_cmd_is($sock, $cmd, "", $rst);
     $cmd = "bop delete arcus-ping:qos_bop 1..10 10 drop"; $rst = "DELETED_DROPPED";
-    print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+    mem_cmd_is($sock, $cmd, "", $rst);
 
     $cmd = "delete arcus-ping:qos_kv"; $rst = "DELETED";
-    print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+    mem_cmd_is($sock, $cmd, "", $rst);
 }
 
 # after test

--- a/t/ascii_ext_protocol.t
+++ b/t/ascii_ext_protocol.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 use strict;
-use Test::More tests => 60;
+use Test::More tests => 40;
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
@@ -72,74 +72,82 @@ my $sock = $server->sock;
 
 # Initialize
 $cmd = "get bkey1"; $rst = "END";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "get kvkey"; $rst = "END";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 
 # Test
 $cmd = "set kvkey 0 0 10"; $val = "0000000000"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "set kvkey 0 0 10"; $val = "11111111111";
-$rst = "CLIENT_ERROR bad data chunk"; $rst2 = "ERROR unknown command";
-print $sock "$cmd\r\n$val\r\n";
-is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst"); is(scalar <$sock>, "$rst2\r\n", "$rst2");
+$rst =
+"CLIENT_ERROR bad data chunk
+ERROR unknown command";
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "set kvkey 0 0 10"; $val = "222222222222";
-$rst = "CLIENT_ERROR bad data chunk"; $rst2 = "ERROR unknown command";
-print $sock "$cmd\r\n$val\r\n";
-is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst"); is(scalar <$sock>, "$rst2\r\n", "$rst2");
-
+$rst =
+"CLIENT_ERROR bad data chunk
+ERROR unknown command";
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "set kvkey 0 10"; $val = "0000000000";
-$rst = "ERROR unknown command"; $rst2 = "ERROR unknown command";
-print $sock "$cmd\r\n$val\r\n";
-is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst"); is(scalar <$sock>, "$rst2\r\n", "$rst2");
+$rst =
+"ERROR unknown command
+ERROR unknown command";
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "set kvkey 0 0 10"; $val = "0000000000"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "set kvkey 0 0 10 10"; $val = "0000000000"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "set kvkey 0 0 10 10 10"; $val = "0000000000";
-$rst = "ERROR unknown command"; $rst2 = "ERROR unknown command";
-print $sock "$cmd\r\n$val\r\n";
-is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst"); is(scalar <$sock>, "$rst2\r\n", "$rst2");
+$rst =
+"ERROR unknown command
+ERROR unknown command";
+mem_cmd_is($sock, $cmd, $val, $rst);
 
 $cmd = "bop insert bkey1 10 5 create 11 0 0"; $val = "datum"; $rst = "CREATED_STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 
 $cmd = "bop insert bkey1 15 5"; $val = "55555"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 16 5"; $val = "666666";
-$rst = "CLIENT_ERROR bad data chunk"; $rst2 = "ERROR unknown command";
-print $sock "$cmd\r\n$val\r\n";
-is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst"); is(scalar <$sock>, "$rst2\r\n", "$rst2");
+$rst =
+"CLIENT_ERROR bad data chunk
+ERROR unknown command";
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 17 5"; $val = "7777777";
-$rst = "CLIENT_ERROR bad data chunk"; $rst2 = "ERROR unknown command";
-print $sock "$cmd\r\n$val\r\n";
-is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst"); is(scalar <$sock>, "$rst2\r\n", "$rst2");
+$rst =
+"CLIENT_ERROR bad data chunk
+ERROR unknown command";
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 18 5"; $val = "88888888";
-$rst = "CLIENT_ERROR bad data chunk"; $rst2 = "ERROR unknown command";
-print $sock "$cmd\r\n$val\r\n";
-is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst"); is(scalar <$sock>, "$rst2\r\n", "$rst2");
+$rst =
+"CLIENT_ERROR bad data chunk
+ERROR unknown command";
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 19 5"; $val = "999999999";
-$rst = "CLIENT_ERROR bad data chunk"; $rst2 = "ERROR unknown command";
-print $sock "$cmd\r\n$val\r\n";
-is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst"); is(scalar <$sock>, "$rst2\r\n", "$rst2");
+$rst =
+"CLIENT_ERROR bad data chunk
+ERROR unknown command";
+mem_cmd_is($sock, $cmd, $val, $rst);
 
 $cmd = "bop insert bkey1 21"; $val = "0000000000";
-$rst = "CLIENT_ERROR bad command line format"; $rst2 = "ERROR unknown command";
-print $sock "$cmd\r\n$val\r\n";
-is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst"); is(scalar <$sock>, "$rst2\r\n", "$rst2");
+$rst =
+"CLIENT_ERROR bad command line format
+ERROR unknown command";
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 22 10"; $val = "0000000000"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 23 10 10"; $val = "0000000000";
-$rst = "CLIENT_ERROR bad command line format"; $rst2 = "ERROR unknown command";
-print $sock "$cmd\r\n$val\r\n";
-is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst"); is(scalar <$sock>, "$rst2\r\n", "$rst2");
+$rst =
+"CLIENT_ERROR bad command line format
+ERROR unknown command";
+mem_cmd_is($sock, $cmd, $val, $rst);
 
 # Finalize
 $cmd = "delete bkey1"; $rst = "DELETED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "delete kvkey"; $rst = "DELETED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 
 $server->stop();
 
@@ -150,77 +158,86 @@ my $sock = $server->sock;
 
 # Initialize
 $cmd = "get bkey1"; $rst = "END";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "get kvkey"; $rst = "END";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 
 # Test
 $cmd = "set kvkey 0 0 10"; $val = "0000000000"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 
 $cmd = "set kvkey 0 0 10"; $val = "11111111111";
-$rst = "CLIENT_ERROR bad data chunk"; $rst2 = "ERROR no arguments";
-print $sock "$cmd\r\n$val\r\n";
-is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst"); is(scalar <$sock>, "$rst2\r\n", "$rst2");
+$rst =
+"CLIENT_ERROR bad data chunk
+ERROR no arguments";
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "set kvkey 0 0 10"; $val = "222222222222";
-$rst = "CLIENT_ERROR bad data chunk"; $rst2 = "ERROR no matching command";
-print $sock "$cmd\r\n$val\r\n";
-is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst"); is(scalar <$sock>, "$rst2\r\n", "$rst2");
+$rst =
+"CLIENT_ERROR bad data chunk
+ERROR no matching command";
+mem_cmd_is($sock, $cmd, $val, $rst);
 
 $cmd = "set kvkey 0 10"; $val = "0000000000";
-$rst = "ERROR no matching command"; $rst2 = "ERROR no matching command";
-print $sock "$cmd\r\n$val\r\n";
-is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst"); is(scalar <$sock>, "$rst2\r\n", "$rst2");
+$rst =
+"ERROR no matching command
+ERROR no matching command";
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "set kvkey 0 0 10"; $val = "0000000000"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "set kvkey 0 0 10 10"; $val = "0000000000"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "set kvkey 0 0 10 10 10"; $val = "0000000000";
-$rst = "ERROR no matching command"; $rst2 = "ERROR no matching command";
-print $sock "$cmd\r\n$val\r\n";
-is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst"); is(scalar <$sock>, "$rst2\r\n", "$rst2");
+$rst =
+"ERROR no matching command
+ERROR no matching command";
+mem_cmd_is($sock, $cmd, $val, $rst);
 
 $cmd = "bop insert bkey1 10 5 create 11 0 0"; $val = "datum"; $rst = "CREATED_STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 
 $cmd = "bop insert bkey1 15 5"; $val = "55555"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 16 5"; $val = "666666";
-$rst = "CLIENT_ERROR bad data chunk"; $rst2 = "ERROR no arguments";
-print $sock "$cmd\r\n$val\r\n";
-is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst"); is(scalar <$sock>, "$rst2\r\n", "$rst2");
+$rst =
+"CLIENT_ERROR bad data chunk
+ERROR no arguments";
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 17 5"; $val = "7777777";
-$rst = "CLIENT_ERROR bad data chunk"; $rst2 = "ERROR no matching command";
-print $sock "$cmd\r\n$val\r\n";
-is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst"); is(scalar <$sock>, "$rst2\r\n", "$rst2");
+$rst =
+"CLIENT_ERROR bad data chunk
+ERROR no matching command";
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 18 5"; $val = "88888888";
-$rst = "CLIENT_ERROR bad data chunk"; $rst2 = "ERROR no matching command";
-print $sock "$cmd\r\n$val\r\n";
-is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst"); is(scalar <$sock>, "$rst2\r\n", "$rst2");
+$rst =
+"CLIENT_ERROR bad data chunk
+ERROR no matching command";
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 19 5"; $val = "999999999";
-$rst = "CLIENT_ERROR bad data chunk"; $rst2 = "ERROR no matching command";
-print $sock "$cmd\r\n$val\r\n";
-is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst"); is(scalar <$sock>, "$rst2\r\n", "$rst2");
+$rst =
+"CLIENT_ERROR bad data chunk
+ERROR no matching command";
+mem_cmd_is($sock, $cmd, $val, $rst);
 
 $cmd = "bop insert bkey1 21"; $val = "0000000000";
-$rst = "CLIENT_ERROR bad command line format"; $rst2 = "ERROR no matching command";
-print $sock "$cmd\r\n$val\r\n";
-is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst"); is(scalar <$sock>, "$rst2\r\n", "$rst2");
+$rst =
+"CLIENT_ERROR bad command line format
+ERROR no matching command";
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 22 10"; $val = "0000000000"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 23 10 10"; $val = "0000000000";
-$rst = "CLIENT_ERROR bad command line format"; $rst2 = "ERROR no matching command";
-print $sock "$cmd\r\n$val\r\n";
-is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst"); is(scalar <$sock>, "$rst2\r\n", "$rst2");
+$rst =
+"CLIENT_ERROR bad command line format
+ERROR no matching command";
+mem_cmd_is($sock, $cmd, $val, $rst);
 
 # Finalize
 $cmd = "delete bkey1"; $rst = "DELETED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "delete kvkey"; $rst = "DELETED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 
 $server->stop();
-
 
 # after test
 release_memcached($engine, $server);

--- a/t/binary-get.t
+++ b/t/binary-get.t
@@ -11,13 +11,15 @@ my $server = get_memcached($engine);
 my $sock = $server->sock;
 
 my $count = 1;
+my $cmd;
+my $val;
+my $rst;
 
 foreach my $blob ("mooo\0", "mumble\0\0\0\0\r\rblarg", "\0", "\r") {
     my $key = "foo$count";
     my $len = length($blob);
-    print "len is $len\n";
-    print $sock "set $key 0 0 $len\r\n$blob\r\n";
-    is(scalar <$sock>, "STORED\r\n", "stored $key");
+    $cmd = "set $key 0 0 $len"; $val = $blob; $rst = "STORED";
+    mem_cmd_is($sock, $cmd, $val, $rst);
     mem_get_is($sock, $key, $blob);
     $count++;
 }

--- a/t/bogus-commands.t
+++ b/t/bogus-commands.t
@@ -9,9 +9,12 @@ use MemcachedTest;
 my $engine = shift;
 my $server = get_memcached($engine);
 my $sock = $server->sock;
+my $cmd;
+my $rst;
 
-print $sock "boguscommand slkdsldkfjsd\r\n";
-is(scalar <$sock>, "ERROR unknown command\r\n", "got error back");
+$cmd = "boguscommand slkdsldkfjsd";
+$rst = "ERROR unknown command";
+mem_cmd_is($sock, $cmd, "", $rst);
 
 # after test
 release_memcached($engine, $server);

--- a/t/cmd_extensions.t
+++ b/t/cmd_extensions.t
@@ -12,20 +12,27 @@ use MemcachedTest;
 my $engine = shift;
 my $server = get_memcached($engine, '-X .libs/example_protocol.so');
 my $sock = $server->sock;
+my $cmd;
+my $val;
+my $rst;
+
 
 ok(defined($sock), 'Connection 0');
 
-print $sock "noop\r\n";
-is(scalar <$sock>, "OK\r\n", "testing noop");
+$cmd = "noop"; $rst = "OK";
+mem_cmd_is($sock, $cmd, "", $rst);
 
-print $sock "echo foo bar\r\n";
-is(scalar <$sock>, "echo [foo] [bar]\r\n", "testing echo");
+$cmd = "echo foo bar"; $rst = "echo [foo] [bar]";
+mem_cmd_is($sock, $cmd, "", $rst);
 
-print $sock "echo 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7\r\n";
-is(scalar <$sock>, "echo [1] [2] [3] [4] [5] [6] [7] [8] [9] [0] [1] [2] [3] [4] [5] [6] [7] [8] [9] [0] [1] [2] [3] [4] [5] [6] [7]\r\n", "Max number of args");
+$cmd = "echo 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7";
+$rst = "echo [1] [2] [3] [4] [5] [6] [7] [8] [9] [0] "
+     . "[1] [2] [3] [4] [5] [6] [7] [8] [9] [0] [1] [2] [3] [4] [5] [6] [7]";
+mem_cmd_is($sock, $cmd, "", $rst);
 
-print $sock "echo 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8\r\n";
-is(scalar <$sock>, "ERROR too many arguments\r\n", "args truncated");
+$cmd = "echo 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8";
+$rst = "ERROR too many arguments";
+mem_cmd_is($sock, $cmd, "", $rst);
 
 # after test
 release_memcached($engine, $server);

--- a/t/coll_bkeymismatch_test.t
+++ b/t/coll_bkeymismatch_test.t
@@ -43,53 +43,53 @@ my $rst;
 
 # Initialize
 $cmd = "get bkey1"; $rst = "END";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
+
 # Success Cases
-
 $cmd = "bop create bkey1 1 0 0"; $rst = "CREATED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "setattr bkey1 maxbkeyrange=0x1000"; $rst = "OK";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop insert bkey1 1 6"; $val = "datum2"; $rst = "BKEY_MISMATCH";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 
 # Finalize
 $cmd = "delete bkey1"; $rst = "DELETED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 
 $cmd = "bop create bkey1 10 0 0"; $rst = "CREATED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop insert bkey1 1 6"; $val = "datum2"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "setattr bkey1 maxbkeyrange=0x1000"; $rst = "ATTR_ERROR bad value";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 
 # Finalize
 $cmd = "delete bkey1"; $rst = "DELETED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 
 
 $cmd = "bop create bkey1 1 0 0"; $rst = "CREATED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "setattr bkey1 maxbkeyrange=10"; $rst = "OK";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop insert bkey1 0x0001 6"; $val = "datum2"; $rst = "BKEY_MISMATCH";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 
 # Finalize
 $cmd = "delete bkey1"; $rst = "DELETED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 
 $cmd = "bop create bkey1 10 0 0"; $rst = "CREATED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop insert bkey1 0x0011 6"; $val = "datum2"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "setattr bkey1 maxbkeyrange=10"; $rst = "ATTR_ERROR bad value";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 
 # Finalize
 $cmd = "delete bkey1"; $rst = "DELETED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 
 # after test
 release_memcached($engine, $server);

--- a/t/coll_bkeyoor_test.t
+++ b/t/coll_bkeyoor_test.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 use strict;
-use Test::More tests => 95;
+use Test::More tests => 88;
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
@@ -103,188 +103,238 @@ delete bkey1
 
 # testBOPSMGetSimple
 $cmd = "get bkey1"; $rst = "END";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop create bkey1 11 0 0"; $rst = "CREATED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop insert bkey1 90 6"; $val = "datum9"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 70 6"; $val = "datum7"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 50 6"; $val = "datum5"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 30 6"; $val = "datum3"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 10 6"; $val = "datum1"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "setattr bkey1 maxcount=5"; $rst = "OK";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-getattr_is($sock, "bkey1 maxcount", "maxcount=5");
-getattr_is($sock, "bkey1 overflowaction", "overflowaction=smallest_trim");
-# $cmd = "bop get bkey1 0"; $rst = "OUT_OF_RANGE";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "getattr bkey1 maxcount overflowaction";
+$rst =
+"ATTR maxcount=5
+ATTR overflowaction=smallest_trim
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
+
 $cmd = "bop get bkey1 0"; $rst = "NOT_FOUND_ELEMENT"; # [ARCUS-137] improve the accuracy of trimmed status
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 20"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 60"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 100"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-# $cmd = "bop get bkey1 0..5"; $rst = "OUT_OF_RANGE";
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 0..5"; $rst = "NOT_FOUND_ELEMENT"; # [ARCUS-137] improve the accuracy of trimmed status
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-#$cmd = "bop get bkey1 5..0"; $rst = "OUT_OF_RANGE";
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 5..0"; $rst = "NOT_FOUND_ELEMENT"; # [ARCUS-137] improve the accuracy of trimmed status
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 20..25"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 25..20"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 82..87"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 87..82"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 100..110"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 110..100"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "setattr bkey1 overflowaction=largest_trim"; $rst = "OK";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-getattr_is($sock, "bkey1 overflowaction", "overflowaction=largest_trim");
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "getattr bkey1 overflowaction";
+$rst =
+"ATTR overflowaction=largest_trim
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 0"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 20"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 60"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-# $cmd = "bop get bkey1 100"; $rst = "OUT_OF_RANGE";
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 100"; $rst = "NOT_FOUND_ELEMENT"; # [ARCUS-137] improve the accuracy of trimmed status
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 0..5"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 5..0"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 20..25"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 25..20"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 82..87"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 87..82"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-# $cmd = "bop get bkey1 100..110"; $rst = "OUT_OF_RANGE";
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 100..110"; $rst = "NOT_FOUND_ELEMENT"; # [ARCUS-137] improve the accuracy of trimmed status
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-# $cmd = "bop get bkey1 110..100"; $rst = "OUT_OF_RANGE";
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 110..100"; $rst = "NOT_FOUND_ELEMENT"; # [ARCUS-137] improve the accuracy of trimmed status
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 
 $cmd = "setattr bkey1 overflowaction=smallest_trim"; $rst = "OK";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-getattr_is($sock, "bkey1 overflowaction", "overflowaction=smallest_trim");
-getattr_is($sock, "bkey1 trimmed", "trimmed=0");
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "getattr bkey1 overflowaction trimmed";
+$rst =
+"ATTR overflowaction=smallest_trim
+ATTR trimmed=0
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop insert bkey1 100 7"; $val = "datum10"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 10 7"; $val = "datum00"; $rst = "OUT_OF_RANGE";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-getattr_is($sock, "bkey1 trimmed", "trimmed=1");
+mem_cmd_is($sock, $cmd, $val, $rst);
+$cmd = "getattr bkey1 trimmed";
+$rst =
+"ATTR trimmed=1
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 10"; $rst = "OUT_OF_RANGE";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 0..10"; $rst = "OUT_OF_RANGE";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 110"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 120..110"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 
 $cmd = "setattr bkey1 overflowaction=largest_trim"; $rst = "OK";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-getattr_is($sock, "bkey1 overflowaction", "overflowaction=largest_trim");
-getattr_is($sock, "bkey1 trimmed", "trimmed=0");
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "getattr bkey1 overflowaction trimmed";
+$rst =
+"ATTR overflowaction=largest_trim
+ATTR trimmed=0
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 10"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 110"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop insert bkey1 10 7"; $val = "datum01"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 100 7"; $val = "datum10"; $rst = "OUT_OF_RANGE";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-getattr_is($sock, "bkey1 trimmed", "trimmed=1");
+mem_cmd_is($sock, $cmd, $val, $rst);
+$cmd = "getattr bkey1 trimmed";
+$rst =
+"ATTR trimmed=1
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 100"; $rst = "OUT_OF_RANGE";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 100..110"; $rst = "OUT_OF_RANGE";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 
 $cmd = "setattr bkey1 overflowaction=smallest_trim"; $rst = "OK";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-getattr_is($sock, "bkey1 overflowaction", "overflowaction=smallest_trim");
-getattr_is($sock, "bkey1 trimmed", "trimmed=0");
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "getattr bkey1 overflowaction trimmed";
+$rst =
+"ATTR overflowaction=smallest_trim
+ATTR trimmed=0
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop insert bkey1 5 7"; $val = "datum00"; $rst = "OUT_OF_RANGE";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-getattr_is($sock, "bkey1 trimmed", "trimmed=1");
+mem_cmd_is($sock, $cmd, $val, $rst);
+$cmd = "getattr bkey1 trimmed";
+$rst =
+"ATTR trimmed=1
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 5"; $rst = "OUT_OF_RANGE";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 0..5"; $rst = "OUT_OF_RANGE";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 110"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 120..110"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 
 $cmd = "setattr bkey1 overflowaction=largest_trim"; $rst = "OK";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-getattr_is($sock, "bkey1 overflowaction", "overflowaction=largest_trim");
-getattr_is($sock, "bkey1 trimmed", "trimmed=0");
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "getattr bkey1 overflowaction trimmed";
+$rst =
+"ATTR overflowaction=largest_trim
+ATTR trimmed=0
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 5"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 110"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop insert bkey1 100 7"; $val = "datum10"; $rst = "OUT_OF_RANGE";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-getattr_is($sock, "bkey1 trimmed", "trimmed=1");
+mem_cmd_is($sock, $cmd, $val, $rst);
+$cmd = "getattr bkey1 trimmed";
+$rst =
+"ATTR trimmed=1
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 100"; $rst = "OUT_OF_RANGE";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 100..110"; $rst = "OUT_OF_RANGE";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 
 $cmd = "setattr bkey1 overflowaction=smallest_silent_trim"; $rst = "OK";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-getattr_is($sock, "bkey1 overflowaction", "overflowaction=smallest_silent_trim");
-getattr_is($sock, "bkey1 trimmed", "trimmed=0");
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "getattr bkey1 overflowaction trimmed";
+$rst =
+"ATTR overflowaction=smallest_silent_trim
+ATTR trimmed=0
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop insert bkey1 100 7"; $val = "datum10"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 10 7"; $val = "datum00"; $rst = "OUT_OF_RANGE";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-getattr_is($sock, "bkey1 trimmed", "trimmed=0");
+mem_cmd_is($sock, $cmd, $val, $rst);
+$cmd = "getattr bkey1 trimmed";
+$rst =
+"ATTR trimmed=0
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 10"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 0..10"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 110"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 120..110"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 
 $cmd = "setattr bkey1 overflowaction=largest_silent_trim"; $rst = "OK";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-getattr_is($sock, "bkey1 overflowaction", "overflowaction=largest_silent_trim");
-getattr_is($sock, "bkey1 trimmed", "trimmed=0");
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "getattr bkey1 overflowaction trimmed";
+$rst =
+"ATTR overflowaction=largest_silent_trim
+ATTR trimmed=0
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 10"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 110"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop insert bkey1 10 7"; $val = "datum01"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 100 7"; $val = "datum10"; $rst = "OUT_OF_RANGE";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-getattr_is($sock, "bkey1 trimmed", "trimmed=0");
+mem_cmd_is($sock, $cmd, $val, $rst);
+$cmd = "getattr bkey1 trimmed";
+$rst =
+"ATTR trimmed=0
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 100"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 100..110"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 
 $cmd = "delete bkey1"; $rst = "DELETED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-
+mem_cmd_is($sock, $cmd, "", $rst);
 
 # after test
 release_memcached($engine, $server);

--- a/t/coll_bop_attr_min_max_bkey.t
+++ b/t/coll_bop_attr_min_max_bkey.t
@@ -1,42 +1,36 @@
 #!/usr/bin/perl
 
 use strict;
-use Test::More tests => 30;
+use Test::More tests => 24;
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
 
 =head
-ok 1 - get minbkey1: END
-ok 2 - bop create minbkey1 1 0 100: CREATED
-ok 3 - getattr minbkey1 minbkey == 'minbkey=-1'
-ok 4 - getattr minbkey1 maxbkey == 'maxbkey=-1'
-ok 5 - bop insert minbkey1 90 6 datum9: STORED
-ok 6 - bop insert minbkey1 70 6 datum7: STORED
-ok 7 - bop insert minbkey1 50 6 datum5: STORED
-ok 8 - bop insert minbkey1 30 6 datum3: STORED
-ok 9 - bop insert minbkey1 10 6 datum1: STORED
-ok 10 - getattr minbkey1 minbkey == 'minbkey=10'
-ok 11 - getattr minbkey1 maxbkey == 'maxbkey=90'
-ok 12 - bop delete minbkey1 10: DELETED
-ok 13 - getattr minbkey1 minbkey == 'minbkey=30'
-ok 14 - getattr minbkey1 maxbkey == 'maxbkey=90'
-ok 15 - delete minbkey1: DELETED
-ok 16 - get minbkey1: END
-ok 17 - bop create minbkey1 1 0 100: CREATED
-ok 18 - getattr minbkey1 minbkey == 'minbkey=-1'
-ok 19 - getattr minbkey1 maxbkey == 'maxbkey=-1'
-ok 20 - bop insert minbkey1 0xffaa2211 6 datum9: STORED
-ok 21 - bop insert minbkey1 0xee0122 6 datum7: STORED
-ok 22 - bop insert minbkey1 0x110491 6 datum5: STORED
-ok 23 - bop insert minbkey1 0x00019A 6 datum3: STORED
-ok 24 - bop insert minbkey1 0x019ACC 6 datum1: STORED
-ok 25 - getattr minbkey1 minbkey == 'minbkey=0x00019A'
-ok 26 - getattr minbkey1 maxbkey == 'maxbkey=0xFFAA2211'
-ok 27 - bop delete minbkey1 0xFFAA2211: DELETED
-ok 28 - getattr minbkey1 minbkey == 'minbkey=0x00019A'
-ok 29 - getattr minbkey1 maxbkey == 'maxbkey=0xEE0122'
-ok 30 - delete minbkey1: DELETED
+ok 1 - get minbkey1:
+ok 2 - bop create minbkey1 1 0 100:
+ok 3 - getattr minbkey1 minbkey maxbkey:
+ok 4 - bop insert minbkey1 90 6:datum9
+ok 5 - bop insert minbkey1 70 6:datum7
+ok 6 - bop insert minbkey1 50 6:datum5
+ok 7 - bop insert minbkey1 30 6:datum3
+ok 8 - bop insert minbkey1 10 6:datum1
+ok 9 - getattr minbkey1 minbkey maxbkey:
+ok 10 - bop delete minbkey1 10:
+ok 11 - getattr minbkey1 minbkey maxbkey:
+ok 12 - delete minbkey1:
+ok 13 - get minbkey1:
+ok 14 - bop create minbkey1 1 0 100:
+ok 15 - getattr minbkey1 minbkey maxbkey:
+ok 16 - bop insert minbkey1 0xffaa2211 6:datum9
+ok 17 - bop insert minbkey1 0xee0122 6:datum7
+ok 18 - bop insert minbkey1 0x110491 6:datum5
+ok 19 - bop insert minbkey1 0x00019A 6:datum3
+ok 20 - bop insert minbkey1 0x019ACC 6:datum1
+ok 21 - getattr minbkey1 minbkey maxbkey:
+ok 22 - bop delete minbkey1 0xFFAA2211:
+ok 23 - getattr minbkey1 minbkey maxbkey:
+ok 24 - delete minbkey1:
 =cut
 
 my $engine = shift;
@@ -49,61 +43,84 @@ my $rst;
 
 # Case 1
 $cmd = "get minbkey1"; $rst = "END";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop create minbkey1 1 0 100"; $rst = "CREATED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-getattr_is($sock, "minbkey1 minbkey", "minbkey=-1");
-getattr_is($sock, "minbkey1 maxbkey", "maxbkey=-1");
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "getattr minbkey1 minbkey maxbkey";
+$rst =
+"ATTR minbkey=-1
+ATTR maxbkey=-1
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop insert minbkey1 90 6"; $val = "datum9"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert minbkey1 70 6"; $val = "datum7"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert minbkey1 50 6"; $val = "datum5"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert minbkey1 30 6"; $val = "datum3"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert minbkey1 10 6"; $val = "datum1"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-getattr_is($sock, "minbkey1 minbkey", "minbkey=10");
-getattr_is($sock, "minbkey1 maxbkey", "maxbkey=90");
+mem_cmd_is($sock, $cmd, $val, $rst);
+$cmd = "getattr minbkey1 minbkey maxbkey";
+$rst =
+"ATTR minbkey=10
+ATTR maxbkey=90
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 
 $cmd = "bop delete minbkey1 10"; $rst = "DELETED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-getattr_is($sock, "minbkey1 minbkey", "minbkey=30");
-getattr_is($sock, "minbkey1 maxbkey", "maxbkey=90");
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "getattr minbkey1 minbkey maxbkey";
+$rst =
+"ATTR minbkey=30
+ATTR maxbkey=90
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 
 $cmd = "delete minbkey1"; $rst = "DELETED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 
 
 
 # Case 2
 $cmd = "get minbkey1"; $rst = "END";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop create minbkey1 1 0 100"; $rst = "CREATED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-getattr_is($sock, "minbkey1 minbkey", "minbkey=-1");
-getattr_is($sock, "minbkey1 maxbkey", "maxbkey=-1");
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "getattr minbkey1 minbkey maxbkey";
+$rst =
+"ATTR minbkey=-1
+ATTR maxbkey=-1
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop insert minbkey1 0xffaa2211 6"; $val = "datum9"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert minbkey1 0xee0122 6"; $val = "datum7"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert minbkey1 0x110491 6"; $val = "datum5"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert minbkey1 0x00019A 6"; $val = "datum3"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert minbkey1 0x019ACC 6"; $val = "datum1"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-getattr_is($sock, "minbkey1 minbkey", "minbkey=0x00019A");
-getattr_is($sock, "minbkey1 maxbkey", "maxbkey=0xFFAA2211");
+mem_cmd_is($sock, $cmd, $val, $rst);
+$cmd = "getattr minbkey1 minbkey maxbkey";
+$rst =
+"ATTR minbkey=0x00019A
+ATTR maxbkey=0xFFAA2211
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop delete minbkey1 0xFFAA2211"; $rst = "DELETED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-getattr_is($sock, "minbkey1 minbkey", "minbkey=0x00019A");
-getattr_is($sock, "minbkey1 maxbkey", "maxbkey=0xEE0122");
-
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "getattr minbkey1 minbkey maxbkey";
+$rst =
+"ATTR minbkey=0x00019A
+ATTR maxbkey=0xEE0122
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 
 $cmd = "delete minbkey1"; $rst = "DELETED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 
 # after test
 release_memcached($engine, $server);

--- a/t/coll_bop_count.t
+++ b/t/coll_bop_count.t
@@ -1,8 +1,7 @@
 #!/usr/bin/perl
 
 use strict;
-#use Test::More tests => 20;
-use Test::More tests => 17;
+use Test::More tests => 20;
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
@@ -37,47 +36,45 @@ my $val;
 my $rst;
 
 $cmd = "get bkey1"; $rst = "END";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "get bkey2"; $rst = "END";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop insert bkey1 90 0x0001 6 create 11 0 0"; $val = "datum9"; $rst = "CREATED_STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 70 0x0001 6"; $val = "datum7"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 50 0x0010 6"; $val = "datum5"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 30 0x0011 6"; $val = "datum3"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 10 0x0110 6"; $val = "datum1"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop create bkey2 11 0 0"; $rst = "CREATED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop count bkey1 10..90"; $rst = "COUNT=5";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop count bkey1 60..20"; $rst = "COUNT=2";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop count bkey1 15..25"; $rst = "COUNT=0";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop count bkey1 25..15"; $rst = "COUNT=0";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop count bkey1 10..90 0 EQ 0x0001"; $rst = "COUNT=2";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop count bkey1 10..90 0 EQ 0x0010"; $rst = "COUNT=1";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-# $cmd = "bop count bkey1 10..90 0 EQ 0x0010,0x0001"; $rst = "COUNT=3";
-# print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-# $cmd = "bop count bkey1 10..90 0 EQ 0x0010,0x0001,0x0011"; $rst = "COUNT=4";
-# print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-# $cmd = "bop count bkey1 10..90 0 NE 0x0001,0x0010"; $rst = "COUNT=2";
-# print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop count bkey1 10..90 0 EQ 0x0010,0x0001"; $rst = "COUNT=3";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop count bkey1 10..90 0 EQ 0x0010,0x0001,0x0011"; $rst = "COUNT=4";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop count bkey1 10..90 0 NE 0x0001,0x0010"; $rst = "COUNT=2";
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop count bkey2 10..90"; $rst = "COUNT=0";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "delete bkey1"; $rst = "DELETED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "delete bkey2"; $rst = "DELETED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-
-
+mem_cmd_is($sock, $cmd, "", $rst);
 
 # after test
 release_memcached($engine, $server);

--- a/t/coll_bop_delete.t
+++ b/t/coll_bop_delete.t
@@ -1,8 +1,7 @@
 #!/usr/bin/perl
 
 use strict;
-#use Test::More tests => 49;
-use Test::More tests => 36;
+use Test::More tests => 49;
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
@@ -69,128 +68,179 @@ my $rst;
 
 # Initialize
 $cmd = "get bkey1"; $rst = "END";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 # Success Cases
 $cmd = "bop insert bkey1 0x090909090909090909 6 create 11 0 0"; $val = "datum9"; $rst = "CREATED_STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 0x07070707070707 6"; $val = "datum7"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 0x0505050505 6"; $val = "datum5"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 0x030303 0x0303 6"; $val = "datum3"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 0x01 0x01 6"; $val = "datum1"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 0x0202 0x02 6"; $val = "datum2"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 0x04040404 0x0404 6"; $val = "datum4"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 0x060606060606 6"; $val = "datum6"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 0x0808080808080808 6"; $val = "datum8"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-bop_ext_get_is($sock, "bkey1 0x00..0xFF", 11, 9,
-               "0x01,0x0202,0x030303,0x04040404,0x0505050505,0x060606060606,0x07070707070707,0x0808080808080808,0x090909090909090909",
-               "0x01,0x02,0x0303,0x0404,,,,,",
-               "datum1,datum2,datum3,datum4,datum5,datum6,datum7,datum8,datum9", "END");
+mem_cmd_is($sock, $cmd, $val, $rst);
+$cmd = "bop get bkey1 0x00..0xFF";
+$rst = "VALUE 11 9
+0x01 0x01 6 datum1
+0x0202 0x02 6 datum2
+0x030303 0x0303 6 datum3
+0x04040404 0x0404 6 datum4
+0x0505050505 6 datum5
+0x060606060606 6 datum6
+0x07070707070707 6 datum7
+0x0808080808080808 6 datum8
+0x090909090909090909 6 datum9
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
+
 # Fail Cases
 $cmd = "bop delete bkey1 5"; $rst = "BKEY_MISMATCH";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop delete bkey1 0..9"; $rst = "BKEY_MISMATCH";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop delete bkey1 0..0xFF"; $rst = "CLIENT_ERROR bad command line format";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop delete bkey1 0x00..0xFFF"; $rst = "CLIENT_ERROR bad command line format";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop delete bkey1 0x11..0xFFFF"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop delete bkey1 0x00..0xFF 1 EQ 0x05"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop delete bkey1 0x00..0xFF 32 EQ 0x05"; $rst = "CLIENT_ERROR bad command line format";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop delete bkey1 0x00..0xFF 1 XX 0x05"; $rst = "CLIENT_ERROR bad command line format";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop delete bkey1 0x00..0xFF 0 & 0xFFFFFF EQ 0x03"; $rst = "CLIENT_ERROR bad command line format";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop delete bkey1 0x00..0xFF 0 & 0xFFFFFF EQ 0x030303"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop delete bkey1 0x00..0xFF 1 * 0x00 EQ 0x03 1 1"; $rst = "CLIENT_ERROR bad command line format";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop delete bkey1 0x00..0xFF 3 GT 0x00"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop delete bkey1 0x0505050505 0 & 0x00 EQ 0x00"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
+
 # Success Cases
 $cmd = "bop delete bkey1 0x00..0xFF 1 & 0xFF EQ 0x03"; $rst = "DELETED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-bop_ext_get_is($sock, "bkey1 0x00..0xFF", 11, 8,
-               "0x01,0x0202,0x04040404,0x0505050505,0x060606060606,0x07070707070707,0x0808080808080808,0x090909090909090909",
-               "0x01,0x02,0x0404,,,,,",
-               "datum1,datum2,datum4,datum5,datum6,datum7,datum8,datum9", "END");
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey1 0x00..0xFF";
+$rst = "VALUE 11 8
+0x01 0x01 6 datum1
+0x0202 0x02 6 datum2
+0x04040404 0x0404 6 datum4
+0x0505050505 6 datum5
+0x060606060606 6 datum6
+0x07070707070707 6 datum7
+0x0808080808080808 6 datum8
+0x090909090909090909 6 datum9
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop delete bkey1 0x00..0xFF 0 ^ 0x10 EQ 0x11"; $rst = "DELETED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-bop_ext_get_is($sock, "bkey1 0x00..0xFF", 11, 7,
-               "0x0202,0x04040404,0x0505050505,0x060606060606,0x07070707070707,0x0808080808080808,0x090909090909090909",
-               "0x02,0x0404,,,,,",
-               "datum2,datum4,datum5,datum6,datum7,datum8,datum9", "END");
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey1 0x00..0xFF";
+$rst = "VALUE 11 7
+0x0202 0x02 6 datum2
+0x04040404 0x0404 6 datum4
+0x0505050505 6 datum5
+0x060606060606 6 datum6
+0x07070707070707 6 datum7
+0x0808080808080808 6 datum8
+0x090909090909090909 6 datum9
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop delete bkey1 0x00..0xFF 0 LE 0x04"; $rst = "DELETED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-bop_ext_get_is($sock, "bkey1 0x00..0xFF", 11, 5,
-               "0x0505050505,0x060606060606,0x07070707070707,0x0808080808080808,0x090909090909090909", ",,,,",
-               "datum5,datum6,datum7,datum8,datum9", "END");
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey1 0x00..0xFF";
+$rst = "VALUE 11 5
+0x0505050505 6 datum5
+0x060606060606 6 datum6
+0x07070707070707 6 datum7
+0x0808080808080808 6 datum8
+0x090909090909090909 6 datum9
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop delete bkey1 0xFFFF..0x0000 2 drop"; $rst = "DELETED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-bop_ext_get_is($sock, "bkey1 0x00..0xFF", 11, 3,
-               "0x0505050505,0x060606060606,0x07070707070707", ",,",
-               "datum5,datum6,datum7", "END");
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey1 0x00..0xFF";
+$rst = "VALUE 11 3
+0x0505050505 6 datum5
+0x060606060606 6 datum6
+0x07070707070707 6 datum7
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop delete bkey1 0x0505050505 0 & 0x00 NE 0x00 drop"; $rst = "DELETED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-bop_ext_get_is($sock, "bkey1 0x00..0xFF", 11, 2,
-               "0x060606060606,0x07070707070707", ",",
-               "datum6,datum7", "END");
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey1 0x00..0xFF";
+$rst = "VALUE 11 2
+0x060606060606 6 datum6
+0x07070707070707 6 datum7
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop delete bkey1 0xFF..0x00 drop"; $rst = "DELETED_DROPPED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 # Finalize
 $cmd = "get bkey1"; $rst = "END";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 
-# #Success Cases
-# $cmd = "bop insert bkey1 0 0x0011 6 create 11 0 10"; $val = "datum0"; $rst = "CREATED_STORED";
-# print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-# $cmd = "bop insert bkey1 1 0x0022 6"; $val = "datum1"; $rst = "STORED";
-# print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-# $cmd = "bop insert bkey1 2 0x0A11 6"; $val = "datum2"; $rst = "STORED";
-# print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-# $cmd = "bop insert bkey1 3 0x0AFF 6"; $val = "datum3"; $rst = "STORED";
-# print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-# $cmd = "bop insert bkey1 4 0xBB77 6"; $val = "datum4"; $rst = "STORED";
-# print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-# $cmd = "bop insert bkey1 5 0xCC 6"; $val = "datum5"; $rst = "STORED";
-# print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-# #check
-# bop_ext_get_is($sock, "bkey1 0..10", 11, 6,
-# "0,1,2,3,4,5", "0x0011,0x0022,0x0A11,0x0AFF,0xBB77,0xCC",
-# "datum0,datum1,datum2,datum3,datum4,datum5","END" );
-#
-# $cmd = "bop delete bkey1 0..10 0 EQ 0x0011,0xBB77"; $rst = "DELETED";
-# print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-# #check
-# bop_ext_get_is($sock, "bkey1 0..10", 11, 4,
-# "1,2,3,5", "0x0022,0x0A11,0x0AFF,0xCC",
-# "datum1,datum2,datum3,datum5", "END");
-#
-# $cmd = "bop delete bkey1 0..10 0 NE 0x0022,0x0A11"; $rst = "DELETED";
-# print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-# #check
-# bop_ext_get_is($sock, "bkey1 0..10", 11, 2,
-# "1,2", "0x0022,0x0A11",
-# "datum1,datum2","END");
-#
-# $cmd = "bop delete bkey1 0..10 drop"; $rst = "DELETED_DROPPED";
-# print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-# # Finalize
-# $cmd = "get bkey1"; $rst = "END";
-# # print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+# Success Cases
+$cmd = "bop insert bkey1 0 0x0011 6 create 11 0 10"; $val = "datum0"; $rst = "CREATED_STORED";
+mem_cmd_is($sock, $cmd, $val, $rst);
+$cmd = "bop insert bkey1 1 0x0022 6"; $val = "datum1"; $rst = "STORED";
+mem_cmd_is($sock, $cmd, $val, $rst);
+$cmd = "bop insert bkey1 2 0x0A11 6"; $val = "datum2"; $rst = "STORED";
+mem_cmd_is($sock, $cmd, $val, $rst);
+$cmd = "bop insert bkey1 3 0x0AFF 6"; $val = "datum3"; $rst = "STORED";
+mem_cmd_is($sock, $cmd, $val, $rst);
+$cmd = "bop insert bkey1 4 0xBB77 6"; $val = "datum4"; $rst = "STORED";
+mem_cmd_is($sock, $cmd, $val, $rst);
+$cmd = "bop insert bkey1 5 0xCC 6"; $val = "datum5"; $rst = "STORED";
+mem_cmd_is($sock, $cmd, $val, $rst);
+
+# check
+$cmd = "bop get bkey1 0..10";
+$rst = "VALUE 11 6
+0 0x0011 6 datum0
+1 0x0022 6 datum1
+2 0x0A11 6 datum2
+3 0x0AFF 6 datum3
+4 0xBB77 6 datum4
+5 0xCC 6 datum5
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop delete bkey1 0..10 0 EQ 0x0011,0xBB77"; $rst = "DELETED";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey1 0..10";
+$rst = "VALUE 11 4
+1 0x0022 6 datum1
+2 0x0A11 6 datum2
+3 0x0AFF 6 datum3
+5 0xCC 6 datum5
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop delete bkey1 0..10 0 NE 0x0022,0x0A11"; $rst = "DELETED";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey1 0..10";
+$rst = "VALUE 11 2
+1 0x0022 6 datum1
+2 0x0A11 6 datum2
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop delete bkey1 0..10 drop"; $rst = "DELETED_DROPPED";
+mem_cmd_is($sock, $cmd, "", $rst);
+
+# Finalize
+$cmd = "get bkey1"; $rst = "END";
+mem_cmd_is($sock, $cmd, "", $rst);
 
 # after test
 release_memcached($engine, $server);

--- a/t/coll_bop_get.t
+++ b/t/coll_bop_get.t
@@ -88,156 +88,273 @@ my $rst;
 
 # Initialize
 $cmd = "get bkey1"; $rst = "END";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "get bkey2"; $rst = "END";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
+
 # Prepare Keys
 $cmd = "bop insert bkey1 0x0090 0x11FF 6 create 11 0 0"; $val = "datum9"; $rst = "CREATED_STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 0x0070 0x01FF 6"; $val = "datum7"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 0x0050 0x00FF 6"; $val = "datum5"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 0x0030 0x000F 6"; $val = "datum3"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 
 $cmd = "bop insert bkey1 0x0010 6"; $val = "datum1"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-bop_ext_get_is($sock, "bkey1 0x00..0x1000",
-               11, 5, "0x0010,0x0030,0x0050,0x0070,0x0090", ",0x000F,0x00FF,0x01FF,0x11FF",
-               "datum1,datum3,datum5,datum7,datum9", "END");
+mem_cmd_is($sock, $cmd, $val, $rst);
+$cmd = "bop get bkey1 0x00..0x1000";
+$rst = "VALUE 11 5
+0x0010 6 datum1
+0x0030 0x000F 6 datum3
+0x0050 0x00FF 6 datum5
+0x0070 0x01FF 6 datum7
+0x0090 0x11FF 6 datum9
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop create bkey2 11 0 0"; $rst = "CREATED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop insert bkey2 0x0100 0x11FF 7"; $val = "datum10"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey2 0x0080 0x01FF 6"; $val = "datum8"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey2 0x0060 0x00FF 6"; $val = "datum6"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey2 0x0040 0x000F 6"; $val = "datum4"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey2 0x0020 0x0000 6"; $val = "datum2"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-bop_ext_get_is($sock, "bkey2 0x0000..0xFFFFFFFF",
-               11, 5, "0x0020,0x0040,0x0060,0x0080,0x0100", "0x0000,0x000F,0x00FF,0x01FF,0x11FF",
-               "datum2,datum4,datum6,datum8,datum10", "END");
+mem_cmd_is($sock, $cmd, $val, $rst);
+$cmd = "bop get bkey2 0x0000..0xFFFFFFFF";
+$rst = "VALUE 11 5
+0x0020 0x0000 6 datum2
+0x0040 0x000F 6 datum4
+0x0060 0x00FF 6 datum6
+0x0080 0x01FF 6 datum8
+0x0100 0x11FF 7 datum10
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
+
 # Success cases
-bop_ext_get_is($sock, "bkey1 0x00..0x1000 0 EQ 0x000F",
-               11, 1, "0x0030", "0x000F", "datum3", "END");
-# bop_ext_get_is($sock, "bkey1 0x00..0x1000 0 EQ 0x000F,0x00FF",
-#               11, 2, "0x0030,0x0050", "0x000F,0x00FF", "datum3,datum5", "END");
-# bop_ext_get_is($sock, "bkey1 0x00..0x1000 0 & 0xFFFF EQ 0x000F,0x00FF",
-#                11, 2, "0x0030,0x0050", "0x000F,0x00FF", "datum3,datum5", "END");
-bop_ext_get_is($sock, "bkey1 0x00..0x1000 0 NE 0x000F",
-               11, 4, "0x0010,0x0050,0x0070,0x0090", ",0x00FF,0x01FF,0x11FF",
-               "datum1,datum5,datum7,datum9", "END");
+$cmd = "bop get bkey1 0x00..0x1000 0 EQ 0x000F";
+$rst = "VALUE 11 1
+0x0030 0x000F 6 datum3
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey1 0x00..0x1000 0 NE 0x000F";
+$rst = "VALUE 11 4
+0x0010 6 datum1
+0x0050 0x00FF 6 datum5
+0x0070 0x01FF 6 datum7
+0x0090 0x11FF 6 datum9
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 
-bop_ext_get_is($sock, "bkey1 0x00..0x1000 0 LT 0x00FF",
-               11, 1, "0x0030", "0x000F", "datum3", "END");
-bop_ext_get_is($sock, "bkey1 0x00..0x1000 0 LE 0x00FF",
-               11, 2, "0x0030,0x0050", "0x000F,0x00FF", "datum3,datum5", "END");
-bop_ext_get_is($sock, "bkey1 0x00..0x1000 0 GT 0x00FF",
-               11, 2, "0x0070,0x0090", "0x01FF,0x11FF", "datum7,datum9", "END");
-bop_ext_get_is($sock, "bkey1 0x00..0x1000 0 GE 0x00FF",
-               11, 3, "0x0050,0x0070,0x0090", "0x00FF,0x01FF,0x11FF", "datum5,datum7,datum9", "END");
-bop_ext_get_is($sock, "bkey1 0x00..0x1000 0 & 0x0100 EQ 0x0100",
-               11, 2, "0x0070,0x0090", "0x01FF,0x11FF", "datum7,datum9", "END");
-bop_ext_get_is($sock, "bkey1 0x00..0x1000 0 | 0x0110 NE 0x0110",
-               11, 5, "0x0010,0x0030,0x0050,0x0070,0x0090", ",0x000F,0x00FF,0x01FF,0x11FF",
-               "datum1,datum3,datum5,datum7,datum9", "END");
-bop_ext_get_is($sock, "bkey1 0x00..0x1000 1 ^ 0xF0   EQ 0xFF",
-               11, 1, "0x0030", "0x000F", "datum3", "END");
-bop_ext_get_is($sock, "bkey1 0x00..0x1000 1 & 0xFF   EQ 0x0F",
-               11, 1, "0x0030", "0x000F", "datum3", "END");
-# bop_ext_get_is($sock, "bkey1 0x0030..0x0090 0 NE 0x000F,0x11FF",
-#                11, 2, "0x0050,0x0070", "0x00FF,0x01FF",
-#                "datum5,datum7", "END");
-bop_ext_get_is($sock, "bkey1 0x0050..0x0050 0 & 0xFFFF EQ 0x00FF 0 1 delete",
-               11, 1, "0x0050", "0x00FF", "datum5", "DELETED");
+$cmd = "bop get bkey1 0x00..0x1000 0 LT 0x00FF";
+$rst = "VALUE 11 1
+0x0030 0x000F 6 datum3
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey1 0x00..0x1000 0 LE 0x00FF";
+$rst = "VALUE 11 2
+0x0030 0x000F 6 datum3
+0x0050 0x00FF 6 datum5
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey1 0x00..0x1000 0 GT 0x00FF";
+$rst = "VALUE 11 2
+0x0070 0x01FF 6 datum7
+0x0090 0x11FF 6 datum9
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey1 0x00..0x1000 0 GE 0x00FF";
+$rst = "VALUE 11 3
+0x0050 0x00FF 6 datum5
+0x0070 0x01FF 6 datum7
+0x0090 0x11FF 6 datum9
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey1 0x00..0x1000 0 & 0x0100 EQ 0x0100";
+$rst = "VALUE 11 2
+0x0070 0x01FF 6 datum7
+0x0090 0x11FF 6 datum9
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey1 0x00..0x1000 0 | 0x0110 NE 0x0110";
+$rst = "VALUE 11 5
+0x0010 6 datum1
+0x0030 0x000F 6 datum3
+0x0050 0x00FF 6 datum5
+0x0070 0x01FF 6 datum7
+0x0090 0x11FF 6 datum9
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey1 0x00..0x1000 1 ^ 0xF0   EQ 0xFF";
+$rst = "VALUE 11 1
+0x0030 0x000F 6 datum3
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey1 0x00..0x1000 1 & 0xFF   EQ 0x0F";
+$rst = "VALUE 11 1
+0x0030 0x000F 6 datum3
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey1 0x0050..0x0050 0 & 0xFFFF EQ 0x00FF 0 1 delete";
+$rst = "VALUE 11 1
+0x0050 0x00FF 6 datum5
+DELETED";
+mem_cmd_is($sock, $cmd, "", $rst);
 
-bop_ext_get_is($sock, "bkey2 0x0000..0xFFFFFFFF 0 EQ 0x0000",
-               11, 1, "0x0020", "0x0000", "datum2", "END");
-bop_ext_get_is($sock, "bkey2 0x0000..0xFFFFFFFF 0 NE 0x0000",
-               11, 4, "0x0040,0x0060,0x0080,0x0100", "0x000F,0x00FF,0x01FF,0x11FF",
-               "datum4,datum6,datum8,datum10", "END");
-bop_ext_get_is($sock, "bkey2 0x0000..0xFFFFFFFF 0 LT 0x00FF",
-               11, 2, "0x0020,0x0040", "0x0000,0x000F", "datum2,datum4", "END");
-bop_ext_get_is($sock, "bkey2 0x0000..0xFFFFFFFF 0 LE 0x00FF",
-               11, 3, "0x0020,0x0040,0x0060", "0x0000,0x000F,0x00FF", "datum2,datum4,datum6", "END");
-bop_ext_get_is($sock, "bkey2 0x0000..0xFFFFFFFF 0 GT 0x00FF",
-               11, 2, "0x0080,0x0100", "0x01FF,0x11FF", "datum8,datum10", "END");
-bop_ext_get_is($sock, "bkey2 0x0000..0xFFFFFFFF 0 GE 0x00FF",
-               11, 3, "0x0060,0x0080,0x0100", "0x00FF,0x01FF,0x11FF", "datum6,datum8,datum10", "END");
-bop_ext_get_is($sock, "bkey2 0x0000..0xFFFFFFFF 0 & 0x0100 EQ 0x0100",
-               11, 2, "0x0080,0x0100", "0x01FF,0x11FF", "datum8,datum10", "END");
-bop_ext_get_is($sock, "bkey2 0x0000..0xFFFFFFFF 0 | 0x0110 NE 0x0110",
-               11, 4, "0x0040,0x0060,0x0080,0x0100", "0x000F,0x00FF,0x01FF,0x11FF", "datum4,datum6,datum8,datum10", "END");
-bop_ext_get_is($sock, "bkey2 0x0000..0xFFFFFFFF 1 ^ 0xF0   EQ 0xFF",
-               11, 1, "0x0040", "0x000F", "datum4", "END");
-bop_ext_get_is($sock, "bkey2 0x0000..0xFFFFFFFF 1 ^ 0xF0   EQ 0xFF",
-               11, 1, "0x0040", "0x000F", "datum4", "END");
+$cmd = "bop get bkey2 0x0000..0xFFFFFFFF 0 EQ 0x0000";
+$rst = "VALUE 11 1
+0x0020 0x0000 6 datum2
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey2 0x0000..0xFFFFFFFF 0 NE 0x0000";
+$rst = "VALUE 11 4
+0x0040 0x000F 6 datum4
+0x0060 0x00FF 6 datum6
+0x0080 0x01FF 6 datum8
+0x0100 0x11FF 7 datum10
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey2 0x0000..0xFFFFFFFF 0 LT 0x00FF";
+$rst = "VALUE 11 2
+0x0020 0x0000 6 datum2
+0x0040 0x000F 6 datum4
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey2 0x0000..0xFFFFFFFF 0 LE 0x00FF";
+$rst = "VALUE 11 3
+0x0020 0x0000 6 datum2
+0x0040 0x000F 6 datum4
+0x0060 0x00FF 6 datum6
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey2 0x0000..0xFFFFFFFF 0 GT 0x00FF";
+$rst = "VALUE 11 2
+0x0080 0x01FF 6 datum8
+0x0100 0x11FF 7 datum10
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey2 0x0000..0xFFFFFFFF 0 GE 0x00FF";
+$rst = "VALUE 11 3
+0x0060 0x00FF 6 datum6
+0x0080 0x01FF 6 datum8
+0x0100 0x11FF 7 datum10
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey2 0x0000..0xFFFFFFFF 0 & 0x0100 EQ 0x0100";
+$rst = "VALUE 11 2
+0x0080 0x01FF 6 datum8
+0x0100 0x11FF 7 datum10
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey2 0x0000..0xFFFFFFFF 0 | 0x0110 NE 0x0110";
+$rst = "VALUE 11 4
+0x0040 0x000F 6 datum4
+0x0060 0x00FF 6 datum6
+0x0080 0x01FF 6 datum8
+0x0100 0x11FF 7 datum10
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey2 0x0000..0xFFFFFFFF 1 ^ 0xF0 EQ 0xFF";
+$rst = "VALUE 11 1
+0x0040 0x000F 6 datum4
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey2 0x0000..0xFFFFFFFF 1 ^ 0xF0   EQ 0xFF";
+$rst = "VALUE 11 1
+0x0040 0x000F 6 datum4
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 
 # Fail Cases
 $cmd = "bop get bkey1 0x00..0x1000 0 EQ 0x0000"; $rst = "NOT_FOUND_ELEMENT";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get bkey1 0..0x1000"; $rst = "CLIENT_ERROR bad command line format";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 # $cmd = "bop get bkey1 0..0x1000 0 EQ 0x000F,0x000FF"; $rst = "CLIENT_ERROR bad command line format";
 # print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
 $cmd = "bop get bkey1 0..1000"; $rst = "BKEY_MISMATCH";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get kvkey 0..1000"; $rst = "NOT_FOUND";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop get kvkey 0..1000"; $rst = "NOT_FOUND";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "set kvkey 0 0 6"; $val = "datumx"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop get kvkey 0..1000"; $rst = "TYPE_MISMATCH";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "delete kvkey"; $rst = "DELETED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 
 # Other Cases
 $cmd = "delete bkey2"; $rst = "DELETED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "bop insert bkey2 0x00 6 create 13 0 0"; $val = "datum1"; $rst = "CREATED_STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey2 0x0000 0x0202 7"; $val = "datum22"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey2 0x000000 8"; $val = "datum333"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey2 0x01 0x01 9"; $val = "datum4444"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey2 0x0001 10"; $val = "datum55555"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey2 0x000001 0x030303 11"; $val = "datum666666"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey2 0x02 12"; $val = "datum7777777"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey2 0x0002 0x0202 13"; $val = "datum88888888"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey2 0x000002 14"; $val = "datum999999999"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey2 0x0101 0x00 5"; $val = "datum"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
-bop_ext_get_is($sock, "bkey2 0x01..0x02",
-               13, 3, "0x01,0x0101,0x02", "0x01,0x00,", "datum4444,datum,datum7777777", "END");
-bop_ext_get_is($sock, "bkey2 0x0001..0x0002",
-               13, 2, "0x0001,0x0002", ",0x0202", "datum55555,datum88888888", "END");
-bop_ext_get_is($sock, "bkey2 0x00..0x0002",
-               13, 7,
-               "0x00,0x0000,0x000000,0x000001,0x000002,0x0001,0x0002", ",0x0202,,0x030303,,,0x0202",
-               "datum1,datum22,datum333,datum666666,datum999999999,datum55555,datum88888888", "END");
-bop_ext_get_is($sock, "bkey2 0x02..0x0000",
-               13, 9,
-               "0x02,0x0101,0x01,0x0002,0x0001,0x000002,0x000001,0x000000,0x0000", ",0x00,0x01,0x0202,,,0x030303,,0x0202",
-               "datum7777777,datum,datum4444,datum88888888,datum55555,datum999999999,datum666666,datum333,datum22", "END");
+mem_cmd_is($sock, $cmd, $val, $rst);
+$cmd = "bop get bkey2 0x01..0x02";
+$rst = "VALUE 13 3
+0x01 0x01 9 datum4444
+0x0101 0x00 5 datum
+0x02 12 datum7777777
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey2 0x0001..0x0002";
+$rst = "VALUE 13 2
+0x0001 10 datum55555
+0x0002 0x0202 13 datum88888888
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey2 0x00..0x0002";
+$rst = "VALUE 13 7
+0x00 6 datum1
+0x0000 0x0202 7 datum22
+0x000000 8 datum333
+0x000001 0x030303 11 datum666666
+0x000002 14 datum999999999
+0x0001 10 datum55555
+0x0002 0x0202 13 datum88888888
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey2 0x02..0x0000";
+$rst = "VALUE 13 9
+0x02 12 datum7777777
+0x0101 0x00 5 datum
+0x01 0x01 9 datum4444
+0x0002 0x0202 13 datum88888888
+0x0001 10 datum55555
+0x000002 14 datum999999999
+0x000001 0x030303 11 datum666666
+0x000000 8 datum333
+0x0000 0x0202 7 datum22
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
+
 # Finalize
 $cmd = "delete bkey1"; $rst = "DELETED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "delete bkey2"; $rst = "DELETED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-
+mem_cmd_is($sock, $cmd, "", $rst);
 
 # after test
 release_memcached($engine, $server);

--- a/t/coll_bop_incrdecr.t
+++ b/t/coll_bop_incrdecr.t
@@ -51,164 +51,216 @@ my $rst;
 
 # Initialize
 $cmd = "get bkey1"; $rst = "END";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
 
 # Prepare Keys
 $cmd = "bop insert bkey1 0x0010 1 create 11 0 0"; $val = "1"; $rst = "CREATED_STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 0x0020 1"; $val = "2"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 0x0030 1"; $val = "3"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 0x0040 1"; $val = "4"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 0x0050 1"; $val = "a"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 
 $cmd = "bop count bkey1 0x0010..0x0050"; $rst = "COUNT=5";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop incr bkey1 0x0010 1"; $rst = "2";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey1 0x0010";
+$rst = "VALUE 11 1
+0x0010 1 2
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 
-print $sock "bop incr bkey1 0x0010 1\r\n";
-is(scalar <$sock>, "2\r\n", "+ 1 = 2");
-bop_ext_get_is($sock, "bkey1 0x0010", 11, 1, "0x0010", "", "2", "END");
+$cmd = "bop incr bkey1 0x0020 25"; $rst = "27";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey1 0x0020";
+$rst = "VALUE 11 1
+0x0020 2 27
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 
-print $sock "bop incr bkey1 0x0020 25\r\n";
-is(scalar <$sock>, "27\r\n", "+ 25 = 27");
-bop_ext_get_is($sock, "bkey1 0x0020", 11, 1, "0x0020", "", "27", "END");
+$cmd = "bop decr bkey1 0x0020 20"; $rst = "7";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey1 0x0020";
+$rst = "VALUE 11 1
+0x0020 1 7
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 
-print $sock "bop decr bkey1 0x0020 20\r\n";
-is(scalar <$sock>, "7\r\n", "- 20 = 7");
-bop_ext_get_is($sock, "bkey1 0x0020", 11, 1, "0x0020", "", "7", "END");
+$cmd = "bop decr bkey1 0x0030 2"; $rst = "1";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey1 0x0030";
+$rst = "VALUE 11 1
+0x0030 1 1
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 
-print $sock "bop decr bkey1 0x0030 2\r\n";
-is(scalar <$sock>, "1\r\n", "- 2 = 1");
-bop_ext_get_is($sock, "bkey1 0x0030", 11, 1, "0x0030", "", "1", "END");
+$cmd = "bop decr bkey1 0x0040 10"; $rst = "0";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey1 0x0040";
+$rst = "VALUE 11 1
+0x0040 1 0
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 
-print $sock "bop decr bkey1 0x0040 10\r\n";
-is(scalar <$sock>, "0\r\n", "- 10 = 0");
-bop_ext_get_is($sock, "bkey1 0x0040", 11, 1, "0x0040", "", "0", "END");
+$cmd = "bop incr bkey1 0x0050 10";
+$rst = "CLIENT_ERROR cannot increment or decrement non-numeric value";
+mem_cmd_is($sock, $cmd, "", $rst, "a + 10 = 0");
 
-print $sock "bop incr bkey1 0x0050 10\r\n";
-is(scalar <$sock>,
-   "CLIENT_ERROR cannot increment or decrement non-numeric value\r\n",
-   "a + 10 = 0");
+$cmd = "bop get bkey1 0x0050";
+$rst = "VALUE 11 1
+0x0050 1 a
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 
-bop_ext_get_is($sock, "bkey1 0x0050", 11, 1, "0x0050", "", "a", "END");
+$cmd = "bop incr bkey1 0x0060 10"; $rst = "NOT_FOUND_ELEMENT";
+mem_cmd_is($sock, $cmd, "", $rst);
 
-print $sock "bop incr bkey1 0x0060 10\r\n";
-$rst = "NOT_FOUND_ELEMENT";
-is(scalar <$sock>, "$rst\r\n", "$rst");
+$cmd = "bop incr bkey1 0x0060 10 6"; $rst = "6";
+mem_cmd_is($sock, $cmd, "", $rst, "initail = 6");
+$cmd = "bop get bkey1 0x0060";
+$rst = "VALUE 11 1
+0x0060 1 6
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 
-print $sock "bop incr bkey1 0x0060 10 6\r\n";
-is(scalar <$sock>, "6\r\n", "initail = 6");
-bop_ext_get_is($sock, "bkey1 0x0060", 11, 1, "0x0060", "", "6", "END");
+$cmd = "bop incr bkey1 0x0060 10 6"; $rst = "16";
+mem_cmd_is($sock, $cmd, "", $rst, "+ 10 = 16");
+$cmd = "bop get bkey1 0x0060";
+$rst = "VALUE 11 1
+0x0060 2 16
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 
-print $sock "bop incr bkey1 0x0060 10 6\r\n";
-is(scalar <$sock>, "16\r\n", "+ 10 = 16");
-bop_ext_get_is($sock, "bkey1 0x0060", 11, 1, "0x0060", "", "16", "END");
+$cmd = "bop decr bkey1 0x0070 10 7 0xFF"; $rst = "7";
+mem_cmd_is($sock, $cmd, "", $rst, "initial = 7 0xFF");
+$cmd = "bop get bkey1 0x0070";
+$rst = "VALUE 11 1
+0x0070 0xFF 1 7
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 
-print $sock "bop decr bkey1 0x0070 10 7 0xFF\r\n";
-is(scalar <$sock>, "7\r\n", "initial = 7 0xFF");
-bop_ext_get_is($sock, "bkey1 0x0070", 11, 1, "0x0070", "0xFF", "7", "END");
+$cmd = "bop decr bkey1 0x0070 5 7 0xFF"; $rst = "2";
+mem_cmd_is($sock, $cmd, "", $rst, "- 5 = 2");
+$cmd = "bop get bkey1 0x0070";
+$rst = "VALUE 11 1
+0x0070 0xFF 1 2
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 
-print $sock "bop decr bkey1 0x0070 5 7 0xFF\r\n";
-is(scalar <$sock>, "2\r\n", "- 5 = 2");
-bop_ext_get_is($sock, "bkey1 0x0070", 11, 1, "0x0070", "0xFF", "2", "END");
+$cmd = "bop decr bkey1 0x0070 10 7 0xFF"; $rst = "0";
+mem_cmd_is($sock, $cmd, "", $rst, "- 10 = 0");
+$cmd = "bop get bkey1 0x0070";
+$rst = "VALUE 11 1
+0x0070 0xFF 1 0
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 
-print $sock "bop decr bkey1 0x0070 10 7 0xFF\r\n";
-is(scalar <$sock>, "0\r\n", "- 10 = 0");
-bop_ext_get_is($sock, "bkey1 0x0070", 11, 1, "0x0070", "0xFF", "0", "END");
+$cmd = "bop incr bkey1 0x0080 0 987654321 0xF0F0";
+$rst = "CLIENT_ERROR bad command line format";
+mem_cmd_is($sock, $cmd, "", $rst, "delta = 0");
 
-print $sock "bop incr bkey1 0x0080 0 987654321 0xF0F0\r\n";
-is(scalar <$sock>, "CLIENT_ERROR bad command line format\r\n", "delta = 0");
+$cmd = "bop incr bkey1 0x0080 1 987654321 0xF0F0"; $rst = "987654321";
+mem_cmd_is($sock, $cmd, "", $rst, "initial = 987654321 0xF0F0");
+$cmd = "bop get bkey1 0x0080";
+$rst = "VALUE 11 1
+0x0080 0xF0F0 9 987654321
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 
-print $sock "bop incr bkey1 0x0080 1 987654321 0xF0F0\r\n";
-is(scalar <$sock>, "987654321\r\n", "initial = 987654321 0xF0F0");
-bop_ext_get_is($sock, "bkey1 0x0080", 11, 1, "0x0080", "0xF0F0", "987654321", "END");
+$cmd = "bop decr bkey1 0x0080 1"; $rst = "987654320";
+mem_cmd_is($sock, $cmd, "", $rst, "- 1 = 987654320");
+$cmd = "bop get bkey1 0x0080";
+$rst = "VALUE 11 1
+0x0080 0xF0F0 9 987654320
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 
-print $sock "bop decr bkey1 0x0080 1\r\n";
-is(scalar <$sock>, "987654320\r\n", "- 1 = 987654320");
-bop_ext_get_is($sock, "bkey1 0x0080", 11, 1, "0x0080", "0xF0F0", "987654320", "END");
+$cmd = "bop decr bkey1 0x0080 900000000"; $rst = "87654320";
+mem_cmd_is($sock, $cmd, "", $rst, "- 900000000 = 87654320");
+$cmd = "bop get bkey1 0x0080";
+$rst = "VALUE 11 1
+0x0080 0xF0F0 8 87654320
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 
-print $sock "bop decr bkey1 0x0080 900000000\r\n";
-is(scalar <$sock>, "87654320\r\n", "- 900000000 = 87654320");
-bop_ext_get_is($sock, "bkey1 0x0080", 11, 1, "0x0080", "0xF0F0", "87654320", "END");
+$cmd = "bop decr bkey1 0x0080 80000000 10"; $rst = "7654320";
+mem_cmd_is($sock, $cmd, "", $rst, "- 80000000 = 7654320");
+$cmd = "bop get bkey1 0x0080";
+$rst = "VALUE 11 1
+0x0080 0xF0F0 7 7654320
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 
-print $sock "bop decr bkey1 0x0080 80000000 10\r\n";
-is(scalar <$sock>, "7654320\r\n", "- 80000000 = 7654320");
-bop_ext_get_is($sock, "bkey1 0x0080", 11, 1, "0x0080", "0xF0F0", "7654320", "END");
+$cmd = "bop decr bkey1 0x0080 7654000 10 0xFFFF"; $rst = "320";
+mem_cmd_is($sock, $cmd, "", $rst, "- 7654000 = 320");
+$cmd = "bop get bkey1 0x0080";
+$rst = "VALUE 11 1
+0x0080 0xF0F0 3 320
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 
-print $sock "bop decr bkey1 0x0080 7654000 10 0xFFFF\r\n";
-is(scalar <$sock>, "320\r\n", "- 7654000 = 320");
-bop_ext_get_is($sock, "bkey1 0x0080", 11, 1, "0x0080", "0xF0F0", "320", "END");
+$cmd = "bop incr bkey1 0x0080 680 10 0xFFFF"; $rst = "1000";
+mem_cmd_is($sock, $cmd, "", $rst, "+ 680 = 1000");
+$cmd = "bop get bkey1 0x0080";
+$rst = "VALUE 11 1
+0x0080 0xF0F0 4 1000
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
 
-print $sock "bop incr bkey1 0x0080 680 10 0xFFFF\r\n";
-is(scalar <$sock>, "1000\r\n", "+ 680 = 1000");
-bop_ext_get_is($sock, "bkey1 0x0080", 11, 1, "0x0080", "0xF0F0", "1000", "END");
+$cmd = "bop incr bkey1 1 10"; $rst = "BKEY_MISMATCH";
+mem_cmd_is($sock, $cmd, "", $rst);
 
-print $sock "bop incr bkey1 1 10\r\n";
-$rst = "BKEY_MISMATCH";
-is(scalar <$sock>, "$rst\r\n", "$rst");
-
-print $sock "bop incr bkey2 0 10\r\n";
-$rst = "NOT_FOUND";
-is(scalar <$sock>, "$rst\r\n", "$rst");
+$cmd = "bop incr bkey2 0 10"; $rst = "NOT_FOUND";
+mem_cmd_is($sock, $cmd, "", $rst);
 
 # additional tests
-$cmd = "bop insert bkey1 0x0100 0"; $val = ""; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+$cmd = "bop insert bkey1 0x0100 0\r\n"; $val = ""; $rst = "STORED"; # 0 value test
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 0x0110 2"; $val = "-1"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 0x0120 20"; $val = "18446744073709551615"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 0x0130 20"; $val = "18446744073709551614"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 0x0140 20"; $val = "18446744073709551616"; $rst = "STORED";
-print $sock "$cmd\r\n$val\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd $val: $rst");
+mem_cmd_is($sock, $cmd, $val, $rst);
 
-print $sock "bop incr bkey1 0x0100 1\r\n";
-is(scalar <$sock>,
-   "CLIENT_ERROR cannot increment or decrement non-numeric value\r\n",
-   "incr1 on empty");
-print $sock "bop decr bkey1 0x0100 1\r\n";
-is(scalar <$sock>,
-   "CLIENT_ERROR cannot increment or decrement non-numeric value\r\n",
-   "decr 1 on empty");
+$rst = "CLIENT_ERROR cannot increment or decrement non-numeric value";
+$cmd = "bop incr bkey1 0x0100 1";
+mem_cmd_is($sock, $cmd, "", $rst, "incr1 on empty");
+$cmd = "bop decr bkey1 0x0100 1";
+mem_cmd_is($sock, $cmd, "", $rst, "decr 1 on empty");
+$cmd = "bop incr bkey1 0x0110 1";
+mem_cmd_is($sock, $cmd, "", $rst, "incr 1 on -1");
+$cmd = "bop decr bkey1 0x0110 1";
+mem_cmd_is($sock, $cmd, "", $rst, "incr 1 on -1");
 
-print $sock "bop incr bkey1 0x0110 1\r\n";
-is(scalar <$sock>,
-   "CLIENT_ERROR cannot increment or decrement non-numeric value\r\n",
-   "incr 1 on -1");
-print $sock "bop decr bkey1 0x0110 1\r\n";
-is(scalar <$sock>,
-   "CLIENT_ERROR cannot increment or decrement non-numeric value\r\n",
-   "incr 1 on -1");
+$cmd = "bop incr bkey1 0x0120 1"; $rst = "0";
+mem_cmd_is($sock, $cmd, "", $rst, "incr 1 on 18446744073709551615");
+$cmd = "bop decr bkey1 0x0120 1"; $rst = "0";
+mem_cmd_is($sock, $cmd, "", $rst, "decr 1 on 0");
 
-print $sock "bop incr bkey1 0x0120 1\r\n";
-is(scalar <$sock>, "0\r\n", "incr 1 on 18446744073709551615");
-print $sock "bop decr bkey1 0x0120 1\r\n";
-is(scalar <$sock>, "0\r\n", "decr 1 on 0");
+$cmd = "bop incr bkey1 0x0130 1"; $rst = "18446744073709551615";
+mem_cmd_is($sock, $cmd, "", $rst, "incr 1 on 18446744073709551614");
+$cmd = "bop decr bkey1 0x0130 1"; $rst = "18446744073709551614";
+mem_cmd_is($sock, $cmd, "", $rst, "decr 1 on 18446744073709551615");
+$cmd = "bop decr bkey1 0x0130 1"; $rst = "18446744073709551613";
+mem_cmd_is($sock, $cmd, "", $rst, "decr 1 on 18446744073709551614");
 
-print $sock "bop incr bkey1 0x0130 1\r\n";
-is(scalar <$sock>, "18446744073709551615\r\n", "incr 1 on 18446744073709551614");
-print $sock "bop decr bkey1 0x0130 1\r\n";
-is(scalar <$sock>, "18446744073709551614\r\n", "decr 1 on 18446744073709551615");
-print $sock "bop decr bkey1 0x0130 1\r\n";
-is(scalar <$sock>, "18446744073709551613\r\n", "decr 1 on 18446744073709551614");
-
-print $sock "bop incr bkey1 0x0140 1\r\n";
-is(scalar <$sock>,
-   "CLIENT_ERROR cannot increment or decrement non-numeric value\r\n",
-   "incr 1 on 18446744073709551616");
-print $sock "bop decr bkey1 0x0140 1\r\n";
-is(scalar <$sock>,
-   "CLIENT_ERROR cannot increment or decrement non-numeric value\r\n",
-   "decr 1 on 18446744073709551616");
+$rst = "CLIENT_ERROR cannot increment or decrement non-numeric value";
+$cmd = "bop incr bkey1 0x0140 1";
+mem_cmd_is($sock, $cmd, "", $rst, "incr 1 on 18446744073709551616");
+$cmd = "bop decr bkey1 0x0140 1";
+mem_cmd_is($sock, $cmd, "", $rst, "decr 1 on 18446744073709551616");
 
 # Finalize
 $cmd = "delete bkey1"; $rst = "DELETED";
-print $sock "$cmd\r\n"; is(scalar <$sock>, "$rst\r\n", "$cmd: $rst");
-
+mem_cmd_is($sock, $cmd, "", $rst);
 
 # after test
 release_memcached($engine, $server);


### PR DESCRIPTION
@jhpark816 

common function 1차 부분적용 PR입니다. 한번에하게되면 너무 많을 것 같아 부분적으로 나눠서 PR보내겠습니다.

참고로 test case 갯수가 달라진 테스트가 있는데 이유는 아래와 같습니다.

- 기존
```
getattr_is($sock, "minbkey1 minbkey", "minbkey=10");
getattr_is($sock, "minbkey1 maxbkey", "maxbkey=90");
```

- 변경
```
$cmd = "getattr minbkey1 minbkey maxbkey";
"ATTR minbkey=-1
ATTR maxbkey=-1
END";
mem_cmd_is($sock, $cmd, "", $rst);
```

과 같이 여러개로 나뉘어진 테스트를 합칠 수 있는 건은 합쳐서 수행하다보니 변경되었습니다.

적용하다보니
```
bop count ......
COUNT=<number>
```
```
set kv 1 0 1
1
STORED
incr kv 1
2
```
와 같은 command들도 mem_cmd_is subroutine을 사용할 수 있게 수정되었습니다.