### PR TITLE
TEST: reduce parallel jobs to 3 for prevent concurrency problems

### DIFF
--- a/run_test.pl
+++ b/run_test.pl
@@ -5,7 +5,7 @@ use Cwd;
 my $engine_name = shift;
 my $script_type = shift;
 my @engine_list = ("default");
-my $opt = '--job 5'; # --job N : run N test jobs in parallel
+my $opt = '--job 3'; # --job N : run N test jobs in parallel
 my $srcdir = getcwd;
 my $ext = "s";
 


### PR DESCRIPTION
travis 환경에서 unit test 수행 시 동시성 문제로 인해
used port로 구동 실패하는 에러가 가끔 발생하는 상태입니다.

이러한 문제를 방지하기 위해 기존 5개 씩 병렬로 진행하는 현재 상태에서 3으로 변경 했습니다.

@jhpark816 
확인 요청 드립니다.