### PR TITLE
CLEANUP: Amended condition to decrease bucket refcount after finishing scan.

### DIFF
--- a/engines/default/assoc.c
+++ b/engines/default/assoc.c
@@ -425,7 +425,7 @@ void assoc_scan_final(struct assoc_scan *scan)
     if (scan->ph_linked) {
         (void)_unlink_scan_placeholder(scan);
     }
-    if (scan->bucket < scan->hashsz) {
+    if (scan->bucket < scan->hashsz && scan->tabcnt > 0) {
         /* decrement bucket's reference count */
         assocp->infotable[scan->bucket].refcount -= 1;
     }


### PR DESCRIPTION
assoc_scan_init() 직후에 snapshot stop 명령이나 scrub 명령이 들어온 경우 assoc_scan_final()에서 버켓 참조카운트를 증가시키지 않았음에도 감소시켜 언더플로우를 발생시킵니다. 

-scrub code
```
     while (engine->initialized && !scrubber->restart) {
         /* scan and scrub cache items */
         /* NOTE: scrub_count can be changed while scrubbing */
         item_count = assoc_scan_next(&scan, item_array, config->scrub_count, 0);
         if (item_count < 0) { /* reached to the end */
             break;
         }
         /* Currently, item_count > 0.
          * See the internals of assoc_scan_next(). It does not return 0.
          */
         for (int i = 0; i < item_count; i++) {
             scrubber->visited++;
             if (do_item_isvalid(item_array[i], current_time) == false) {
                 do_item_unlink(item_array[i], ITEM_UNLINK_INVALID);
                 scrubber->cleaned++;
             }
             else if (scrubber->runmode == SCRUB_MODE_STALE &&
                      do_item_isstale(item_array[i]) == true) {
                 do_item_unlink(item_array[i], ITEM_UNLINK_STALE);
                 scrubber->cleaned++;
             }
         }

         UNLOCK_CACHE();
         if (++scan_execs >= scan_break) {
             struct timespec sleep_time = {0, (64*1000)};
             nanosleep(&sleep_time, NULL); /* 64 usec */
             scan_execs = 0;
         }
         TRYLOCK_CACHE(5);
     }
     assoc_scan_final(&scan);
```

@jhpark816 검토 요청드립니다.