### PR TITLE
[persistence] incremented snapped item count.

### DIFF
--- a/engines/default/mc_snapshot.c
+++ b/engines/default/mc_snapshot.c
@@ -276,6 +276,7 @@ static int do_snapshot_data_dump(snapshot_st *ss, void **item_array, int item_co
             }
             if (ret == -1) break;
         }
+        ss->snapped++;
     }
     return ret;
 #else


### PR DESCRIPTION
스냅샷을 데이터 모드로 동작시켰을 때 스냅샷된 캐시 아이템 개수를 증가시키지 않아서
stats snapshot 에서 snapped 정보가 0으로 나오는 문제가 있습니다.

@jhpark816 리뷰 요청드립니다.