### PR TITLE
FEATURE: add multi delete feature

### DIFF
--- a/doc/command-key-value.md
+++ b/doc/command-key-value.md
@@ -44,6 +44,16 @@ delete 명령이 있으며 syntax는 다음과 같다.
 delete <key> [<time>] [noreply]\r\n
 ```
 
+한번에 여러 cache item들을 삭제하기 위한 mdelete 명령이 있으며, syntax는 다음과 같다.
+mdelete 명령은 1.11.8을 초과하는 버전부터 제공한다.
+
+```
+mdelete <lenkeys> <numkeys>\r\n
+<"space separated keys">\r\n
+```
+- \<”space separated keys”\> - key list로, 스페이스(' ')로 구분한다.
+- \<lenkeys\>과 \<numkeys> - key list 문자열의 길이와 key 개수를 나타낸다.
+
 **Increment/Decrement 명령**
 
 incr, decr 명령이 있으며, syntax는 아래와 같다.

--- a/include/memcached/types.h
+++ b/include/memcached/types.h
@@ -34,6 +34,7 @@ struct iovec {
 #define PROXY_SUPPORT
 #define BOP_COUNT_OPTIMIZE
 //#define NEW_PREFIX_STATS_MANAGEMENT
+#define SUPPORT_MDELETE
 #define SUPPORT_BOP_MGET
 #define SUPPORT_BOP_SMGET
 #define JHPARK_OLD_SMGET_INTERFACE
@@ -104,6 +105,13 @@ extern "C" {
         OPERATION_GETS,    /**< Retrieve with gets semantics */
         OPERATION_MGET     /**< Retrieve with mget semantics */
     } ENGINE_RETRIEVE_OPERATION;
+
+#ifdef SUPPORT_MDELETE
+    typedef enum {
+        OPERATION_DELETE = 22,
+        OPERATION_MDELETE
+    } ENGINE_DELETION_OPERATION;
+#endif
 
     /* collection operation */
     typedef enum {

--- a/memcached.c
+++ b/memcached.c
@@ -3192,11 +3192,11 @@ static void process_mdelete_complete(conn *c)
                     ret = ENGINE_ENOMEM;
                     break; /* out of memory */
                 }
-                STATS_MISS(c, delete, key, nkey);
                 /* mdelete responds to requests whether the key exists or not.
                 * Thus, ENGINE_KEY_ENOENT state is not error.
                 */
                 ret = ENGINE_SUCCESS;
+                STATS_MISS(c, delete, key, nkey);
             } else if (ret == ENGINE_EWOULDBLOCK) {
                 c->ewouldblock = true;
                 ret = ENGINE_SUCCESS;
@@ -3210,6 +3210,14 @@ static void process_mdelete_complete(conn *c)
             }
         }
     } while(0);
+
+    if (settings.verbose > 1) {
+        mc_logger->log(EXTENSION_LOG_DEBUG, c, ">%d END\n", c->sfd);
+    }
+
+    if (ret == ENGINE_SUCCESS && add_iov(c, "END\r\n", 5) != 0) {
+        ret = ENGINE_ENOMEM;
+    }
 
     switch(ret) {
       case ENGINE_SUCCESS:

--- a/memcached.c
+++ b/memcached.c
@@ -3134,6 +3134,108 @@ static void process_mget_complete(conn *c)
     }
 }
 
+#ifdef SUPPORT_MDELETE
+static void process_mdelete_complete(conn *c)
+{
+    assert(c->coll_op == OPERATION_MDELETE);
+    assert(c->coll_strkeys != NULL);
+
+    ENGINE_ERROR_CODE ret = ENGINE_SUCCESS;
+    token_t *key_tokens   = NULL;
+
+    do {
+        key_tokens = (token_t*)token_buff_get(&c->thread->token_buff, c->coll_numkeys);
+        if (key_tokens == NULL) {
+            ret = ENGINE_ENOMEM;
+            break;
+        }
+
+        bool must_backward_compatible = false;
+        ret = tokenize_sblocks(&c->memblist, c->coll_lenkeys, c->coll_numkeys, key_tokens,
+                               must_backward_compatible);
+        if (ret != ENGINE_SUCCESS) {
+            break; /* ENGINE_EBADVALUE | ENGINE_ENOMEM */
+        }
+
+        /* check key length */
+        for (int k = 0; k < c->coll_numkeys; k++) {
+            if (key_tokens[k].length > KEY_MAX_LENGTH) {
+                ret = ENGINE_EBADVALUE;
+                break;
+            }
+        }
+
+        if (ret == ENGINE_EBADVALUE) { /* too long key */
+            break;
+        }
+
+        /* do delete operation for each key */
+        for (int k = 0; k < c->coll_numkeys; k++) {
+            char *key = key_tokens[k].value;
+            size_t nkey = key_tokens[k].length;
+
+            ret = mc_engine.v1->remove(mc_engine.v0, c, key, nkey, 0, 0);
+
+            if (add_iov(c, key, nkey) != 0) {
+                ret = ENGINE_ENOMEM;
+                break; /* out of memory */
+            }
+
+            if (ret == ENGINE_SUCCESS) {
+                if (add_iov(c, " DELETED\r\n", 10) != 0) {
+                    ret = ENGINE_ENOMEM;
+                    break; /* out of memory */
+                }
+                STATS_HIT(c, delete, key, nkey);
+            } else if (ret == ENGINE_KEY_ENOENT) {
+                if (add_iov(c, " NOT_FOUND\r\n", 12) != 0) {
+                    ret = ENGINE_ENOMEM;
+                    break; /* out of memory */
+                }
+                STATS_MISS(c, delete, key, nkey);
+                /* mdelete responds to requests whether the key exists or not.
+                * Thus, ENGINE_KEY_ENOENT state is not error.
+                */
+                ret = ENGINE_SUCCESS;
+            } else if (ret == ENGINE_EWOULDBLOCK) {
+                c->ewouldblock = true;
+                ret = ENGINE_SUCCESS;
+            } else {
+                break;
+            }
+
+            if (settings.verbose > 1) {
+                mc_logger->log(EXTENSION_LOG_DEBUG, c, ">%d deleting key %s\n",
+                               c->sfd, key);
+            }
+        }
+    } while(0);
+
+    switch(ret) {
+      case ENGINE_SUCCESS:
+        conn_set_state(c, conn_mwrite);
+        c->msgcurr = 0;
+        break;
+     default:
+        if (ret == ENGINE_EBADVALUE)   out_string(c, "CLIENT_ERROR bad data chunk");
+        else if (ret == ENGINE_ENOMEM) out_string(c, "SERVER_ERROR out of memory writing get response");
+        else if (ret == ENGINE_ENOTSUP) out_string(c, "NOT_SUPPORTED");
+        else handle_unexpected_errorcode_ascii(c, ret);
+    }
+
+    /* free token buffer */
+    if (key_tokens != NULL) {
+        token_buff_release(&c->thread->token_buff, key_tokens);
+    }
+    if (ret != ENGINE_SUCCESS) {
+        /* free key string memory blocks */
+        assert(c->coll_strkeys == (void*)&c->memblist);
+        mblck_list_free(&c->thread->mblck_pool, &c->memblist);
+        c->coll_strkeys = NULL;
+    }
+}
+#endif
+
 static void update_stat_cas(conn *c, ENGINE_ERROR_CODE ret)
 {
     switch (ret) {
@@ -3179,6 +3281,9 @@ static void complete_update_ascii(conn *c)
         else if (c->coll_op == OPERATION_BOP_SMGET) process_bop_smget_complete(c);
 #endif
         else if (c->coll_op == OPERATION_MGET) process_mget_complete(c);
+#ifdef SUPPORT_MDELETE
+        else if (c->coll_op == OPERATION_MDELETE) process_mdelete_complete(c);
+#endif
         return;
     }
 
@@ -8614,6 +8719,9 @@ static inline void process_get_command(conn *c, token_t *tokens, size_t ntokens,
 
 static void process_prepare_nread_keys(conn *c, uint32_t vlen, uint32_t kcnt)
 {
+#ifdef SUPPORT_MDELETE
+    assert(c->coll_op == OPERATION_MGET || c->coll_op == OPERATION_MDELETE);
+#endif
     ENGINE_ERROR_CODE ret = ENGINE_SUCCESS;
 
     /* allocate memory blocks needed */
@@ -8625,7 +8733,9 @@ static void process_prepare_nread_keys(conn *c, uint32_t vlen, uint32_t kcnt)
     case ENGINE_SUCCESS:
         c->coll_strkeys = (void*)&c->memblist;
         ritem_set_first(c, CONN_RTYPE_MBLCK, vlen);
+#ifndef SUPPORT_MDELETE
         c->coll_op = OPERATION_MGET;
+#endif
         conn_set_state(c, conn_nread);
         break;
     default:
@@ -8658,9 +8768,48 @@ static inline void process_mget_command(conn *c, token_t *tokens, const size_t n
 
     c->coll_numkeys = numkeys;
     c->coll_lenkeys = lenkeys;
+#ifdef SUPPORT_MDELETE
+    c->coll_op = OPERATION_MGET;
+#endif
+    process_prepare_nread_keys(c, lenkeys, numkeys);
+}
+
+#ifdef SUPPORT_MDELETE
+static inline void process_mdelete_command(conn *c, token_t *tokens, const size_t ntokens)
+{
+    uint32_t lenkeys = 0, numkeys = 0;
+
+    if ((! safe_strtoul(tokens[COMMAND_TOKEN+1].value, &lenkeys)) ||
+        (! safe_strtoul(tokens[COMMAND_TOKEN+2].value, &numkeys)) ||
+        (lenkeys > (UINT_MAX-2))) {
+        print_invalid_command(c, tokens, ntokens);
+        out_string(c, "CLIENT_ERROR bad command line format");
+        return;
+    }
+
+    /* There are (numkeys-1) space characters in the tokens.
+     * Therefore, numkeys is always smaller than (lenkeys/2)+1 even when all keys are one letter.
+     */
+    if (lenkeys < 1 || numkeys < 1 || numkeys > ((lenkeys/2)+1)) {
+        out_string(c, "CLIENT_ERROR bad value");
+        return;
+    }
+
+    if (numkeys > MAX_MDELETE_KEY_COUNT) {
+        out_string(c, "CLIENT_ERROR bad value");
+        return;
+    }
+
+    /* add trailling \r\n length to lenkeys. */
+    lenkeys += 2;
+
+    c->coll_numkeys = numkeys;
+    c->coll_lenkeys = lenkeys;
+    c->coll_op = OPERATION_MDELETE;
 
     process_prepare_nread_keys(c, lenkeys, numkeys);
 }
+#endif
 
 static void process_update_command(conn *c, token_t *tokens, const size_t ntokens,
                                    ENGINE_STORE_OPERATION store_op, bool handle_cas)
@@ -13102,6 +13251,12 @@ static void process_command(conn *c, char *command, int cmdlen)
     {
         process_delete_command(c, tokens, ntokens);
     }
+#ifdef SUPPORT_MDELETE
+    else if ((ntokens == 4) && (strcmp(tokens[COMMAND_TOKEN].value, "mdelete") == 0))
+    {
+        process_mdelete_command(c, tokens, ntokens);
+    }
+#endif
     else if ((ntokens >= 5 && ntokens <= 13) && (strcmp(tokens[COMMAND_TOKEN].value, "lop") == 0))
     {
         process_lop_command(c, tokens, ntokens);

--- a/memcached.h
+++ b/memcached.h
@@ -87,6 +87,9 @@
 #define BIN_PKT_HDR_WORDS (MIN_BIN_PKT_LENGTH/sizeof(uint32_t))
 
 #define MAX_MGET_KEY_COUNT 10000
+#ifdef SUPPORT_MDELETE
+#define MAX_MDELETE_KEY_COUNT 10000
+#endif
 
 /* Max element value size */
 #define MAX_ELEMENT_BYTES  (4*1024)

--- a/t/lib/MemcachedTest.pm
+++ b/t/lib/MemcachedTest.pm
@@ -76,6 +76,8 @@ sub mem_cmd_is {
         }
     } elsif ($#cmd_pipeline > 1) {
         $rst_type = 3;
+    } elsif ($cmd =~ /^mdelete/) {
+        $rst_type = 4;
     } else {
         $line = scalar <$sock>;
         $resp = $resp . (substr $line, 0, length($line)-2);
@@ -125,6 +127,17 @@ sub mem_cmd_is {
             $line = scalar <$sock>;
             $resp = $resp . (substr $line, 0, length($line)-2);
             if ($count eq 0) {
+                last;
+            }
+            $resp = $resp . "\n";
+        }
+    } elsif ($rst_type eq 4) { #mdelete
+        $count = $#prdct_response + 1;
+        while ($count--) {
+            $line = scalar <$sock>;
+            $resp = $resp . (substr $line, 0, length($line)-2);
+            #mdelete's response always contain trailling CRLF excepts ERROR case
+            if ($count eq 0 && $line =~ /.*ERROR.*/) {
                 last;
             }
             $resp = $resp . "\n";

--- a/t/mdelete.t
+++ b/t/mdelete.t
@@ -59,6 +59,7 @@ sub kv_mdelete_hits {
     for (my $kcnt = 0; $kcnt < $key_cnt; $kcnt += 1) {
         $rst .= "key_$kcnt DELETED\n";
     }
+    $rst .= "END\n";
 
     my $cmd = "mdelete $key_len $key_cnt";
     mem_cmd_is($sock, $cmd, $key_str, $rst);
@@ -76,6 +77,7 @@ sub kv_mdelete_not_found {
         $rst .= "not_found_$kcnt NOT_FOUND\n";
     }
 
+    $rst .= "END\n";
     my $key_len = length($val);
     my $cmd = "mdelete $key_len $key_cnt";
     mem_cmd_is($sock, $cmd, $val, $rst);

--- a/t/mdelete.t
+++ b/t/mdelete.t
@@ -1,0 +1,128 @@
+#!/usr/bin/perl
+
+use strict;
+use Test::More tests => 3014;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use MemcachedTest;
+
+my $engine = shift;
+my $server = get_memcached($engine);
+my $sock = $server->sock;
+
+sub bad_command {
+
+    my $key_str = "key1 key2 key3 key4";
+    my $key_len = length($key_str);
+    my $key_cnt = 4;
+
+    my $unknown_command = "ERROR unknown command";
+    #to many or few tokens
+    mem_cmd_is($sock, "mdelete 10 10 10", "", $unknown_command);
+    mem_cmd_is($sock, "mdelete 10", "", $unknown_command);
+
+    my $bad_format = "CLIENT_ERROR bad command line format";
+    mem_cmd_is($sock, "mdelete $key_len -1", "", $bad_format);
+    mem_cmd_is($sock, "mdelete 0.5 $key_len", "", $bad_format);
+    mem_cmd_is($sock, "mdelete not_number $key_len", "", $bad_format);
+
+    my $bad_data_chunk = "CLIENT_ERROR bad data chunk";
+    #wrong key_count
+    mem_cmd_is($sock, "mdelete $key_len 10", $key_str, $bad_data_chunk);
+    mem_cmd_is($sock, "mdelete $key_len 2", $key_str, $bad_data_chunk);
+
+    my $too_long_key = 'a' x 35000;
+    mem_cmd_is($sock, "mdelete 35011 2", "$too_long_key normal_key", $bad_data_chunk);
+
+    my $bad_value = "CLIENT_ERROR bad value";
+    mem_cmd_is($sock, "mdelete $key_len 0", "", $bad_value);
+    mem_cmd_is($sock, "mdelete 0 10", "", $bad_value);
+    mem_cmd_is($sock, "mdelete 0 0", "", $bad_value);
+}
+
+sub prepare_kv_mdelete {
+    my ($key_cnt) = @_;
+
+    for (my $kcnt = 0; $kcnt < $key_cnt; $kcnt += 1) {
+        my $val = "value_$kcnt";
+        my $len = length($val);
+        my $cmd = "set key_$kcnt 0 0 $len";
+        mem_cmd_is($sock, $cmd, $val, "STORED");
+    }
+}
+
+sub kv_mdelete_hits {
+    my ($key_len, $key_cnt, $key_str) = @_;
+
+    my $rst = "";
+
+    for (my $kcnt = 0; $kcnt < $key_cnt; $kcnt += 1) {
+        $rst .= "key_$kcnt DELETED\n";
+    }
+
+    my $cmd = "mdelete $key_len $key_cnt";
+    mem_cmd_is($sock, $cmd, $key_str, $rst);
+}
+
+sub kv_mdelete_not_found {
+
+    my ($key_cnt) = @_;
+
+    my $val = "not_found_0";
+    my $rst = "not_found_0 NOT_FOUND\n";
+
+    for (my $kcnt = 1; $kcnt < $key_cnt; $kcnt += 1) {
+        $val = "$val not_found_$kcnt";
+        $rst .= "not_found_$kcnt NOT_FOUND\n";
+    }
+
+    my $key_len = length($val);
+    my $cmd = "mdelete $key_len $key_cnt";
+    mem_cmd_is($sock, $cmd, $val, $rst);
+}
+
+# mixed case(DELETED || NOT_FOUND)
+sub kv_mdelete_mixed {
+    my ($key_cnt) = @_;
+
+    my $val = "not_found_0";
+    my $rst = "not_found_0 NOT_FOUND\n";
+
+    for (my $kcnt = 1; $kcnt < $key_cnt; $kcnt += 1) {
+        if ($kcnt % 2 == 0 ) {
+            $val = "$val not_found_$kcnt";
+            $rst .= "not_found_$kcnt NOT_FOUND\n";
+            next;
+        }
+        $val = "$val key_$kcnt";
+        $rst .= "key_$kcnt DELETED\n";
+    }
+
+    my $key_len = length($val);
+    my $cmd = "mdelete $key_len $key_cnt";
+    mem_cmd_is($sock, $cmd, $val, $rst);
+}
+
+bad_command();
+
+my $key_cnt = 1000;
+my $key_str;
+my $key_len;
+
+$key_str = "key_0";
+for (my $kcnt = 1; $kcnt < $key_cnt; $kcnt += 1) {
+    $key_str = "$key_str key_$kcnt";
+}
+$key_len = length($key_str);
+
+prepare_kv_mdelete($key_cnt);
+kv_mdelete_hits($key_len, $key_cnt, $key_str);
+
+prepare_kv_mdelete($key_cnt);
+kv_mdelete_not_found($key_cnt);
+
+prepare_kv_mdelete($key_cnt);
+kv_mdelete_mixed($key_cnt);
+
+# after test
+release_memcached($engine, $server);

--- a/t/tlist/engine_default_b.txt
+++ b/t/tlist/engine_default_b.txt
@@ -94,3 +94,4 @@
 ./t/unixsocket.t
 ./t/verbosity.t
 ./t/whitespace.t
+./t/mdelete.t

--- a/t/tlist/engine_default_s.txt
+++ b/t/tlist/engine_default_s.txt
@@ -87,3 +87,4 @@
 ./t/unixsocket.t
 ./t/verbosity.t
 ./t/whitespace.t
+./t/mdelete.t


### PR DESCRIPTION
## 명령어

기존 mget 명령과 유사
```
mdelete <lenkeys> <numkeys>\r\n
<"space separated keys">\r\n
```
<”space separated keys”> - key list로, 스페이스(' ')로 구분한다.
\<lenkeys\>과 \<numkeys\> - key list 문자열의 길이와 key 개수를 나타낸다.

## 제약사항

클라이언트의 요청 단위는 현 java client의 mget과 같은 200개로 한다.

서버의 한계는 mget과 같은 10000개로 한다. 

## response

정상적으로 수행된 경우 기존 삭제 명령과 같이 DELETED, NOT_FOUND 중 하나의 결과를 낸다.

```
<key1> DELETED|NOT_FOUND\r\n
<key2> DELETED|NOT_FOUND\r\n
...
<keyN> DELETED|NOT_FOUND\r\n
```

## 동작 과정

* process_command
    * tokens의 총 길이가 4이고 첫번째 토큰이 ‘mdelete’이면 process_mdelete_command 함수 실행 
* process_mdelete_command: conn 구조체의 coll_op 변수에 OPERATION_MDELETE 대입.
    * lenkeys와 numkeys의 무결성 검증. (음수인 경우 등) 검증 방식은 process_mget_command와 같음.
    * 문제가 없는 경우 process_prepare_nread_keys 실행
* process_prepare_nread_keys
    * nread 과정에서 필요한 메모리 블락을 connection에 할당함.
    * 원래는 mget에서 사용하는 함수이나 mdelete에서도 같이 사용.
    * 동작이 완료되면 conn 상태를 nread로 바꿈
* process_mdelete_complete
    * nread 상태에서 실행. complete_ascii 함수에서 호출 됨.
    * 입력으로 들어온 키에 대해 엔진의 remove api 호출. 
    * 리턴값에 따라 reponse string 구성.
    * 메모리가 부족하거나 bad value가 들어온 경우 중단
    * conn 상태를 mwrite 로 바꿈