### PR TITLE
[persistence] fixed passing improper struct type.

### DIFF
--- a/engines/default/cmdlogrec.c
+++ b/engines/default/cmdlogrec.c
@@ -1261,7 +1261,7 @@ int lrec_construct_map_elem_insert(LogRec *logrec, hash_item *it, map_elem_item 
 
     log->header.logtype = LOG_MAP_ELEM_INSERT;
     log->header.updtype = UPD_MAP_ELEM_INSERT;
-    log->header.body_length = GET_8_ALIGN_SIZE(offsetof(MapElemDelData, data) +
+    log->header.body_length = GET_8_ALIGN_SIZE(offsetof(MapElemInsData, data) +
                                                log->body.keylen + log->body.fldlen + log->body.vallen);
     return log->header.body_length+sizeof(LogHdr);
 }


### PR DESCRIPTION
map element insert 함수에서 map element delete struct type 을 사용하는 부분을 수정했습니다.

@jhpark816 검토 부탁드립니다.