### PR TITLE
CLEANUP: fix wrong response

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -8327,7 +8327,7 @@ static void process_stat(conn *c, token_t *tokens, const size_t ntokens)
     const char *subcommand = tokens[SUBCOMMAND_TOKEN].value;
 
     if (ntokens < 2) {
-        out_string(c, "CLIENT_ERROR bad command line");
+        out_string(c, "CLIENT_ERROR bad command line format");
         return;
     }
 


### PR DESCRIPTION
"CLIENT_ERROR bad command line format" 으로 응답해야 할 상황에, format을 빼먹고 "CLIENT_ERROR bad command line" 으로 응답하고 있어 수정합니다.

코드 전체에서 format을 빼고 응답하는 부분은 이 곳 밖에 없고, 토큰 개수를 검사하는 부분에서는 모두 bad command line format으로 응답하고 있어 오타로 보는게 합당할 것 같습니다. 