### PR TITLE
FEATURE: List element free

### DIFF
--- a/engines/default/default_engine.c
+++ b/engines/default/default_engine.c
@@ -400,6 +400,13 @@ default_list_elem_alloc(ENGINE_HANDLE* handle, const void* cookie,
     return ret;
 }
 
+#ifdef INSERT_FIX
+static void
+default_list_elem_free(ENGINE_HANDLE* handle, const void *cookie, eitem *eitem)
+{
+    list_elem_free((list_elem_item*)eitem);
+}
+#endif
 static void
 default_list_elem_release(ENGINE_HANDLE* handle, const void *cookie,
                           eitem **eitem_array, const int eitem_count)
@@ -1475,6 +1482,9 @@ create_instance(uint64_t interface, GET_SERVER_API get_server_api,
          /* LIST Collection API */
          .list_struct_create = default_list_struct_create,
          .list_elem_alloc   = default_list_elem_alloc,
+#ifdef INSERT_FIX
+         .list_elem_free    = default_list_elem_free,
+#endif
          .list_elem_release = default_list_elem_release,
          .list_elem_insert  = default_list_elem_insert,
          .list_elem_delete  = default_list_elem_delete,

--- a/engines/default/items.c
+++ b/engines/default/items.c
@@ -1515,7 +1515,11 @@ static list_elem_item *do_list_elem_alloc(const uint32_t nbytes, const void *coo
         assert(elem->slabs_clsid == 0);
         elem->slabs_clsid = slabs_clsid(ntotal);
         assert(elem->slabs_clsid > 0);
+#ifdef INSERT_FIX
+        elem->refcount    = 0;
+#else
         elem->refcount    = 1;
+#endif
         elem->nbytes      = nbytes;
         elem->prev = elem->next = (list_elem_item *)ADDR_MEANS_UNLINKED; /* Unliked state */
     }
@@ -6494,6 +6498,14 @@ list_elem_item *list_elem_alloc(const uint32_t nbytes, const void *cookie)
     return elem;
 }
 
