### PR TITLE
[persistence] Keeped the termination order of module.

### DIFF
--- a/engines/default/mc_snapshot.c
+++ b/engines/default/mc_snapshot.c
@@ -432,9 +432,9 @@ static bool do_snapshot_action(snapshot_st *ss)
                     "Failed to get item scan resource.\n");
         goto done;
     }
-    while (engine->initialized) {
+    while (1) {
         if (ss->reqstop) {
-            logger->log(EXTENSION_LOG_INFO, NULL, "Stop the current snapshot.\n");
+            logger->log(EXTENSION_LOG_INFO, NULL, "Ongoing snapshot recognized stop request.\n");
             break;
         }
         item_count = itscan_getnext(shandle, item_array, erst_array, item_arrsz);
@@ -571,6 +571,10 @@ static ENGINE_ERROR_CODE do_snapshot_start(snapshot_st *ss,
 
 static void do_snapshot_stop(snapshot_st *ss, bool wait_stop)
 {
+    if (!ss->running) {
+        return;
+    }
+
     while (ss->running) {
         ss->reqstop = true; /* request to stop the snapshot */
 


### PR DESCRIPTION
엔진 종료 시에 checkpoint 와 snapshot 동작 종료는 checkpoint -> snapshot 순으로 종료되야 한다.
checkpoint 스레드가 snapshot 동작을 수행하고 있을 때 snapshot 스레드가 engine->initialized 를 먼저 확인하여 중단되면, 전체 데이터를 스냅샷 하지 못한 채 스냅샷이 중단되고, 체크포인트 모듈에서 에러 메세지를 출력하게 된다. ("Failed in checkpoint. Retry checkpoint in 5 seconds.")

따라서 두 모듈은 engine->initialized 가 아닌 각 모듈의 종료 요청(reqstop)을 받은 경우에 동작을 끝내도록 한다.

@jhpark816 검토 부탁드립니다.