### PR TITLE
CLEANUP: fixed cppcheck warning(exlclude items.c memcached.c)

### DIFF
--- a/engines/default/items.c
+++ b/engines/default/items.c
@@ -4877,6 +4877,7 @@ static ENGINE_ERROR_CODE do_btree_elem_get_by_posi(btree_meta_info *info,
     assert(node->ndepth == 0);
     posi.node = node;
     posi.indx = index-tot_ecnt;
+    posi.bkeq = false;
 
     elem = BTREE_GET_ELEM_ITEM(posi.node, posi.indx);
     elem->refcount++;

--- a/testapp.c
+++ b/testapp.c
@@ -599,6 +599,7 @@ static enum test_return test_config_parser(void) {
     items[3].found = false;
     */
     /* Plain string */
+    assert(string_val);
     assert(parse_config("string=sval", items, error) == 0);
     assert(items[3].found);
     assert(strcmp(string_val, "sval") == 0);
@@ -698,6 +699,7 @@ static enum test_return test_config_parser(void) {
     assert(fgets(buffer, sizeof(buffer), error) == NULL);
 
     remove(outfile);
+    fclose(error);
     return TEST_PASS;
 }
 
@@ -1953,6 +1955,7 @@ static enum test_return test_binary_pipeline_hickup(void)
     if ((ret = pthread_create(&tid, NULL,
                               binary_hickup_recv_verification_thread, NULL)) != 0) {
         fprintf(stderr, "Can't create thread: %s\n", strerror(ret));
+        free(buffer);
         return TEST_FAIL;
     }
 


### PR DESCRIPTION
cppcheck에서 경고가 나오는 부분을 수정했습니다.

대부분 변수의 스코프를 더 줄여서 쓰라는 경고입니다.

testapp.c에서는 메모리를 해제하지 않거나 파일을 열기만 하고 닫지 않는 문제가 있어 수정했습니다.

함수가 만들어지기만 하고 쓰이지 않았다는 경고( The function 'foo' is never used)도 뜨는데 작성한 함수를 지우는 건 부적절 한 것 같아 일단 내버려두었습니다. 

디폴트 엔진의 items.c 와 memcached.c에는 경고가 너무 많아 일단 두 파일을 제외하고 PR합니다.

리뷰가 끝나면 나머지 두 파일도 수정하겠습니다.  