### PR TITLE
[persistence] Declared command log flush thread state as volatile

### DIFF
--- a/engines/default/checkpoint.c
+++ b/engines/default/checkpoint.c
@@ -302,8 +302,11 @@ static void* chkpt_thread_main(void* arg)
 
         if (elapsed_time >= CHKPT_CHECK_INTERVAL) {
             if (do_checkpoint_needed(cs)) {
+                logger->log(EXTENSION_LOG_INFO, NULL, "Checkpoint started.\n");
                 ret = do_checkpoint(cs);
-                if (ret != CHKPT_SUCCESS) {
+                if (ret == CHKPT_SUCCESS) {
+                    logger->log(EXTENSION_LOG_INFO, NULL, "Checkpoint has been done.\n");
+                } else {
                     logger->log(EXTENSION_LOG_WARNING, NULL, "Failed in checkpoint. "
                                 "Retry checkpoint in 5 seconds.\n");
                     if (ret == CHKPT_ERROR_FILE_REMOVE) need_remove = true;


### PR DESCRIPTION
리팩토링 성격의 작업이며, 
command log flush thread state 변수를 volatile 로 선언하여
해당 변수들을 접근시에 별도의 락을 잡지 않도록 합니다.

@jhpark816 리뷰 요청드립니다.