### PR TITLE
CLEANUP: add a directory path length check of the cmdlog file

### DIFF
--- a/cmdlog.h
+++ b/cmdlog.h
@@ -22,6 +22,7 @@
 #define COMMAND_LOGGING
 #define CMDLOG_INPUT_SIZE 400
 #define CMDLOG_FILENAME_LENGTH 256 /* filename plus path's length */
+#define CMDLOG_DIRPATH_LENGTH 128 /* directory path's length */
 
 #define CMDLOG_NOT_STARTED   0  /* not started */
 #define CMDLOG_EXPLICIT_STOP 1  /* stop by user request */
@@ -37,7 +38,7 @@ struct cmd_log_stats {
     int stop_cause; /* how stopped */
     uint32_t entered_commands;   /* number of entered command */
     uint32_t skipped_commands; /* number of skipped command */
-    char dirpath[CMDLOG_FILENAME_LENGTH];
+    char dirpath[CMDLOG_DIRPATH_LENGTH];
 };
 
 void cmdlog_init(int port, EXTENSION_LOGGER_DESCRIPTOR *logger);

--- a/memcached.c
+++ b/memcached.c
@@ -9663,6 +9663,11 @@ static void process_logging_command(conn *c, token_t *tokens, const size_t ntoke
 
     if (ntokens > 2 && strcmp(type, "start") == 0) {
         if (ntokens > 3) {
+            if (tokens[SUBCOMMAND_TOKEN+1].length > CMDLOG_DIRPATH_LENGTH) {
+                out_string(c, "\tcommand logging failed to start, path exceeds 128.\n");
+                cmdlog_in_use = false;
+                return;
+            }
             fpath = tokens[SUBCOMMAND_TOKEN+1].value;
         }
 


### PR DESCRIPTION
cmdlog file 생성 시 directory path length check를 추가 했습니다.