### PR TITLE
CLEANUP: reduce print of no more small memory chunk log

### DIFF
--- a/engines/default/items.c
+++ b/engines/default/items.c
@@ -629,6 +629,13 @@ static void *do_item_alloc_internal(struct default_engine *engine,
 
     if (it == NULL) {
         engine->items.itemstats[id].outofmemory++;
+        if (id == LRU_CLSID_FOR_SMALL) {
+            logger->log(EXTENSION_LOG_WARNING, NULL, "no more small memory chunk"
+                         "space_shortage_level=%d, item size=%lu\n", slabs_space_shortage_level(), ntotal);
+        } else {
+            logger->log(EXTENSION_LOG_WARNING, NULL, "no more memory chunk id=%d, item size=%lu\n", id, ntotal);
+        }
+
         /* Last ditch effort. There is a very rare bug which causes
          * refcount leaks. We've fixed most of them, but it still happens,
          * and it may happen in the future.

--- a/engines/default/slabs.c
+++ b/engines/default/slabs.c
@@ -671,8 +671,6 @@ static sm_blck_t *do_smmgr_blck_alloc(struct default_engine *engine)
             sm_anchor.free_chunk_space -= SM_BLOCK_SIZE;
         }
         do_smmgr_used_blck_link(blck);
-    } else {
-        logger->log(EXTENSION_LOG_WARNING, NULL, "no more small memory chunk\n");
     }
     return blck;
 }


### PR DESCRIPTION
no more small memory chunk log의 출력을 줄이기 위한 PR 입니다.
item eviction을 수행 하면서 재시도에 성공 할 경우 log는 출력하지 않고,
eviction을 수행 했지만 메모리가 부족할 경우에만 log message를
출력하도록 변경 했습니다.