### PR TITLE
[persistence] fix ovflact text

### DIFF
--- a/engines/default/cmdlogrec.c
+++ b/engines/default/cmdlogrec.c
@@ -101,7 +101,7 @@ static uint8_t get_it_link_updtype(uint8_t type)
 
 static char *get_coll_ovflact_text(uint8_t ovflact)
 {
-    char *ovfarr[7] = { "error", "head_trim", "tail_trim",
+    char *ovfarr[8] = { "null", "error", "head_trim", "tail_trim",
                         "smallest_trim", "largest_trim",
                         "smallest_silent_trim", "largest_silent_trim" };
 


### PR DESCRIPTION
persistence 에서 overflow action text array가 잘못되어 수정 했습니다.
ENGINE_OVFL_ACTION enum이 1부터 시작하는데, text array는 0부터 error인 상태입니다.

@jhpark816 
확인 요청 드립니다.