### PR TITLE
TEST: add error message when file open fails

### DIFF
--- a/t/whitespace.t
+++ b/t/whitespace.t
@@ -33,7 +33,7 @@ BEGIN {
 use Test::More tests => scalar(@files);
 
 foreach my $f (@files) {
-    open(my $fh, $f) or die;
+    open(my $fh, $f) or die "$f (failed file open)";
     my $before = do { local $/; <$fh>; };
     close ($fh);
     my $after = $before;


### PR DESCRIPTION
whitespace test에서, file open이 실패했을 때
error message 추가 PR 입니다.

whitespace 를 발견해서 테스트가 실패 할 경우 해당 file name을 출력 해주지만,
file open 이 실패할 경우 출력해주지 않고 종료되어서 원인을 찾기 어려운 문제가 있었습니다.

@jhpark816 
확인 요청 드립니다.