### PR TITLE
TEST: add apt-get update to prevent package installation from failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
       env: COVERAGE_FLAGS="--enable-coverage"
 
 script:
+  - sudo apt-get update -qq
   - sudo apt-get install -qq build-essential autoconf automake libtool libcppunit-dev libevent-dev
   - ./config/autorun.sh
   - ./configure $COVERAGE_FLAGS


### PR DESCRIPTION
travis ci test 환경 구축 중 package 설치 실패를 방지하기 위해
apt-get update를 수행하고 package 설치하도록 수정 했습니다.

Error log
```
E: Package 'libcppunit-dev' has no installation candidate
```

@jhpark816 
확인 요청 드립니다.