### PR TITLE
[persistence] fix gcc int type error. use macro not dependent on system.

### DIFF
--- a/engines/default/checkpoint.c
+++ b/engines/default/checkpoint.c
@@ -30,7 +30,7 @@
 #include "cmdlogbuf.h"
 
 #define CHKPT_MAX_FILENAME_LENGTH  255
-#define CHKPT_FILE_NAME_FORMAT     "%s/%s%ld"
+#define CHKPT_FILE_NAME_FORMAT     "%s/%s%"PRId64
 #define CHKPT_SNAPSHOT_PREFIX      "snapshot_"
 #define CHKPT_CMDLOG_PREFIX        "cmdlog_"
 


### PR DESCRIPTION
int64_t 가 시스템 종속적인 타입이어서 포맷이 일치하지 않는 경우가 있어 에러가 발생합니다.
PRId64 매크로를 사용하도록 변경하였습니다.

@jhpark816 검토 부탁드립니다.