### PR TITLE
CLEANUP: add bind error warning message

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -14188,6 +14188,13 @@ static int server_socket(int port, enum network_transport transport,
                 freeaddrinfo(ai);
                 return 1;
             }
+            char addr_buf[INET6_ADDRSTRLEN];
+            const void *addr = (next->ai_family == AF_INET) ?
+                               (const void*)(&((struct sockaddr_in*)next->ai_addr)->sin_addr) :
+                               (const void*)(&((struct sockaddr_in6*)next->ai_addr)->sin6_addr);
+            inet_ntop(next->ai_family, addr, addr_buf, sizeof(addr_buf));
+            mc_logger->log(EXTENSION_LOG_WARNING, NULL,
+                           "%s:%d already in use\n", addr_buf, port);
             safe_close(sfd);
             continue;
         } else {


### PR DESCRIPTION
bind 시에 해당 address 가 사용중이어서 실패하면
warning 레벨의 로그를 남기도록 하는 PR입니다.

만약 ipv4, ipv6 모두 사용중일 시에 아래와 같이 로깅됩니다.

May 30 17:25:40 jam2in-s001 memcached[32527]: 0.0.0.0:11211 already in use
May 30 17:25:40 jam2in-s001 memcached[32527]: :::11211 already in use


