### PR TITLE
CLEANUP: remove ATTR_MISMATCH with bop smget specification change

### DIFF
--- a/doc/command-btree-collection.md
+++ b/doc/command-btree-collection.md
@@ -530,8 +530,6 @@ smget 수행의 실패 시의 response string은 다음과 같다.
 
 - “TYPE_MISMATCH” - 어떤 key가 b+tree type이 아님
 - “BKEY_MISMATCH” - smget에 참여된 b+tree들의 bkey 유형이 서로 다름.
-- “ATTR_MISMATCH” - smget에 참여된 b+tree들의 속성들이 서로 다름.
-                    maxcount, maxbkeyrange, overflowaction이 모두 동일해야 함.
 - “OUT_OF_RANGE” - 기존 smget 동작에서만 발생할 수 있는 실패 response string이다.
 - "NOT_SUPPORTED" - 지원하지 않음
 - “CLIENT_ERROR bad command line format” - protocol syntax 틀림

--- a/memcached.c
+++ b/memcached.c
@@ -2777,7 +2777,6 @@ static void process_bop_smget_complete_old(conn *c) {
         if (ret == ENGINE_EBADVALUE)     out_string(c, "CLIENT_ERROR bad data chunk");
         else if (ret == ENGINE_EBADTYPE) out_string(c, "TYPE_MISMATCH");
         else if (ret == ENGINE_EBADBKEY) out_string(c, "BKEY_MISMATCH");
-        else if (ret == ENGINE_EBADATTR) out_string(c, "ATTR_MISMATCH");
         else if (ret == ENGINE_EBKEYOOR) out_string(c, "OUT_OF_RANGE");
         else if (ret == ENGINE_ENOMEM)   out_string(c, "SERVER_ERROR out of memory");
         else if (ret == ENGINE_ENOTSUP)  out_string(c, "NOT_SUPPORTED");
@@ -2964,7 +2963,6 @@ static void process_bop_smget_complete(conn *c) {
         if (ret == ENGINE_EBADVALUE)     out_string(c, "CLIENT_ERROR bad data chunk");
         else if (ret == ENGINE_EBADTYPE) out_string(c, "TYPE_MISMATCH");
         else if (ret == ENGINE_EBADBKEY) out_string(c, "BKEY_MISMATCH");
-        else if (ret == ENGINE_EBADATTR) out_string(c, "ATTR_MISMATCH");
         else if (ret == ENGINE_ENOMEM)   out_string(c, "SERVER_ERROR out of memory");
         else if (ret == ENGINE_ENOTSUP)  out_string(c, "NOT_SUPPORTED");
 #if 0 // JHPARK_SMGET_OFFSET_HANDLING
@@ -6452,8 +6450,6 @@ static void process_bin_bop_smget_complete_old(conn *c) {
             write_bin_packet(c, PROTOCOL_BINARY_RESPONSE_EBADTYPE, 0);
         else if (ret == ENGINE_EBADBKEY)
             write_bin_packet(c, PROTOCOL_BINARY_RESPONSE_EBADBKEY, 0);
-        else if (ret == ENGINE_EBADATTR)
-            write_bin_packet(c, PROTOCOL_BINARY_RESPONSE_EBADATTR, 0);
         else if (ret == ENGINE_EBKEYOOR)
             write_bin_packet(c, PROTOCOL_BINARY_RESPONSE_EBKEYOOR, 0);
         else if (ret == ENGINE_ENOMEM)
@@ -6656,8 +6652,6 @@ static void process_bin_bop_smget_complete(conn *c) {
             write_bin_packet(c, PROTOCOL_BINARY_RESPONSE_EBADTYPE, 0);
         else if (ret == ENGINE_EBADBKEY)
             write_bin_packet(c, PROTOCOL_BINARY_RESPONSE_EBADBKEY, 0);
-        else if (ret == ENGINE_EBADATTR)
-            write_bin_packet(c, PROTOCOL_BINARY_RESPONSE_EBADATTR, 0);
 #if 0 // JHPARK_SMGET_OFFSET_HANDLING
         else if (ret == ENGINE_EBKEYOOR)
             write_bin_packet(c, PROTOCOL_BINARY_RESPONSE_EBKEYOOR, 0);


### PR DESCRIPTION
bop smget spec 변경으로, ATTR_MISMATCH response를
return하지 않게 되었습니다. 관련 코드와 document를 제거하기 위한 PR입니다.

@jhpark816 
확인요청 드립니다.