### PR TITLE
CLEANUP: add outofmemorys stats and allocation retry log

### DIFF
--- a/engines/default/default_engine.c
+++ b/engines/default/default_engine.c
@@ -1002,6 +1002,8 @@ static void stats_engine(struct default_engine *engine,
     pthread_mutex_lock(&engine->stats.lock);
     len = sprintf(val, "%"PRIu64, (uint64_t)engine->stats.evictions);
     add_stat("evictions", 9, val, len, cookie);
+    len = sprintf(val, "%"PRIu64, (uint64_t)engine->stats.outofmemorys);
+    add_stat("outofmemorys", 12, val, len, cookie);
     len = sprintf(val, "%"PRIu64, (uint64_t)engine->assoc.tot_prefix_items);
     add_stat("curr_prefixes", 13, val, len, cookie);
     len = sprintf(val, "%"PRIu64, (uint64_t)engine->stats.sticky_items);
@@ -1080,6 +1082,7 @@ default_reset_stats(ENGINE_HANDLE* handle, const void *cookie)
     pthread_mutex_lock(&engine->stats.lock);
     engine->stats.evictions = 0;
     engine->stats.reclaimed = 0;
+    engine->stats.outofmemorys = 0;
     engine->stats.total_items = 0;
     pthread_mutex_unlock(&engine->stats.lock);
 }

--- a/engines/default/default_engine.h
+++ b/engines/default/default_engine.h
@@ -71,6 +71,7 @@ struct engine_stats {
    pthread_mutex_t lock;
    uint64_t evictions;
    uint64_t reclaimed;
+   uint64_t outofmemorys;
    uint64_t sticky_bytes;
    uint64_t sticky_items;
    uint64_t curr_bytes;


### PR DESCRIPTION
1. slabs class 별로 있는 outofmemory 지표를 통합하여 보여줄 수 있도록
```outofmemorys``` 지표를 추가 했습니다. ```stats```명령어를 통해 확인할 수 있습니다.

2. allocation failure로 인해 retry 할 경우 retry 완료 후 verbose level
설정에 따라 retry count를 출력하도록 추가 했습니다.