### PR TITLE
[persistence] set enable change log after recovery.

### DIFF
--- a/engines/default/cmdlogmgr.c
+++ b/engines/default/cmdlogmgr.c
@@ -24,6 +24,7 @@
 #include "cmdlogmgr.h"
 #include "cmdlogbuf.h"
 #include "checkpoint.h"
+#include "item_clog.h"
 
 typedef struct _wait_entry_info {
     int16_t           free_list;
@@ -176,6 +177,9 @@ ENGINE_ERROR_CODE cmdlog_mgr_init(struct default_engine* engine)
     if (ret != ENGINE_SUCCESS) {
         return ret;
     }
+    /* set enable change log */
+    (void)item_clog_set_enable(true);
+
     ret = cmdlog_buf_flush_thread_start();
     if (ret != ENGINE_SUCCESS) {
         return ret;

--- a/engines/default/item_clog.c
+++ b/engines/default/item_clog.c
@@ -296,11 +296,6 @@ void item_clog_init(struct default_engine *engine)
     config = &engine->config;
     logger = engine->server.log->get_logger();
 
-    /* set enable change log */
-#ifdef ENABLE_PERSISTENCE
-    if (config->use_persistence) item_clog_set_enable(true);
-#endif
-
     logger->log(EXTENSION_LOG_INFO, NULL, "ITEM change log module initialized.\n");
 }
 


### PR DESCRIPTION
recovery 때 redo 된 명령어들이 로그파일에 반영되지 않도록
recovery 가 끝난 후에 item_clog 가 enable 되도록 수정.

*즉시 재시작을 고려하지 않은 구현

@jhpark816 검토 부탁드립니다.