### PR TITLE
[persistence] make checkpoint time unique.

### DIFF
--- a/engines/default/mc_snapshot.c
+++ b/engines/default/mc_snapshot.c
@@ -810,7 +810,7 @@ int mc_snapshot_file_apply(const char *filepath)
     return ret;
 }
 
-int mc_snapshot_get_chkpttime(const int fd, int *lasttime)
+int mc_snapshot_get_chkpttime(const int fd, int64_t *lasttime)
 {
     return 0;
 }

--- a/engines/default/mc_snapshot.h
+++ b/engines/default/mc_snapshot.h
@@ -40,7 +40,7 @@ void mc_snapshot_stats(ADD_STAT add_stat, const void *cookie);
 
 #ifdef ENABLE_PERSISTENCE
 int mc_snapshot_file_apply(const char *filepath);
-int mc_snapshot_get_chkpttime(const int fd, int *lasttime);
+int mc_snapshot_get_chkpttime(const int fd, int64_t *lasttime);
 #endif
 
 #endif


### PR DESCRIPTION
issue : https://github.com/naver/arcus-memcached/issues/295 을 해결하기 위한 PR.

checkpoint 식별자인 checkpoint time 을 unique 한 값으로 만들기 위해 
tm_mday(일, 1 ~ 31) 와 tm_mon(월, 0 ~ 11) 를 추가로 더 해줌.

@jhpark816 검토 부탁드립니다.