### PR TITLE
TEST : modified issue_ee_599.t test

### DIFF
--- a/t/issue_ee_599.t
+++ b/t/issue_ee_599.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 use strict;
-use Test::More tests => 27;
+use Test::More tests => 8;
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
@@ -19,37 +19,17 @@ $size = 10;
 $cmd = "set key1 1 0 $size"; $val = "x"x$size; $rst = "STORED";
 mem_cmd_is($sock, $cmd, $val, $rst);
 
-sleep(0.01);
-$stats = mem_stats($sock, "slabs");
-is ($stats->{"SM:used_min_classid"}, 12, "$cmd confirm used_min_classid");
-is ($stats->{"SM:used_max_classid"}, 12, "$cmd confirm used_max_classid");
-is ($stats->{"SM:used_01pct_classid"}, 12, "$cmd confirm used_01pct_classid");
-is ($stats->{"SM:free_min_classid"}, 709, "$cmd confirm free_min_classid");
-is ($stats->{"SM:free_max_classid"}, -1, "$cmd confirm free_max_classid");
-is ($stats->{"SM:free_small_space"}, 0, "$cmd confirm free_small_space");
-
 $size = 3;
 $cmd = "set key2 1 0 $size"; $val = "x"x$size; $rst = "STORED";
 mem_cmd_is($sock, $cmd, $val, $rst);
-
-sleep(0.01);
-$stats = mem_stats($sock, "slabs");
-is ($stats->{"SM:used_min_classid"}, 11, "$cmd confirm used_min_classid");
-is ($stats->{"SM:used_max_classid"}, 12, "$cmd confirm used_max_classid");
 
 $size = 20;
 $cmd = "set key3 1 0 $size"; $val = "x"x$size; $rst = "STORED";
 mem_cmd_is($sock, $cmd, $val, $rst);
 
-sleep(0.01);
-$stats = mem_stats($sock, "slabs");
-is ($stats->{"SM:used_min_classid"}, 11, "$cmd confirm used_min_classid");
-is ($stats->{"SM:used_max_classid"}, 13, "$cmd confirm used_max_classid");
-
 $size = 3;
 $cmd = "set key4 1 0 $size"; $val = "x"x$size; $rst = "STORED";
 mem_cmd_is($sock, $cmd, $val, $rst);
-
 
 # make free space
 $cmd = "delete key1"; $rst = "DELETED";
@@ -57,22 +37,13 @@ mem_cmd_is($sock, $cmd, "", $rst);
 
 sleep(0.01);
 $stats = mem_stats($sock, "slabs");
-is ($stats->{"SM:used_min_classid"}, 11, "$cmd confirm used_min_classid");
-is ($stats->{"SM:used_max_classid"}, 13, "$cmd confirm used_max_classid");
-is ($stats->{"SM:used_01pct_classid"}, 13, "$cmd confirm used_01pct_classid");
-is ($stats->{"SM:free_min_classid"}, 12, "$cmd confirm free_min_classid");
-is ($stats->{"SM:free_max_classid"}, 12, "$cmd confirm free_max_classid");
+is ($stats->{"SM:free_small_space"} != 0, 1,"$cmd confirm that free_small_space is not 0");
 
 $cmd = "delete key3"; $rst = "DELETED";
 mem_cmd_is($sock, $cmd, "", $rst);
 
 sleep(0.01);
 $stats = mem_stats($sock, "slabs");
-is ($stats->{"SM:used_min_classid"}, 11, "$cmd confirm used_min_classid");
-is ($stats->{"SM:used_max_classid"}, 11, "$cmd confirm used_max_classid");
-is ($stats->{"SM:used_01pct_classid"}, 11, "$cmd confirm used_01pct_classid");
-is ($stats->{"SM:free_min_classid"}, 12, "$cmd confirm free_min_classid");
-is ($stats->{"SM:free_max_classid"}, 13, "$cmd confirm free_max_classid");
 # Previously, there was a phenomenon in
 # which free_small_space was calculated to be larger than 0
 is ($stats->{"SM:free_small_space"}, 0, "$cmd confirm free_small_space");


### PR DESCRIPTION
기존 테스트에서 slab의 maxid, minid등을 확인했었습니다.
Enterprise 기능에서 hash_item의 크기가 migration등의 기능 추가로 community version에서의 slab id가 12였던게 ee version에서는 slab id가 13으로 변하는 상황 때문에 ee version의 테스트가 실패하네요.

해당 dependency를 제거한 테스트로 변경하였습니다.