### PR TITLE
[persistence] checkpoint must be not stopped by snapshot stop command.

### DIFF
--- a/engines/default/mc_snapshot.c
+++ b/engines/default/mc_snapshot.c
@@ -571,7 +571,7 @@ static ENGINE_ERROR_CODE do_snapshot_start(snapshot_st *ss,
 
 static void do_snapshot_stop(snapshot_st *ss, bool wait_stop)
 {
-    if (!ss->running) {
+    if (!ss->running || ss->mode == MC_SNAPSHOT_MODE_CHKPT) {
         return;
     }
 


### PR DESCRIPTION
issue : https://github.com/naver/arcus-memcached/issues/362 해결을 위한 PR 입니다.

체크포인트에 의한 스냅샷인 경우 stop 되지 않도록 합니다.

@jhpark816 리뷰 요청드립니다.