### PR TITLE
DOC: remove time option of delete command

### DIFF
--- a/doc/command-key-value.md
+++ b/doc/command-key-value.md
@@ -41,7 +41,7 @@ mget <lenkeys> <numkeys>\r\n
 delete 명령이 있으며 syntax는 다음과 같다.
 
 ```
-delete <key> [<time>] [noreply]\r\n
+delete <key> [noreply]\r\n
 ```
 
 **Increment/Decrement 명령**


### PR DESCRIPTION
delete command 에서 delay delete를 지원하는
time option을 사용할 수 있는 것처럼 되어 있습니다.

실제로는 지원하지 않고 있고, 아마 기존 memcached 버전의 backward compatibility 때문에
남겨둔 값으로 보입니다. 실제 코드를 보면 delete 에 time option을 줄 순 있지만, `0`이 아니면 error 처리 됩니다.
현재 최신 memcached도 같은 코드로 동작하는 상태로, time option을 노출시키지 않는게 좋을 것 같습니다.

@jhpark816 
확인 요청 드립니다.