### PR TITLE
FIX : coll_bop_random_insert.bt fix few code

### DIFF
--- a/t/coll_bop_random_insert.bt
+++ b/t/coll_bop_random_insert.bt
@@ -151,4 +151,4 @@ for ($start = $maximum_btree_size - $range; $start >= 0; $start -= $range) {
 }
 
 # after test
-release_memcached($engine);
+release_memcached($engine, $server);


### PR DESCRIPTION
default engine 테스트에서는 release_memcached 함수를 사용하지 않아서 통과됐었는데
누락 됐었습니다.