### PR TITLE
CLEANUP: reduce initial size of roottable and realloc as necessary

### DIFF
--- a/engines/default/assoc.c
+++ b/engines/default/assoc.c
@@ -34,6 +34,12 @@
 #define GET_HASH_TABIDX(hash, shift, mask) (((hash) >> (shift)) & (mask))
 
 #define DEFAULT_PREFIX_HASHPOWER 10
+
+#define VARIABLE_SIZED_ROOTTABLE 1
+#ifdef VARIABLE_SIZED_ROOTTABLE
+    #define DEFAULT_ROOT_SIZE_POWER 9
+#endif
+
 #define DEFAULT_PREFIX_MAX_DEPTH 1
 
 typedef struct {
@@ -56,20 +62,38 @@ ENGINE_ERROR_CODE assoc_init(struct default_engine *engine)
     assoc->hashmask = hashmask(assoc->hashpower);
     assoc->rootpower = 0;
 
+#ifdef VARIABLE_SIZED_ROOTTABLE
+    assoc->root_size_power = DEFAULT_ROOT_SIZE_POWER;
+    assoc->roottable = calloc(hashsize(assoc->root_size_power), sizeof(void *));
+#else
     assoc->roottable = calloc(assoc->hashsize * 2, sizeof(void *));
+#endif
+
     if (assoc->roottable == NULL) {
         return ENGINE_ENOMEM;
     }
+
+#ifdef VARIABLE_SIZED_ROOTTABLE
+    assoc->roottable[0].hashtable = calloc(assoc->hashsize, sizeof(void*));
+#else
     assoc->roottable[0].hashtable = (hash_item**)&assoc->roottable[assoc->hashsize];
+#endif
+
+    if (assoc->roottable[0].hashtable == NULL) {
+        free(assoc->roottable);
+        return ENGINE_ENOMEM;
+    }
 
     assoc->infotable = calloc(assoc->hashsize, sizeof(struct bucket_info));
     if (assoc->infotable == NULL) {
+        free(assoc->roottable[0].hashtable);
         free(assoc->roottable);
         return ENGINE_ENOMEM;
     }
 
     assoc->prefix_hashtable = calloc(hashsize(DEFAULT_PREFIX_HASHPOWER), sizeof(void *));
     if (assoc->prefix_hashtable == NULL) {
+        free(assoc->roottable[0].hashtable);
         free(assoc->roottable);
         free(assoc->infotable);
         return ENGINE_ENOMEM;
@@ -169,13 +193,26 @@ static void assoc_expand(struct default_engine *engine)
     struct assoc *assoc = &engine->assoc;
     hash_item** new_hashtable;
     uint32_t ii, table_count = hashsize(assoc->rootpower); // 2 ^ n
+    uint32_t roottable_size = hashsize(assoc->root_size_power);
+    struct table *reallocated_roottable = NULL;
+    bool need_realloc = true;
 
-    new_hashtable = calloc(assoc->hashsize * table_count, sizeof(void *));
-    if (new_hashtable) {
-        for (ii=0; ii < table_count; ++ii) {
-            assoc->roottable[table_count+ii].hashtable = &new_hashtable[assoc->hashsize*ii];
+#ifdef VARIABLE_SIZED_ROOTTABLE
+    need_realloc = table_count * 2 > roottable_size;
+    if(need_realloc){
+        reallocated_roottable = realloc(assoc->roottable, sizeof(void*) * roottable_size * 2);
+        assoc->root_size_power++;
+    }
+#endif
+    if(!need_realloc || reallocated_roottable){
+        assoc->roottable = reallocated_roottable;
+        new_hashtable = calloc(assoc->hashsize * table_count, sizeof(void *));
+        if (new_hashtable) {
+            for (ii=0; ii < table_count; ++ii) {
+                assoc->roottable[table_count+ii].hashtable = &new_hashtable[assoc->hashsize*ii];
+            }
+            assoc->rootpower++;
         }
-        assoc->rootpower++;
     }
 }
 

--- a/engines/default/assoc.h
+++ b/engines/default/assoc.h
@@ -58,6 +58,7 @@ struct assoc {
     uint32_t hashsize;  /* hash table size */
     uint32_t hashmask;  /* hash bucket mask */
     uint32_t rootpower; /* how many hash tables we use ? (power of 2) */
+    uint32_t root_size_power;
 
     /* cache item hash table : an array of hash tables */
     struct table {


### PR DESCRIPTION
##  개요

이전의 코드는 루트 테이블의 크기와 테이블의 갯수를 혼동하고 있다는 문제점이 있어 다시 PR합니다.

## 변경점

### assoc.h

* 필요한 때에만 확장을 하려면, table_count 가 두 배가 되었을 때에도 루트 테이블의 공간이 부족하지 않은지 판단할 수 있어야 합니다. 현재 assoc 구조체의 rootpower로는 table_count 밖에 알 수 없기 때문에, 루트테이블의 크기를 저장하는 변수를 추가하였습니다.

### macro 

* 'VARIABLE_SIZED_ROOTTABLE' 이라는 태그를 추가하였습니다.
* 루트 테이블의 크기와 관련되어 있다는 점이 분명하게 드러나도록 'DEFAULT_ROOTPOWER' 를 'DEFAULT_ROOT_SIZE_POWER' 로 변경하였습니다.

### assoc_init()

* 에러 핸들링을 if문 하나로 통일하였습니다.

### assoc_expand()

* 해쉬테이블이 확장할 때 마다 루트테이블을 같이 확장하던 코드를, table_count 가 두 배가 되었을 때 기존의 루트 테이블이 부족할 경우에만 realloc 하도록 고쳤습니다.


