### PR TITLE
[persistence] fix to write maxbkeyrange value if item type is simple kv.

### DIFF
--- a/engines/default/cmdlogrec.c
+++ b/engines/default/cmdlogrec.c
@@ -840,6 +840,7 @@ int lrec_construct_setattr(LogRec *logrec, hash_item *it, uint8_t updtype)
     ITSetAttrLog *log = (ITSetAttrLog*)logrec;
     log->keyptr = (char*)item_get_key(it);
     log->body.keylen = it->nkey;
+    log->body.maxbkrlen = BKEY_NULL;
 
     int naddition = 0;
     switch (updtype) {
@@ -859,12 +860,9 @@ int lrec_construct_setattr(LogRec *logrec, hash_item *it, uint8_t updtype)
           if (updtype == UPD_SETATTR_EXPTIME_INFO_BKEY) {
               log->body.maxbkrlen = ((btree_meta_info*)info)->maxbkeyrange.len;
               log->maxbkrptr      = ((btree_meta_info*)info)->maxbkeyrange.val;
-          } else {
-              log->body.maxbkrlen = BKEY_NULL;
-              log->maxbkrptr      = NULL;
-          }
-          if (log->body.maxbkrlen != BKEY_NULL) {
-              naddition = BTREE_REAL_NBKEY(log->body.maxbkrlen);
+              if (log->body.maxbkrlen != BKEY_NULL) {
+                  naddition = BTREE_REAL_NBKEY(log->body.maxbkrlen);
+              }
           }
       }
       break;


### PR DESCRIPTION
setattr 명령 시 아이템 타입이 simple kv 인 경우에 maxbkeyrange value copy 가 일어나는 버그를 수정.

```
static void lrec_it_setattr_write(LogRec *logrec, char *bufptr)
{
    ITSetAttrLog *log = (ITSetAttrLog*)logrec;
    int offset = sizeof(LogHdr) + offsetof(ITSetAttrData, data);

    memcpy(bufptr, (void*)logrec, offset);

    if (log->body.maxbkrlen != BKEY_NULL) { //simple kv 인 경우 이 값을 초기화시키지 않아서 실행됨.
        /* maxbkeyrange value copy */
        memcpy(bufptr + offset, log->maxbkrptr, BTREE_REAL_NBKEY(log->body.maxbkrlen));
        offset += BTREE_REAL_NBKEY(log->body.maxbkrlen);
    }
```

@jhpark816 검토 부탁드립니다.