### PR TITLE
FIX: memory leak when getting hostname by address

### DIFF
--- a/arcus_zk.c
+++ b/arcus_zk.c
@@ -1065,7 +1065,7 @@ static int arcus_build_znode_name(char *ensemble_list)
         hp = gethostbyaddr((char*)&myaddr.sin_addr.s_addr,
                             sizeof(myaddr.sin_addr.s_addr), AF_INET);
         if (hp) {
-            hostp = strdup(hp->h_name);
+            hostp = hp->h_name;
         } else {
             // if gethostbyaddr() doesn't work, try gethostname
             if (gethostname((char *)&hostbuf, sizeof(hostbuf))) {


### PR DESCRIPTION
arcus_zk에서 gethostbyaddr 호출 시 발생되는 메모리 leak을 수정한 코드입니다.