+#ifdef INSERT_FIX
+void list_elem_free(list_elem_item *elem)
+{
+    LOCK_CACHE();
+    do_list_elem_free(elem);
+    UNLOCK_CACHE();
+}
+#endif
 void list_elem_release(list_elem_item **elem_array, const int elem_count)
 {
     int cnt = 0;

--- a/engines/default/items.h
+++ b/engines/default/items.h
@@ -418,6 +418,9 @@ ENGINE_ERROR_CODE list_struct_create(const char *key, const uint32_t nkey,
 
 list_elem_item *list_elem_alloc(const uint32_t nbytes, const void *cookie);
 
+#ifdef INSERT_FIX
+void list_elem_free(list_elem_item *elem);
+#endif
 void list_elem_release(list_elem_item **elem_array, const int elem_count);
 
 ENGINE_ERROR_CODE list_elem_insert(const char *key, const uint32_t nkey,

--- a/engines/demo/demo_engine.c
+++ b/engines/demo/demo_engine.c
@@ -290,6 +290,13 @@ Demo_list_elem_alloc(ENGINE_HANDLE* handle, const void* cookie,
     return ENGINE_ENOTSUP;
 }
 
+#ifdef INSERT_FIX
+static void
+Demo_list_elem_free(ENGINE_HANDLE* handle, const void *cookie, eitem *eitem)
+{
+    return;
+}
+#endif
 static void
 Demo_list_elem_release(ENGINE_HANDLE* handle, const void *cookie,
                           eitem **eitem_array, const int eitem_count)
@@ -768,6 +775,9 @@ create_instance(uint64_t interface, GET_SERVER_API get_server_api,
          /* LIST Collection API */
          .list_struct_create = Demo_list_struct_create,
          .list_elem_alloc   = Demo_list_elem_alloc,
+#ifdef INSERT_FIX
+         .list_elem_free    = Demo_list_elem_free,
+#endif
          .list_elem_release = Demo_list_elem_release,
          .list_elem_insert  = Demo_list_elem_insert,
          .list_elem_delete  = Demo_list_elem_delete,

--- a/include/memcached/engine.h
+++ b/include/memcached/engine.h
@@ -351,6 +351,9 @@ extern "C" {
                                              const void* key, const int nkey,
                                              const size_t nbytes, eitem** eitem);
 
+#ifdef INSERT_FIX
+        void (*list_elem_free)(ENGINE_HANDLE* handle, const void* cookie, eitem *eitem);
+#endif
         void (*list_elem_release)(ENGINE_HANDLE* handle, const void *cookie,
                                   eitem **eitem_array, const int eitem_count);
 

--- a/include/memcached/types.h
+++ b/include/memcached/types.h
@@ -39,6 +39,7 @@ struct iovec {
 #define JHPARK_OLD_SMGET_INTERFACE
 #define MAX_EFLAG_COMPARE_COUNT 100
 
+#define INSERT_FIX
 
 #ifdef __cplusplus
 extern "C" {

--- a/memcached.c
+++ b/memcached.c
@@ -775,7 +775,11 @@ static void conn_coll_eitem_free(conn *c) {
     switch (c->coll_op) {
       /* lop */
       case OPERATION_LOP_INSERT:
+#ifdef INSERT_FIX
+        mc_engine.v1->list_elem_free(mc_engine.v0, c, c->coll_eitem);
+#else
         mc_engine.v1->list_elem_release(mc_engine.v0, c, &c->coll_eitem, 1);
+#endif
         break;
       case OPERATION_LOP_GET:
         mc_engine.v1->list_elem_release(mc_engine.v0, c, c->coll_eitem, c->coll_ecount);
@@ -1612,14 +1616,23 @@ static void process_lop_insert_complete(conn *c) {
     assert(c->coll_op == OPERATION_LOP_INSERT);
     assert(c->coll_eitem != NULL);
     eitem *elem = (eitem *)c->coll_eitem;
+#ifdef INSERT_FIX
+    ENGINE_ERROR_CODE ret;
+#endif
 
     mc_engine.v1->get_elem_info(mc_engine.v0, c, ITEM_TYPE_LIST, elem, &c->einfo);
 
     if (einfo_check_ascii_tail_string(&c->einfo) != 0) { /* check "\r\n" */
+#ifdef INSERT_FIX
+        ret = ENGINE_EINVAL;
+#endif
         out_string(c, "CLIENT_ERROR bad data chunk");
     } else {
         bool created;
+#ifdef INSERT_FIX
+#else
         ENGINE_ERROR_CODE ret;
+#endif
 
         ret = mc_engine.v1->list_elem_insert(mc_engine.v0, c,
                                              c->coll_key, c->coll_nkey, c->coll_index, elem,
@@ -1665,7 +1678,13 @@ static void process_lop_insert_complete(conn *c) {
         }
     }
 
+#ifdef INSERT_FIX
+    if (ret != ENGINE_SUCCESS) {
+        mc_engine.v1->list_elem_free(mc_engine.v0, c, elem);
+    }
+#else
     mc_engine.v1->list_elem_release(mc_engine.v0, c, &c->coll_eitem, 1);
+#endif
     c->coll_eitem = NULL;
 }
 
@@ -4657,8 +4676,14 @@ static void process_bin_lop_insert_complete(conn *c) {
             write_bin_packet(c, PROTOCOL_BINARY_RESPONSE_EINTERNAL, 0);
     }
 
+#ifdef INSERT_FIX
+    if (ret != ENGINE_SUCCESS) {
+        mc_engine.v1->list_elem_free(mc_engine.v0, c, elem);
+    }
+#else
     /* release the c->coll_eitem reference */
     mc_engine.v1->list_elem_release(mc_engine.v0, c, &c->coll_eitem, 1);
+#endif
     c->coll_eitem = NULL;
 }
 


### PR DESCRIPTION
- List에 element를 삽입 할 때 refcount를 증가시키는 부분은 필요하지 않아 증가/감소하지 않도록 하였습니다.

- Element 삽입 수행 실패 시, 또는 client로부터 데이터를 제대로 읽지 못한 경우 list_elem_free()를 호출하여 할당해두었던 element를 반환하게끔 수정했습니다.

list_elem_alloc() 다음에 list_elem_free()가 위치하도록 하였고,
process_lop_insert_complete()와 process_bin_lop_insert_complete() 모두에서 list_elem_free()를 호출하도록 하였습니다.

- [ ] @MinWooJin
- [ ] @jhpark816