### PR TITLE
[persistence] get file path and async_logging from engine conf file.

### DIFF
--- a/engines/default/default_engine.c
+++ b/engines/default/default_engine.c
@@ -120,6 +120,15 @@ initialize_configuration(struct default_engine *se, const char *cfg_str)
             { .key = "use_persistence",
               .datatype = DT_BOOL,
               .value.dt_bool = &se->config.use_persistence },
+            { .key = "data_path",
+              .datatype = DT_STRING,
+              .value.dt_string = &se->config.data_path },
+            { .key = "logs_path",
+              .datatype = DT_STRING,
+              .value.dt_string = &se->config.logs_path },
+            { .key = "async_logging",
+              .datatype = DT_BOOL,
+              .value.dt_bool = &se->config.async_logging },
 #endif
             { .key = "verbose",
               .datatype = DT_SIZE,
@@ -1575,6 +1584,9 @@ create_instance(uint64_t interface, GET_SERVER_API get_server_api,
          .use_cas = true,
 #ifdef ENABLE_PERSISTENCE
          .use_persistence = false,
+         .data_path = NULL,
+         .logs_path = NULL,
+         .async_logging = true, /* FIXME: change it after implementing sync logging(default=false). */
 #endif
          .verbose = 0,
          .oldest_live = 0,

--- a/engines/default/default_engine.conf
+++ b/engines/default/default_engine.conf
@@ -13,11 +13,11 @@
 #
 # use persistence (true or false, default: false)
 use_persistence=false
-
-# data file path
+#
+# data file path (required)
 #data_path=<data_path>
 #
-# logs file path
+# logs file path (required)
 #logs_path=<logs_path>
 #
 # asynchronous logging

--- a/engines/default/default_engine.h
+++ b/engines/default/default_engine.h
@@ -47,6 +47,9 @@ struct engine_config {
    bool   use_cas;
 #ifdef ENABLE_PERSISTENCE
    bool   use_persistence;
+   char   *data_path;
+   char   *logs_path;
+   bool   async_logging;
 #endif
    size_t verbose;
    rel_time_t oldest_live;


### PR DESCRIPTION
issue : https://github.com/naver/arcus-memcached/issues/268

data_path, log_path, async_logging 설정 값을 받을 수 있도록 처리.

@jhpark816 검토 부탁드립니다.