### PR TITLE
CLEANUP: reduce initial size of roottable and realloc as necessary

### DIFF
--- a/engines/default/assoc.h
+++ b/engines/default/assoc.h
@@ -58,6 +58,7 @@ struct assoc {
     uint32_t hashsize;  /* hash table size */
     uint32_t hashmask;  /* hash bucket mask */
     uint32_t rootpower; /* how many hash tables we use ? (power of 2) */
+    uint32_t rootsize;
 
     /* cache item hash table : an array of hash tables */
     struct table {


### PR DESCRIPTION
vim 에디터의 자동 indentation 때문에 정렬이 바뀌는 문제가 있었습니다.

수정해서 다시 PR합니다.