### PR TITLE
[persistence] added use_persistence config in default_engine.conf file

### DIFF
--- a/engines/default/default_engine.c
+++ b/engines/default/default_engine.c
@@ -1615,8 +1615,7 @@ create_instance(uint64_t interface, GET_SERVER_API get_server_api,
       .config = {
          .use_cas = true,
 #ifdef ENABLE_PERSISTENCE_03_CHECKPOINT
-         /* FIXME: default value must be false. now temporarily true */
-         .use_persistence = true,
+         .use_persistence = false,
 #endif
          .verbose = 0,
          .oldest_live = 0,

--- a/engines/default/default_engine.conf
+++ b/engines/default/default_engine.conf
@@ -8,3 +8,5 @@
 #max_map_size=50000
 #max_btree_size=50000
 
+# use persistence (true or false, default: false)
+use_persistence=false


### PR DESCRIPTION
#219 persistence 기능 on/off를 위한 옵션추가 PR 입니다.

defualt_engine.conf 파일 내부에 use_persistence로 구동 시 on/off 할 수 있습니다.
기본값은 off 상태입니다.

@jhpark816 
확인 요청 드립니다.