### PR TITLE
[persistence] Use tls in global waiter struct to avoid cache lock.

### DIFF
--- a/engines/default/cmdlogmgr.c
+++ b/engines/default/cmdlogmgr.c
@@ -47,7 +47,7 @@ struct cmdlog_global {
 /* global data */
 static struct default_engine *engine = NULL;
 static EXTENSION_LOGGER_DESCRIPTOR* logger = NULL;
-static struct cmdlog_global logmgr_gl;
+static __thread struct cmdlog_global logmgr_gl;
 
 /* Recovery Function */
 static ENGINE_ERROR_CODE cmdlog_mgr_recovery()


### PR DESCRIPTION
tls 를 사용하여 waiter alloc/free 시에 cache lock 을 잡지 않도록 하였습니다.

@jhpark816 검토부탁드립니다.