### PR TITLE
[persistence] fix passing nprefix value with -1 to dump all cache items.

### DIFF
--- a/engines/default/checkpoint.c
+++ b/engines/default/checkpoint.c
@@ -200,7 +200,7 @@ static int do_checkpoint(chkpt_st *cs, bool *need_remove)
         return CHKPT_ERROR;
     }
 
-    if (mc_snapshot_direct(MC_SNAPSHOT_MODE_DATA, NULL, 0, cs->path) == ENGINE_SUCCESS) {
+    if (mc_snapshot_direct(MC_SNAPSHOT_MODE_DATA, NULL, -1, cs->path) == ENGINE_SUCCESS) {
         cs->lasttime = newtime;
         ret = CHKPT_SUCCESS;
     } else {


### PR DESCRIPTION
모든 캐시 데이터를 덤프하도록 nprefix 값은 -1로 넘겨주어야 함.

Reviewer
- [ ] @jhpark816 