### PR TITLE
FIX: remove deprecated syntax by perl version

### DIFF
--- a/t/udp.t
+++ b/t/udp.t
@@ -203,7 +203,7 @@ sub construct_udp_message {
     my $cur_dg ="";
     my $cur_udp_header ="";
     for (my $cur_dg_index = 0; $cur_dg_index < $num_datagram; $cur_dg_index++) {
-        $cur_dg = %$datagrams->{$cur_dg_index};
+        $cur_dg = $datagrams->{$cur_dg_index};
         isnt($cur_dg,"","missing datagram for segment $cur_dg_index");
         $cur_udp_header=substr($cur_dg, 0, 8);
         $msg .= substr($cur_dg,8);


### PR DESCRIPTION
perl version에 따라서 deprecated 된 syntax를 제거하기 위한 PR입니다.
travis-ci test 실패의 원인이었고,
perl 5.22.0 version 이후에서 실행 시 error가 발생합니다.

@jhpark816 
확인 요청 드립니다.