### PR TITLE
[persistence] remove not needed updtype.

### DIFF
--- a/engines/default/cmdlogrec.h
+++ b/engines/default/cmdlogrec.h
@@ -57,14 +57,10 @@ enum upd_type {
     UPD_MAP_CREATE,
     UPD_MAP_ELEM_INSERT,
     UPD_MAP_ELEM_DELETE,
-    UPD_MAP_ELEM_UPDATE,
     /* btree command */
     UPD_BT_CREATE,
     UPD_BT_ELEM_INSERT,
-    UPD_BT_ELEM_UPSERT,
     UPD_BT_ELEM_DELETE,
-    UPD_BT_ELEM_UPDATE,
-    UPD_BT_ELEM_ARITHMETIC,
     /* not command */
     UPD_NONE
 };


### PR DESCRIPTION
update, arithmetic 명령은 복구 시에 insert 명령으로 재수행하므로 필요 없어진 upd type 들을 제거하였습니다. 

@jhpark816 검토 부탁드립니다.