### PR TITLE
[persistence] change the location of no create lrec flag

### DIFF
--- a/engines/default/items.c
+++ b/engines/default/items.c
@@ -6622,7 +6622,6 @@ ENGINE_ERROR_CODE list_elem_insert(const char *key, const uint32_t nkey,
                         "list elem insert - cmdlog waiter alloc fail\n");
             return ENGINE_ENOMEM; /* FIXME: define error code */
         }
-        waiter->elem_clog_with_collection = true;
     }
 #endif
 
@@ -6635,6 +6634,9 @@ ENGINE_ERROR_CODE list_elem_insert(const char *key, const uint32_t nkey,
         if (it == NULL) {
             ret = ENGINE_ENOMEM;
         } else {
+#ifdef ENABLE_PERSISTENCE
+            if (waiter != NULL) waiter->elem_clog_with_collection = true;
+#endif
             ret = do_item_link(it);
             if (ret == ENGINE_SUCCESS) {
                 *created = true;
@@ -6916,7 +6918,6 @@ ENGINE_ERROR_CODE set_elem_insert(const char *key, const uint32_t nkey,
                         "set elem insert - cmdlog waiter alloc fail\n");
             return ENGINE_ENOMEM; /* FIXME: define error code */
         }
-        waiter->elem_clog_with_collection = true;
     }
 #endif
 
@@ -6929,6 +6930,9 @@ ENGINE_ERROR_CODE set_elem_insert(const char *key, const uint32_t nkey,
         if (it == NULL) {
             ret = ENGINE_ENOMEM;
         } else {
+#ifdef ENABLE_PERSISTENCE
+            if (waiter != NULL) waiter->elem_clog_with_collection = true;
+#endif
             ret = do_item_link(it);
             if (ret == ENGINE_SUCCESS) {
                 *created = true;
@@ -7191,7 +7195,6 @@ ENGINE_ERROR_CODE btree_elem_insert(const char *key, const uint32_t nkey,
                         "btree elem insert - cmdlog waiter alloc fail\n");
             return ENGINE_ENOMEM; /* FIXME: define error code */
         }
-        waiter->elem_clog_with_collection = true;
     }
 #endif
 
@@ -7209,6 +7212,9 @@ ENGINE_ERROR_CODE btree_elem_insert(const char *key, const uint32_t nkey,
         if (it == NULL) {
             ret = ENGINE_ENOMEM;
         } else {
+#ifdef ENABLE_PERSISTENCE
+            if (waiter != NULL) waiter->elem_clog_with_collection = true;
+#endif
             ret = do_item_link(it);
             if (ret == ENGINE_SUCCESS) {
                 *created = true;
@@ -9975,7 +9981,6 @@ ENGINE_ERROR_CODE map_elem_insert(const char *key, const uint32_t nkey,
                         "map elem insert - cmdlog waiter alloc fail\n");
             return ENGINE_ENOMEM; /* FIXME: define error code */
         }
-        waiter->elem_clog_with_collection = true;
     }
 #endif
 
@@ -9988,6 +9993,9 @@ ENGINE_ERROR_CODE map_elem_insert(const char *key, const uint32_t nkey,
         if (it == NULL) {
             ret = ENGINE_ENOMEM;
         } else {
+#ifdef ENABLE_PERSISTENCE
+            if (waiter != NULL) waiter->elem_clog_with_collection = true;
+#endif
             ret = do_item_link(it);
             if (ret == ENGINE_SUCCESS) {
                 *created = true;


### PR DESCRIPTION
persistence에서 link log record를 생성하지 않도록 하기 위한 flag 설정 위치를
실제 item link 시키기 전으로 변경 했습니다.

attribute를 포함하여 요청 하는 경우 항상 log record를 attribute 정보를 포함하지 않도록 하고,
기존의 오류 처리(create == true인데, item이 있으면 실패)를 만족시키기 위함 입니다.

@jhpark816 
확인 요청 드립니다.