### PR TITLE
[persistence] add config file for default engine config

### DIFF
--- a/engines/default/default_engine.conf
+++ b/engines/default/default_engine.conf
@@ -1,0 +1,10 @@
+# This is a default engine config file
+
+# collection max size (default : 50000)
+# The collection max size limits the maximum number of elements that can be stored
+# in each collection item. Its hard limit is 1000000.
+#max_list_size=50000
+#max_set_size=50000
+#max_map_size=50000
+#max_btree_size=50000
+


### PR DESCRIPTION
default_engine의 설정값 파일로 관리하기 위해,
default_engine.conf 파일을 추가 했습니다.
collection max size의 경우 duplicate entry warning 이 출력되서 제거했고,
item_size_max 설정만 추가 했습니다.

모든 설정을 확인해보지 않았지만,
item_size_max의 경우 conf 파일에 있는 설정값으로 설정됩니다.

@jhpark816 
확인 요청 드립니다.