### PR TITLE
CLEANUP: fixed bucket_info comment's typo

### DIFF
--- a/engines/default/assoc.h
+++ b/engines/default/assoc.h
@@ -49,7 +49,7 @@ typedef struct _prefix_t {
 struct bucket_info {
     uint16_t refcount; /* reference count */
     uint16_t curpower; /* current hash power:
-                        * how may hash tables each hash bucket use ? (power of 2)
+                        * how many hash tables each hash bucket use ? (power of 2)
                         */
 };
 


### PR DESCRIPTION
주석에 오타가 있어 수정합니다. 