### PR TITLE
FEATURE:Element Free

### DIFF
--- a/engines/default/default_engine.c
+++ b/engines/default/default_engine.c
@@ -506,6 +506,13 @@ default_set_elem_alloc(ENGINE_HANDLE* handle, const void* cookie,
     return ret;
 }
 
+#ifdef INSERT_FIX
+static void
+default_set_elem_free(ENGINE_HANDLE* handle, const void *cookie, eitem *eitem)
+{
+    set_elem_free((set_elem_item*)eitem);
+}
+#endif
 static void
 default_set_elem_release(ENGINE_HANDLE* handle, const void *cookie,
                          eitem **eitem_array, const int eitem_count)
@@ -618,6 +625,13 @@ default_map_elem_alloc(ENGINE_HANDLE* handle, const void* cookie,
     }
     return ret;
 }
+#ifdef INSERT_FIX
+static void
+default_map_elem_free(ENGINE_HANDLE* handle, const void *cookie, eitem *eitem)
+{
+    map_elem_free((map_elem_item*)eitem);
+}
+#endif
 
 static void
 default_map_elem_release(ENGINE_HANDLE* handle, const void *cookie,
@@ -730,6 +744,13 @@ default_btree_elem_alloc(ENGINE_HANDLE* handle, const void* cookie,
     return ret;
 }
 
+#ifdef INSERT_FIX
+static void
+default_btree_elem_free(ENGINE_HANDLE* handle, const void *cookie, eitem *eitem)
+{
+    btree_elem_free((btree_elem_item*)eitem);
+}
+#endif
 static void
 default_btree_elem_release(ENGINE_HANDLE* handle, const void *cookie,
                            eitem **eitem_array, const int eitem_count)
@@ -1489,6 +1510,9 @@ create_instance(uint64_t interface, GET_SERVER_API get_server_api,
          /* SET Colleciton API */
          .set_struct_create = default_set_struct_create,
          .set_elem_alloc    = default_set_elem_alloc,
+#ifdef INSERT_FIX
+         .set_elem_free     = default_set_elem_free,
+#endif
          .set_elem_release  = default_set_elem_release,
          .set_elem_insert   = default_set_elem_insert,
          .set_elem_delete   = default_set_elem_delete,
@@ -1497,6 +1521,9 @@ create_instance(uint64_t interface, GET_SERVER_API get_server_api,
          /* MAP Collection API */
          .map_struct_create = default_map_struct_create,
          .map_elem_alloc    = default_map_elem_alloc,
+#ifdef INSERT_FIX
+         .map_elem_free     = default_map_elem_free,
+#endif
          .map_elem_release  = default_map_elem_release,
          .map_elem_insert   = default_map_elem_insert,
          .map_elem_update   = default_map_elem_update,
@@ -1505,6 +1532,9 @@ create_instance(uint64_t interface, GET_SERVER_API get_server_api,
          /* B+Tree Collection API */
          .btree_struct_create = default_btree_struct_create,
          .btree_elem_alloc   = default_btree_elem_alloc,
+#ifdef INSERT_FIX
+         .btree_elem_free    = default_btree_elem_free,
+#endif
          .btree_elem_release = default_btree_elem_release,
          .btree_elem_insert  = default_btree_elem_insert,
          .btree_elem_update  = default_btree_elem_update,

--- a/engines/default/items.c
+++ b/engines/default/items.c
@@ -1832,7 +1832,11 @@ static set_elem_item *do_set_elem_alloc(const uint32_t nbytes, const void *cooki
         assert(elem->slabs_clsid == 0);
         elem->slabs_clsid = slabs_clsid(ntotal);
         assert(elem->slabs_clsid > 0);
+#ifdef INSERT_FIX
+        elem->refcount    = 0;
+#else
         elem->refcount    = 1;
+#endif
         elem->nbytes      = nbytes;
         elem->next = (set_elem_item *)ADDR_MEANS_UNLINKED; /* Unliked state */
     }
@@ -2391,7 +2395,11 @@ static btree_elem_item *do_btree_elem_alloc(const uint32_t nbkey, const uint32_t
         assert(elem->slabs_clsid == 0);
         elem->slabs_clsid = slabs_clsid(ntotal);
         assert(elem->slabs_clsid > 0);
+#ifdef INSERT_FIX
+        elem->refcount    = 0;
+#else
         elem->refcount    = 1;
+#endif
         elem->status      = BTREE_ITEM_STATUS_UNLINK; /* unlinked state */
         elem->nbkey       = (uint8_t)nbkey;
         elem->neflag      = (uint8_t)neflag;
@@ -6497,6 +6505,9 @@ list_elem_item *list_elem_alloc(const uint32_t nbytes, const void *cookie)
 void list_elem_free(list_elem_item *elem)
 {
     LOCK_CACHE();
+#ifdef INSERT_FIX
+    assert(elem->next == (list_elem_item *)ADDR_MEANS_UNLINKED);
+#endif
     do_list_elem_free(elem);
     UNLOCK_CACHE();
 }
@@ -6709,6 +6720,15 @@ set_elem_item *set_elem_alloc(const uint32_t nbytes, const void *cookie)
     UNLOCK_CACHE();
     return elem;
 }
+#ifdef INSERT_FIX
+void set_elem_free(set_elem_item *elem)
+{
+    LOCK_CACHE();
+    assert(elem->next == (set_elem_item *)ADDR_MEANS_UNLINKED);
+    do_set_elem_free(elem);
+    UNLOCK_CACHE();
+}
+#endif
 
 void set_elem_release(set_elem_item **elem_array, const int elem_count)
 {
@@ -6882,6 +6902,22 @@ btree_elem_item *btree_elem_alloc(const uint32_t nbkey, const uint32_t neflag, c
     return elem;
 }
 
+#ifdef INSERT_FIX
+void btree_elem_free(btree_elem_item *elem)
+{
+    LOCK_CACHE();
+    assert (elem->status == BTREE_ITEM_STATUS_UNLINK);
+    /* for cases with trimmed element, refcount can be over 0 */
+    if (elem->refcount != 0) {
+        elem->refcount--;
+    }
+    if (elem->refcount == 0) {
+        elem->status = BTREE_ITEM_STATUS_FREE;
+        do_btree_elem_free(elem);
+    }
+    UNLOCK_CACHE();
+}
+#endif
 void btree_elem_release(btree_elem_item **elem_array, const int elem_count)
 {
     int cnt = 0;
@@ -8731,7 +8767,11 @@ static map_elem_item *do_map_elem_alloc(const int nfield,
     if (elem != NULL) {
         assert(elem->slabs_clsid == 0);
         elem->slabs_clsid = slabs_clsid(ntotal);
+#ifdef INSERT_FIX
+        elem->refcount    = 0;
+#else
         elem->refcount    = 1;
+#endif
         elem->nfield      = (uint8_t)nfield;
         elem->nbytes      = (uint16_t)nbytes;
         elem->next = (map_elem_item *)ADDR_MEANS_UNLINKED; /* Unliked state */
@@ -9305,6 +9345,15 @@ map_elem_item *map_elem_alloc(const int nfield, const uint32_t nbytes, const voi
     return elem;
 }
 
+#ifdef INSERT_FIX
+void map_elem_free(map_elem_item *elem)
+{
+    LOCK_CACHE();
+    assert(elem->next == (map_elem_item *)ADDR_MEANS_UNLINKED);
+    do_map_elem_free(elem);
+    UNLOCK_CACHE();
+}
+#endif
 void map_elem_release(map_elem_item **elem_array, const int elem_count)
 {
     int cnt = 0;

--- a/engines/default/items.h
+++ b/engines/default/items.h
@@ -443,6 +443,9 @@ ENGINE_ERROR_CODE set_struct_create(const char *key, const uint32_t nkey,
 
 set_elem_item *set_elem_alloc(const uint32_t nbytes, const void *cookie);
 
+#ifdef INSERT_FIX
+void set_elem_free(set_elem_item *elem);
+#endif
 void set_elem_release(set_elem_item **elem_array, const int elem_count);
 
 ENGINE_ERROR_CODE set_elem_insert(const char *key, const uint32_t nkey,
@@ -470,6 +473,9 @@ ENGINE_ERROR_CODE map_struct_create(const char *key, const uint32_t nkey,
 map_elem_item *map_elem_alloc(const int nfield,
                               const uint32_t nbytes, const void *cookie);
 
+#ifdef INSERT_FIX
+void map_elem_free(map_elem_item *elem);
+#endif
 void map_elem_release(map_elem_item **elem_array, const int elem_count);
 
 ENGINE_ERROR_CODE map_elem_insert(const char *key, const uint32_t nkey,
@@ -498,6 +504,9 @@ ENGINE_ERROR_CODE btree_struct_create(const char *key, const uint32_t nkey,
 btree_elem_item *btree_elem_alloc(const uint32_t nbkey, const uint32_t neflag, const uint32_t nbytes,
                                   const void *cookie);
 
+#ifdef INSERT_FIX
+void btree_elem_free(btree_elem_item *elem);
+#endif
 void btree_elem_release(btree_elem_item **elem_array, const int elem_count);
 
 ENGINE_ERROR_CODE btree_elem_insert(const char *key, const uint32_t nkey,

--- a/engines/demo/demo_engine.c
+++ b/engines/demo/demo_engine.c
@@ -352,6 +352,13 @@ Demo_set_elem_alloc(ENGINE_HANDLE* handle, const void* cookie,
     return ENGINE_ENOTSUP;
 }
 
+#ifdef INSERT_FIX
+static void
+Demo_set_elem_free(ENGINE_HANDLE* handle, const void *cookie, eitem *eitem)
+{
+    return;
+}
+#endif
 static void
 Demo_set_elem_release(ENGINE_HANDLE* handle, const void *cookie,
                          eitem **eitem_array, const int eitem_count)
@@ -415,6 +422,13 @@ Demo_map_elem_alloc(ENGINE_HANDLE* handle, const void* cookie,
 {
     return ENGINE_ENOTSUP;
 }
+#ifdef INSERT_FIX
+static void
+Demo_map_elem_free(ENGINE_HANDLE* handle, const void *cookie, eitem *eitem)
+{
+    return;
+}
+#endif
 
 static void
 Demo_map_elem_release(ENGINE_HANDLE* handle, const void *cookie,
@@ -479,6 +493,13 @@ Demo_btree_elem_alloc(ENGINE_HANDLE* handle, const void* cookie,
     return ENGINE_ENOTSUP;
 }
 
+#ifdef INSERT_FIX
+static void
+Demo_btree_elem_free(ENGINE_HANDLE* handle, const void *cookie, eitem *eitem)
+{
+    return;
+}
+#endif
 static void
 Demo_btree_elem_release(ENGINE_HANDLE* handle, const void *cookie,
                            eitem **eitem_array, const int eitem_count)
@@ -782,6 +803,9 @@ create_instance(uint64_t interface, GET_SERVER_API get_server_api,
          /* SET Colleciton API */
          .set_struct_create = Demo_set_struct_create,
          .set_elem_alloc    = Demo_set_elem_alloc,
+#ifdef INSERT_FIX
+         .set_elem_free     = Demo_set_elem_free,
+#endif
          .set_elem_release  = Demo_set_elem_release,
          .set_elem_insert   = Demo_set_elem_insert,
          .set_elem_delete   = Demo_set_elem_delete,
@@ -790,6 +814,9 @@ create_instance(uint64_t interface, GET_SERVER_API get_server_api,
          /* MAP Collection API */
          .map_struct_create = Demo_map_struct_create,
          .map_elem_alloc    = Demo_map_elem_alloc,
+#ifdef INSERT_FIX
+         .map_elem_free     = Demo_map_elem_free,
+#endif
          .map_elem_release  = Demo_map_elem_release,
          .map_elem_insert   = Demo_map_elem_insert,
          .map_elem_update   = Demo_map_elem_update,
@@ -798,6 +825,9 @@ create_instance(uint64_t interface, GET_SERVER_API get_server_api,
          /* B+Tree Collection API */
          .btree_struct_create = Demo_btree_struct_create,
          .btree_elem_alloc   = Demo_btree_elem_alloc,
+#ifdef INSERT_FIX
+         .btree_elem_free    = Demo_btree_elem_free,
+#endif
          .btree_elem_release = Demo_btree_elem_release,
          .btree_elem_insert  = Demo_btree_elem_insert,
          .btree_elem_update  = Demo_btree_elem_update,

--- a/include/memcached/engine.h
+++ b/include/memcached/engine.h
@@ -388,6 +388,9 @@ extern "C" {
                                             const void* key, const int nkey,
                                             const size_t nbytes, eitem** eitem);
 
+#ifdef INSERT_FIX
+        void (*set_elem_free)(ENGINE_HANDLE* handle, const void* cookie, eitem *eitem);
+#endif
         void (*set_elem_release)(ENGINE_HANDLE* handle, const void *cookie,
                                  eitem **eitem_array, const int eitem_count);
 
@@ -431,6 +434,10 @@ extern "C" {
                                             const size_t nfield,
                                             const size_t nbytes,
                                             eitem** eitem);
+#ifdef INSERT_FIX
+        void (*map_elem_free) (ENGINE_HANDLE* handle, const void* cookie, eitem *eitem);
+#endif
+
         void (*map_elem_release)(ENGINE_HANDLE* handle,
                                  const void *cookie,
                                  eitem **eitem_array,
@@ -487,6 +494,9 @@ extern "C" {
                                               const size_t nbkey, const size_t neflag,
                                               const size_t nbytes, eitem** eitem);
 
+#ifdef INSERT_FIX
+        void (*btree_elem_free) (ENGINE_HANDLE* handle, const void *cookie, eitem *eitem);
+#endif
         void (*btree_elem_release)(ENGINE_HANDLE* handle, const void *cookie,
                                    eitem **eitem_array, const int eitem_count);
 

--- a/include/memcached/types.h
+++ b/include/memcached/types.h
@@ -31,6 +31,7 @@ struct iovec {
 #include <sys/uio.h>
 #endif
 
+#define INSERT_FIX
 #define PROXY_SUPPORT
 #define BOP_COUNT_OPTIMIZE
 //#define NEW_PREFIX_STATS_MANAGEMENT

--- a/memcached.c
+++ b/memcached.c
@@ -784,7 +784,11 @@ static void conn_coll_eitem_free(conn *c)
         break;
       /* sop */
       case OPERATION_SOP_INSERT:
+#ifdef INSERT_FIX
+        mc_engine.v1->set_elem_free(mc_engine.v0, c, c->coll_eitem);
+#else
         mc_engine.v1->set_elem_release(mc_engine.v0, c, &c->coll_eitem, 1);
+#endif
         break;
       case OPERATION_SOP_DELETE:
       case OPERATION_SOP_EXIST:
@@ -799,7 +803,11 @@ static void conn_coll_eitem_free(conn *c)
         break;
       /* mop */
       case OPERATION_MOP_INSERT:
+#ifdef INSERT_FIX
+        mc_engine.v1->map_elem_free(mc_engine.v0, c, c->coll_eitem);
+#else
         mc_engine.v1->map_elem_release(mc_engine.v0, c, &c->coll_eitem, 1);
+#endif
         break;
       case OPERATION_MOP_UPDATE:
         free(c->coll_eitem);
@@ -814,7 +822,11 @@ static void conn_coll_eitem_free(conn *c)
       /* bop */
       case OPERATION_BOP_INSERT:
       case OPERATION_BOP_UPSERT:
+#ifdef INSERT_FIX
+        mc_engine.v1->btree_elem_free(mc_engine.v0, c, c->coll_eitem);
+#else
         mc_engine.v1->btree_elem_release(mc_engine.v0, c, &c->coll_eitem, 1);
+#endif
         break;
       case OPERATION_BOP_UPDATE:
         free(c->coll_eitem);
@@ -1672,14 +1684,23 @@ static void process_sop_insert_complete(conn *c)
 {
     assert(c->coll_op == OPERATION_SOP_INSERT);
     assert(c->coll_eitem != NULL);
+#ifdef INSERT_FIX
+    ENGINE_ERROR_CODE ret;
+#endif
 
     mc_engine.v1->get_elem_info(mc_engine.v0, c, ITEM_TYPE_SET, c->coll_eitem, &c->einfo);
 
     if (einfo_check_ascii_tail_string(&c->einfo) != 0) { /* check "\r\n" */
+#ifdef INSERT_FIX
+        ret = ENGINE_EINVAL;
+#endif
         out_string(c, "CLIENT_ERROR bad data chunk");
     } else {
         bool created;
+#ifdef INSERT_FIX
+#else
         ENGINE_ERROR_CODE ret;
+#endif
 
         ret = mc_engine.v1->set_elem_insert(mc_engine.v0, c, c->coll_key, c->coll_nkey,
                                             c->coll_eitem, c->coll_attrp, &created, 0);
@@ -1717,7 +1738,13 @@ static void process_sop_insert_complete(conn *c)
         }
     }
 
+#ifdef INSERT_FIX
+    if (ret != ENGINE_SUCCESS) {
+        mc_engine.v1->set_elem_free(mc_engine.v0, c,c->coll_eitem);
+    }
+#else
     mc_engine.v1->set_elem_release(mc_engine.v0, c, &c->coll_eitem, 1);
+#endif
     c->coll_eitem = NULL;
 }
 
@@ -1841,6 +1868,9 @@ static void process_mop_insert_complete(conn *c)
 {
     assert(c->coll_op == OPERATION_MOP_INSERT);
     assert(c->coll_eitem != NULL);
+#ifdef INSERT_FIX
+    ENGINE_ERROR_CODE ret;
+#endif
 
     mc_engine.v1->get_elem_info(mc_engine.v0, c, ITEM_TYPE_MAP, c->coll_eitem, &c->einfo);
 
@@ -1848,10 +1878,16 @@ static void process_mop_insert_complete(conn *c)
     memcpy((void*)c->einfo.score, c->coll_field.value, c->coll_field.length);
 
     if (einfo_check_ascii_tail_string(&c->einfo) != 0) { /* check "\r\n" */
+#ifdef INSERT_FIX
+        ret = ENGINE_EINVAL;
+#endif
         out_string(c, "CLIENT_ERROR bad data chunk");
     } else {
         bool created;
+#ifdef INSERT_FIX
+#else
         ENGINE_ERROR_CODE ret;
+#endif
 
         ret = mc_engine.v1->map_elem_insert(mc_engine.v0, c, c->coll_key, c->coll_nkey,
                                             c->coll_eitem, c->coll_attrp, &created, 0);
@@ -1889,7 +1925,13 @@ static void process_mop_insert_complete(conn *c)
         }
     }
 
+#ifdef INSERT_FIX
+    if (ret != ENGINE_SUCCESS) {
+        mc_engine.v1->map_elem_free(mc_engine.v0, c, c->coll_eitem);
+    }
+#else
     mc_engine.v1->map_elem_release(mc_engine.v0, c, &c->coll_eitem, 1);
+#endif
     c->coll_eitem = NULL;
 }
 
@@ -2246,7 +2288,11 @@ static void process_bop_insert_complete(conn *c)
 
     if (einfo_check_ascii_tail_string(&c->einfo) != 0) { /* check "\r\n" */
         // release the btree element
+#ifdef INSERT_FIX
+        mc_engine.v1->btree_elem_free(mc_engine.v0, c, c->coll_eitem);
+#else
         mc_engine.v1->btree_elem_release(mc_engine.v0, c, &c->coll_eitem, 1);
+#endif
         c->coll_eitem = NULL;
         out_string(c, "CLIENT_ERROR bad data chunk");
     } else {
@@ -2266,7 +2312,13 @@ static void process_bop_insert_complete(conn *c)
         }
 
         // release the btree element in advance since coll_eitem field is to be used, soon.
+#ifdef INSERT_FIX
+        if( ret != ENGINE_SUCCESS) {
+            mc_engine.v1->btree_elem_free(mc_engine.v0, c, c->coll_eitem);
+        }
+#else
         mc_engine.v1->btree_elem_release(mc_engine.v0, c, &c->coll_eitem, 1);
+#endif
         c->coll_eitem = NULL;
 
         if (settings.detail_enabled) {
@@ -5083,7 +5135,13 @@ static void process_bin_sop_insert_complete(conn *c)
     }
 
     /* release the c->coll_eitem reference */
+#ifdef INSERT_FIX
+    if (ret != ENGINE_SUCCESS) {
+        mc_engine.v1->set_elem_free(mc_engine.v0, c, c->coll_eitem);
+    }
+#else
     mc_engine.v1->set_elem_release(mc_engine.v0, c, &c->coll_eitem, 1);
+#endif
     c->coll_eitem = NULL;
 }
 
@@ -5578,7 +5636,13 @@ static void process_bin_bop_insert_complete(conn *c)
     }
 
     /* release the c->coll_eitem reference */
+#ifdef INSERT_FIX
+    if (ret != ENGINE_SUCCESS) {
+        mc_engine.v1->btree_elem_free(mc_engine.v0, c, c->coll_eitem);
+    }
+#else
     mc_engine.v1->btree_elem_release(mc_engine.v0, c, &c->coll_eitem, 1);
+#endif
     c->coll_eitem = NULL;
 }
 


### PR DESCRIPTION
Collection에 element 삽입할 때 release()함수 대신 free()함수를 새로 구현하였습니다.
- 할당하는 과정에서 refcount는 불필요하므로 refcount = 0으로 지정했습니다.
- insert 실패 후 elem_free 함수를 호출하도록 하였습니다. (refcount 감소 안함)

추가적으로  btree는 getrim 옵션이 있으면 기존의 element를 조회하고 refcount가 증가할 수 있기 때문에 elem_free 내에서 refcount가 0이 아닐 때 감소하도록 구현했습니다. 

reviewer
- [ ] @MinWooJin 
- [ ] @jhpark816 
