### PR TITLE
FIX: could refer invalid memory space in trim_copy().

### DIFF
--- a/config_parser.c
+++ b/config_parser.c
@@ -51,10 +51,13 @@ static int trim_copy(char *dest, size_t size, const char *src,
 
    /* Find the last non-escaped non-space character */
    const char *lastchar = src + strlen(src) - 1;
+   if (lastchar < src) {
+       return -1;
+   }
    while (lastchar > src && isspace(*lastchar)) {
        lastchar--;
    }
-   if (lastchar < src || *lastchar == '\\') {
+   if (*lastchar == '\\') {
        lastchar++;
    }
    assert(lastchar >= src);


### PR DESCRIPTION
key=value 형태로 이루어진 config file 을 line 별로 읽을 때 
trim_copy() 를 통해 key와 value 를 parsing 한다.

현재 value 가 없는 line을 parsing 할 때 포인터가 invalid 한 곳을 가리키는 문제가 있다.

예를들어 data_path= 와 같이 value 가 주어지지 않은 line 은 파일에는 data_path=LF 기록이 되어 있고,
fget 으로 인해 받은 문자열은 (data_path=LF'\0') 을 받는다.
key 파싱 이후에 src 는 LF 를 가리키고 있고, value 파싱 시에
isspace 와 do~while 쪽에서 src 포인터를 각각 증가시켜 유효 메모리 범위를 넘어서게 된다. 

Reviewer
- [ ] @jhpark816 
