### PR TITLE
[persistence] do module_final() only if the module is initialized.

### DIFF
--- a/engines/default/cmdlogbuf.c
+++ b/engines/default/cmdlogbuf.c
@@ -724,7 +724,9 @@ ENGINE_ERROR_CODE cmdlog_buf_init(struct default_engine* engine)
 
 void cmdlog_buf_final(void)
 {
-    log_gl.initialized = false;
+    if (log_gl.initialized == false) {
+        return;
+    }
 
     /* log buffer final */
     log_BUFFER *logbuff = &log_gl.log_buffer;
@@ -745,6 +747,7 @@ void cmdlog_buf_final(void)
     pthread_mutex_destroy(&log_gl.log_write_lock);
     pthread_mutex_destroy(&log_gl.log_flush_lock);
     pthread_mutex_destroy(&log_gl.flush_lsn_lock);
+    log_gl.initialized = false;
     logger->log(EXTENSION_LOG_INFO, NULL, "CMDLOG BUFFER module destroyed.\n");
 }
 
@@ -778,6 +781,10 @@ ENGINE_ERROR_CODE cmdlog_buf_flush_thread_start(void)
 
 void cmdlog_buf_flush_thread_stop(void)
 {
+    if (log_gl.initialized == false) {
+        return;
+    }
+
     struct timespec sleep_time = {0, 10000000}; // 10 msec.
 
     if (log_gl.log_flusher.init == true) {

--- a/engines/default/cmdlogmgr.c
+++ b/engines/default/cmdlogmgr.c
@@ -211,8 +211,6 @@ ENGINE_ERROR_CODE cmdlog_mgr_init(struct default_engine* engine_ptr)
 
 void cmdlog_mgr_final(void)
 {
-    logmgr_gl.initialized = false;
-
     chkpt_thread_stop();
     cmdlog_buf_flush_thread_stop();
     /* CONSIDER: do last checkpoint before shutdown engine. */
@@ -220,6 +218,9 @@ void cmdlog_mgr_final(void)
     cmdlog_buf_final();
     cmdlog_waiter_final();
 
-    logger->log(EXTENSION_LOG_INFO, NULL, "COMMAND LOG MANAGER module destroted.\n");
+    if (logmgr_gl.initialized == true) {
+        logmgr_gl.initialized = false;
+        logger->log(EXTENSION_LOG_INFO, NULL, "COMMAND LOG MANAGER module destroyed.\n");
+    }
 }
 #endif

--- a/engines/default/mc_snapshot.c
+++ b/engines/default/mc_snapshot.c
@@ -62,6 +62,7 @@ typedef struct _snapshot_st {
    int      nprefix;    /* prefix name length */
    struct snapshot_file   file;
    struct snapshot_buffer buffer;
+   volatile bool initialized;
 } snapshot_st;
 
 /* global data */
@@ -627,15 +628,21 @@ ENGINE_ERROR_CODE mc_snapshot_init(struct default_engine *engine)
     if (do_snapshot_init(&snapshot_anch, engine) < 0) {
         return ENGINE_FAILED;
     }
+    snapshot_anch.initialized = true;
     logger->log(EXTENSION_LOG_INFO, NULL, "SNAPSHOT module initialized.\n");
     return ENGINE_SUCCESS;
 }
 
 void mc_snapshot_final(void)
 {
+    if (snapshot_anch.initialized == false) {
+        return;
+    }
+
     mc_snapshot_stop();
 
     do_snapshot_final(&snapshot_anch);
+    snapshot_anch.initialized = false;
     logger->log(EXTENSION_LOG_INFO, NULL, "SNAPSHOT module destroyed.\n");
 }
 


### PR DESCRIPTION
issue : https://github.com/naver/arcus-memcached/issues/356

각 modul_final() 수행은 module_initialized 여부를 확인하고 진행하도록 수정하였습니다.

@jhpark816 리뷰 부탁드립니다.