### PR TITLE
[persistence] snapshot item was restored could be NULL.

### DIFF
--- a/engines/default/cmdlogrec.c
+++ b/engines/default/cmdlogrec.c
@@ -1350,7 +1350,6 @@ hash_item *lrec_get_item_if_collection_link(ITLinkLog *log)
         return NULL;
     }
     hash_item *it = item_get(&log->body.data, log->body.cm.keylen);
-    assert(it != NULL && IS_COLL_ITEM(it));
     return it;
 }
 

--- a/engines/default/mc_snapshot.c
+++ b/engines/default/mc_snapshot.c
@@ -793,8 +793,8 @@ int mc_snapshot_file_apply(const char *filepath)
                 item_release(last_coll_it);
             }
             last_coll_it = lrec_get_item_if_collection_link((ITLinkLog*)logrec);
-        } else if (loghdr->logtype == LOG_SNAPSHOT_ELEM) {
-            assert(last_coll_it != NULL && IS_COLL_ITEM(last_coll_it));
+        } else if (loghdr->logtype == LOG_SNAPSHOT_ELEM && last_coll_it) {
+            assert(IS_COLL_ITEM(last_coll_it));
             lrec_set_item_in_snapshot_elem((SnapshotElemLog*)logrec, last_coll_it);
             err = lrec_redo_from_record(logrec);
             if (err != ENGINE_SUCCESS) {


### PR DESCRIPTION
스냅샷 복구 모듈에서 엘리먼트 삽입 명령을 수행하기 위해 복구된 콜렉션 아이템을 얻어옵니다.
해당 아이템이 expired 된 경우, NULL 을 반환할 수 있습니다.

그렇기 때문에 NULL 을 확인하는 assert 문을 제거하고,
이 아이템에 삽입할 엘리먼트 명령 수행은 skip 하도록 합니다.

@jhpark816  리뷰 요청드립니다.