### PR TITLE
[persistence] Destroyed log global mutex.

### DIFF
--- a/engines/default/cmdlogbuf.c
+++ b/engines/default/cmdlogbuf.c
@@ -742,6 +742,9 @@ void cmdlog_buf_final(void)
     /* log file final */
     cmdlog_file_close(true);
 
+    pthread_mutex_destroy(&log_gl.log_write_lock);
+    pthread_mutex_destroy(&log_gl.log_flush_lock);
+    pthread_mutex_destroy(&log_gl.flush_lsn_lock);
     logger->log(EXTENSION_LOG_INFO, NULL, "CMDLOG BUFFER module destroyed.\n");
 }
 


### PR DESCRIPTION
cmdlog_buf_final() 에서 pthread_mutex_destroy() 가 필요합니다.

@jhpark816 검토 부탁드립니다.