### PR TITLE
[persistence] made checkpoint time human readable.

### DIFF
--- a/engines/default/checkpoint.c
+++ b/engines/default/checkpoint.c
@@ -66,16 +66,14 @@ static chkpt_st chkpt_anch;
 
 static int64_t getnowtime(void)
 {
+    char buf[20] = {0};
     int64_t ltime;
     time_t clock = time(0);
     struct tm *date = localtime(&clock);
 
-    ltime  = date->tm_year * 10000000000;
-    ltime += date->tm_mon  * 100000000;
-    ltime += date->tm_mday * 1000000;
-    ltime += date->tm_hour * 10000;
-    ltime += date->tm_min  * 100;
-    ltime += date->tm_sec;
+    /* year(YYYY) month(01-12) day(01-31) hour(00-23) minute(00-59) second(00-61). */
+    strftime(buf, 20, "%Y%m%d%H%M%S", date);
+    sscanf(buf, "%" SCNd64, &ltime);
     return ltime;
 }
 


### PR DESCRIPTION
checkpoint time 을 human readable 하게 만들었습니다.
format = year/month/day/hour/minute/second.

2019. 10. 07. 16:20:32 초에 checkpoint 수행 시 생성되는 파일 이름은.
snapshot(or cmdlog)_20191007162032 입니다.

reference : http://zetcode.com/articles/cdatetime/
%Y : year (XXXX)
%m : Month as a decimal number (01-12)
%d : Day of the month, zero-padded (01-31)
%H : Hour in 24h format (00-23)
%M : Minute (00-59)
%S : Second (00-61)

@jhpark816 검토 부탁드립니다.