### PR TITLE
[persistence] reset the default value of use_persistence to false

### DIFF
--- a/engines/default/default_engine.conf
+++ b/engines/default/default_engine.conf
@@ -12,7 +12,7 @@
 # Persistence configuration
 #
 # use persistence (true or false, default: false)
-use_persistence=true
+use_persistence=false
 #
 # The path of the snapshot file (default: ARCUS-DB)
 data_path=ARCUS-DB


### PR DESCRIPTION
default_engine.conf 파일의 기본 설정이 false 인데,
이전에 다른 commit에 의해 true로 설정된 상태로 merge 되었습니다.
false로 원복 시키기 위한 commit 입니다.

@jhpark816 
확인 요청 드립니다.