### PR TITLE
CLEANUP: reduce initial size of roottable and realloc as necessary

### DIFF
--- a/engines/default/assoc.h
+++ b/engines/default/assoc.h
@@ -58,6 +58,7 @@ struct assoc {
     uint32_t hashsize;  /* hash table size */
     uint32_t hashmask;  /* hash bucket mask */
     uint32_t rootpower; /* how many hash tables we use ? (power of 2) */
+    uint32_t rootsize;
 
     /* cache item hash table : an array of hash tables */
     struct table {


### PR DESCRIPTION
### root_size_power →  rootsize


제곱 연산을 하는 대신에 직접 크기를 저장하게 바꾸었습니다.  

### assoc_expand()의 code tag 문제

code tag로 표현된 변경점과 기존 코드가 완전히 분리될 수 있도록 바꾸었습니다.

realloc이 실패했을 경우 뒤의 해쉬 테이블 확장도 하면 안되기 때문에, 중간에 return 하도록 처리했습니다.
