### PR TITLE
CLEANUP: reduce initial size of roottable and realloc as necessary

### DIFF
--- a/engines/default/assoc.c
+++ b/engines/default/assoc.c
@@ -34,6 +34,7 @@
 #define GET_HASH_TABIDX(hash, shift, mask) (((hash) >> (shift)) & (mask))
 
 #define DEFAULT_PREFIX_HASHPOWER 10
+#define DEFAULT_ROOTPOWER 9
 #define DEFAULT_PREFIX_MAX_DEPTH 1
 
 typedef struct {
@@ -56,20 +57,32 @@ ENGINE_ERROR_CODE assoc_init(struct default_engine *engine)
     assoc->hashmask = hashmask(assoc->hashpower);
     assoc->rootpower = 0;
 
-    assoc->roottable = calloc(assoc->hashsize * 2, sizeof(void *));
+    int table_count = hashsize(DEFAULT_ROOTPOWER);
+
+    assoc->roottable = calloc(table_count, sizeof(void *));
+
     if (assoc->roottable == NULL) {
         return ENGINE_ENOMEM;
     }
-    assoc->roottable[0].hashtable = (hash_item**)&assoc->roottable[assoc->hashsize];
+
+    assoc->roottable[0].hashtable = calloc(assoc->hashsize, sizeof(void*));
+
+    if (assoc->roottable[0].hashtable == NULL) {
+        free(assoc->roottable);
+        return ENGINE_ENOMEM;
+    }
 
     assoc->infotable = calloc(assoc->hashsize, sizeof(struct bucket_info));
+
     if (assoc->infotable == NULL) {
+        free(assoc->roottable[0].hashtable);
         free(assoc->roottable);
         return ENGINE_ENOMEM;
     }
 
     assoc->prefix_hashtable = calloc(hashsize(DEFAULT_PREFIX_HASHPOWER), sizeof(void *));
     if (assoc->prefix_hashtable == NULL) {
+        free(assoc->roottable[0].hashtable);
         free(assoc->roottable);
         free(assoc->infotable);
         return ENGINE_ENOMEM;
@@ -170,7 +183,16 @@ static void assoc_expand(struct default_engine *engine)
     hash_item** new_hashtable;
     uint32_t ii, table_count = hashsize(assoc->rootpower); // 2 ^ n
 
+    struct table *reallocated_roottable = realloc(assoc->roottable, sizeof(void*) * table_count * 2);
+    assert(reallocated_roottable);
+
+    if(reallocated_roottable == NULL){
+        return;
+    }
+    assoc->roottable = reallocated_roottable;
+
     new_hashtable = calloc(assoc->hashsize * table_count, sizeof(void *));
+
     if (new_hashtable) {
         for (ii=0; ii < table_count; ++ii) {
             assoc->roottable[table_count+ii].hashtable = &new_hashtable[assoc->hashsize*ii];


### PR DESCRIPTION
* 변경사항만 커밋될 수 있도록 했습니다.

이전 PR에서는 마스터 브랜치에 잘못된 PR을 넣어서 제가 커밋하지 않는 내용까지 변경사항으로 뜨는 문제가 있었습니다. develop 브랜치에 PR 하도록 고쳤습니다.

* 메모리 할당 실패를 처리하는 코드를 넣었습니다.

이전 PR에서는 할당 실패로 NULL 이 리턴됐을 때의 예외처리 코드가 없다는 문제가 있었습니다. 같은 함수의 예외 처리 방식을 참고해 고쳤습니다.

assoc_init 함수에서 assoc->roottable과 assoc->roottable[0].hashtable 의 할당이 실패했을 때, 메모리가 충분하지 않다는 점을 알리기 위해 ENGINE_ENOMEM을 리턴하게 했습니다. 메모리 누수를 방지하기 위해 이전에 할당에 성공한 메모리도 모두 해제 했습니다.

assoc_expand 함수에서는 new_hashtable의 예외 처리 코드와 마찬가지로 할당이 성공했을 때에만 테이블의 확장이 실행되도록 고쳤습니다.