### PR TITLE
CLEANUP: fixed do_smmgr_memid comment

### DIFF
--- a/engines/default/slabs.c
+++ b/engines/default/slabs.c
@@ -366,11 +366,12 @@ static inline int do_smmgr_memid(int slen, bool above)
     }
     int smid = cls->tocnt + ((slen-cls->tolen) / cls->sulen);
     /* The above code logic likes followings.
-    if (slen < ( 2*1024)) return (  0 + ((slen          ) /  16));
-    if (slen < ( 6*1024)) return (128 + ((slen-( 2*1024)) /  32));
-    if (slen < (14*1024)) return (256 + ((slen-( 6*1024)) /  64));
-    if (slen < (30*1024)) return (384 + ((slen-(14*1024)) / 128));
-    else                  return (512 + ((slen-(30*1024)) / 256));
+    if (slen < (   1024)) return (  0 + ((slen          ) /   8));
+    if (slen < ( 3*1024)) return (128 + ((slen-(   1024)) /  16));
+    if (slen < ( 7*1024)) return (256 + ((slen-( 3*1024)) /  32));
+    if (slen < (15*1024)) return (384 + ((slen-( 7*1024)) /  64));
+    if (slen < (31*1024)) return (512 + ((slen-(15*1024)) / 128));
+    else                  return (640 + ((slen-(31*1024)) / 256));
     *****************************************/
     if (above && ((slen-cls->tolen) % cls->sulen) != 0) {
         smid++;


### PR DESCRIPTION
주석과 실제 코드 내용이 맞지 않아 PR 합니다.

```
sm class info
index  sunit_len  sunit_cnt  total_len  total_cnt
-------------------------------------------------
    0          8        128          0          0
    1         16        128       1024        128
    2         32        128       3072        256
    3         64        128       7168        384
    4        128        128      15360        512
    5        256         68      31744        640
    6          0          0      49152        708
-------------------------------------------------
```

위 내용이 실제 smmgr 상태입니다. 