### PR TITLE
[persistence] set last size of snapshot file.

### DIFF
--- a/engines/default/checkpoint.c
+++ b/engines/default/checkpoint.c
@@ -365,7 +365,7 @@ int chkpt_recovery_analysis(void)
         logger->log(EXTENSION_LOG_INFO, NULL,
                     "Check that %s is valid snapshot file for recovery.\n",
                     cs->snapshot_path);
-        if (mc_snapshot_check_file_validity(snapshot_fd) == 0) {
+        if (mc_snapshot_check_file_validity(snapshot_fd, &cs->lastsize) == 0) {
             cs->lasttime = atoll(strchr(ent->d_name, '_') + 1);
             assert(cs->lasttime != 0);
             close(snapshot_fd);

--- a/engines/default/mc_snapshot.c
+++ b/engines/default/mc_snapshot.c
@@ -691,7 +691,7 @@ void mc_snapshot_stats(ADD_STAT add_stat, const void *cookie)
 
 #ifdef ENABLE_PERSISTENCE
 /* Check snapshot file validity by inspecting snapshottail log record. */
-int mc_snapshot_check_file_validity(const int fd)
+int mc_snapshot_check_file_validity(const int fd, size_t *filesize)
 {
     assert(fd > 0);
 
@@ -709,6 +709,7 @@ int mc_snapshot_check_file_validity(const int fd)
         return -1;
     }
 
+    *filesize = sizeof(log) + offset;
     lseek(fd, 0, SEEK_SET);
 
     return lrec_check_snapshot_tail(&log);

--- a/engines/default/mc_snapshot.h
+++ b/engines/default/mc_snapshot.h
@@ -39,7 +39,7 @@ void mc_snapshot_stop(void);
 void mc_snapshot_stats(ADD_STAT add_stat, const void *cookie);
 
 #ifdef ENABLE_PERSISTENCE
-int mc_snapshot_check_file_validity(const int fd);
+int mc_snapshot_check_file_validity(const int fd, size_t *filesize);
 int mc_snapshot_file_apply(const char *filepath);
 #endif
 


### PR DESCRIPTION
snapshot backup file 이 있는 경우 다음 체크포인트는 이 파일의 size 기반으로 동작해야하므로
cs->lastsize 를 세팅합니다.

```
 static bool do_checkpoint_needed(chkpt_st *cs)
 {
     struct engine_config *config = cs->config;
     size_t snapshot_file_size = cs->lastsize;
     size_t cmdlog_file_size   = cmdlog_file_getsize();
     size_t min_logsize        = config->chkpt_interval_min_logsize;
     int    pct_snapshot       = config->chkpt_interval_pct_snapshot;

     if ((cmdlog_file_size < min_logsize) ||
         (cmdlog_file_size < (snapshot_file_size + (snapshot_file_size*(pct_snapshot*0.01))))) {
         return false;
     }
     return true;
 }
```
@jhpark816 검토 부탁드립니다.