### PR TITLE
CLEANUP: fixed cppcheck's warning

### DIFF
--- a/basic_engine_testsuite.c
+++ b/basic_engine_testsuite.c
@@ -52,7 +52,8 @@ static enum test_result get_info_features_test(ENGINE_HANDLE *h, ENGINE_HANDLE_V
     assert (nfeats > 0);
     const feature_info *fi = info->features;
     while (nfeats-- > 0) {
-        assert(fi++ != NULL);
+        assert(fi != NULL);
+        fi++;
     }
 
     return SUCCESS;

--- a/cluster_config.c
+++ b/cluster_config.c
@@ -137,7 +137,7 @@ static int gen_node_continuum(struct cont_item *continuum,
 {
     char buffer[MAX_NODE_NAME_LENGTH+1] = "";
     int  length;
-    int  hh, nn, pp;
+    unsigned int  hh, nn, pp;
     unsigned char digest[16];
     bool duplicate = 0;
 

--- a/memcached.c
+++ b/memcached.c
@@ -9287,7 +9287,7 @@ static void process_verbosity_command(conn *c, token_t *tokens, const size_t nto
 
     if (ntokens == 3) {
         char buf[50];
-        sprintf(buf, "verbosity %u\r\nEND", settings.verbose);
+        sprintf(buf, "verbosity %d\r\nEND", settings.verbose);
         out_string(c, buf);
     } else if (ntokens == 4 && safe_strtoul(config_val, &level)) {
         if (level > MAX_VERBOSITY_LEVEL) {
@@ -15284,7 +15284,7 @@ int main (int argc, char **argv) {
                         "Chunk size must be greater than 0\n");
                 return 1;
             }
-            old_opts += sprintf(old_opts, "chunk_size=%u;", settings.chunk_size);
+            old_opts += sprintf(old_opts, "chunk_size=%d;", settings.chunk_size);
             break;
         case 't':
             settings.num_threads = atoi(optarg);

--- a/sasl_defs.c
+++ b/sasl_defs.c
@@ -31,7 +31,7 @@ static int sasl_server_userdb_checkpass(sasl_conn_t *conn,
     size_t unmlen = strlen(user);
     if ((passlen + unmlen) > (MAX_ENTRY_LEN - 4)) {
         fprintf(stderr,
-                "WARNING: Failed to authenticate <%s> due to too long password (%d)\n",
+                "WARNING: Failed to authenticate <%s> due to too long password (%u)\n",
                 user, passlen);
         return SASL_NOAUTHZ;
     }

--- a/testapp.c
+++ b/testapp.c
@@ -315,7 +315,7 @@ static pid_t start_server(in_port_t *port_out, bool daemon, int timeout) {
         char *argv[20];
         int arg = 0;
         char tmo[24];
-        snprintf(tmo, sizeof(tmo), "%u", timeout);
+        snprintf(tmo, sizeof(tmo), "%d", timeout);
 
         putenv(environment);
 

--- a/thread.c
+++ b/thread.c
@@ -471,7 +471,8 @@ void notify_io_complete(const void *cookie, ENGINE_ERROR_CODE status)
         conn->next = thr->pending_io;
         thr->pending_io = conn;
     }
-    assert(number_of_pending(conn, thr->pending_io) == 1);
+    int pending = number_of_pending(conn, thr->pending_io);
+    assert(pending == 1);
 
     UNLOCK_THREAD(thr);
 


### PR DESCRIPTION
cppcheck에서 warning 띄우는 부분을 수정했습니다.


argument는 int인데 type specifier는 unsigned int일 경우에는 type specifier를 고쳤습니다.  단 cluster_config.c:146 의 경우 hh, nn, pp가 모두 for문의 인덱스로 쓰이는 변수들이라 unsigned로 고쳤습니다.  

```
[basic_engine_testsuite.c:55]: (warning) Assert statement modifies 'fi'.
[cluster_config.c:146]: (warning) %u in format string (no. 2) requires 'unsigned int' but the argument type is 'int'.
[memcached.c:9290]: (warning) %u in format string (no. 1) requires 'unsigned int' but the argument type is 'int'.
[memcached.c:15287]: (warning) %u in format string (no. 1) requires 'unsigned int' but the argument type is 'int'.
[sasl_defs.c:33]: (warning) %d in format string (no. 2) requires 'int' but the argument type is 'unsigned int'.
[testapp.c:318]: (warning) %u in format string (no. 1) requires 'unsigned int' but the argument type is 'int'.
[thread.c:474]: (warning) Assert statement calls a function which may have desired side effects: 'number_of_pending'.
```
