### PR TITLE
FEATURE: add coverage test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,30 @@ compiler:
   - clang
   - gcc
 
+env:
+  - COVERAGE_FLAGS="--enable-coverage"
+  - COVERAGE_FLAGS=""
+
+matrix:
+  exclude:
+    - compiler: clang
+      env: COVERAGE_FLAGS="--enable-coverage"
+
 script:
   - sudo apt-get install -qq build-essential autoconf automake libtool libcppunit-dev libevent-dev
   - ./config/autorun.sh
-  - ./configure
+  - ./configure $COVERAGE_FLAGS
   - make
   - make test
+
+after_success:
+  - |
+    if [[ ! -z $COVERAGE_FLAGS ]]
+    then
+        sudo apt-get install lcov
+        gem install coveralls-lcov
+        lcov -d . -c -o coverage.info && coveralls-lcov coverage.info
+    fi
 
 notifications:
   email:

--- a/Makefile.am
+++ b/Makefile.am
@@ -65,7 +65,7 @@ libmcd_util_la_SOURCES= \
                         mock_server.c \
                         util.c
 
-AM_CFLAGS = @COMMON_CFLAGS@
+AM_CFLAGS = @PROFILER_FLAGS@ @COMMON_CFLAGS@
 memcached_SOURCES = \
                     cache.h \
                     config_static.h \


### PR DESCRIPTION
커버리지 테스트를 위해 travisl.yml에서 coveralls 관련 동작을 추가했습니다.

gcc + 커버리지 측정, clang + 커버리지 측정, gcc 커버리지 없음, clang 커버리지 없음 이렇게 네 가지가 동시에 빌드됩니다.

커버리지 플래그가 있을 때에만 관련한 스크립트가 동작하도록 작성했습니다.

커버리지 측정 조건을 넣어서 clang으로 컴파일하면 default.profraw 라는 파일이 생기는데 이게 whitespace.t 테스트에 자꾸 걸려서 예외 조건에 추가했습니다.