### PR TITLE
FIX: compile error occur because of macro location

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -2182,10 +2182,11 @@ static void process_mop_get_complete(conn *c)
             }
             if (ret == ENGINE_ENOMEM) break;
 
-            sprintf(respptr, "%s\r\n",
 #ifdef COLLGET_RESULT
+            sprintf(respptr, "%s\r\n",
                     (delete ? (eresult.dropped ? "DELETED_DROPPED" : "DELETED") : "END"));
 #else
+            sprintf(respptr, "%s\r\n",
                     (delete ? (dropped ? "DELETED_DROPPED" : "DELETED") : "END"));
 #endif
             if ((add_iov(c, respptr, strlen(respptr)) != 0) ||


### PR DESCRIPTION
매크로의 위치 때문에 아래와 같은 컴파일 에러가 발생합니다.
```
memcached.c:2186:2: error: embedding a directive within macro arguments has undefined behavior [-Werror,-Wembedded-directive]
#ifdef COLLGET_RESULT
```