### PR TITLE
CLEANUP: add error handling for auto_scrub

### DIFF
--- a/arcus_zk.c
+++ b/arcus_zk.c
@@ -1282,11 +1282,13 @@ static void sm_check_and_scrub_stale(bool *retry)
        /* remove stale items after zk_timeout have passed
         * since a new node is added to the cluster
         */
-        if (arcus_memcached_scrub_stale() != 0) {
+        if (arcus_memcached_scrub_stale() == 0) {
+            sm_info.node_added_time = 0;
+        } else {
             arcus_conf.logger->log(EXTENSION_LOG_WARNING, NULL,
                                   "Failed to scrub stale data.\n");
+            *retry = true; /* Do retry */
         }
-        sm_info.node_added_time = 0;
     } else {
         *retry = true; /* Do retry */
     }


### PR DESCRIPTION
노드 추가에 따른 auto scrub 동작 실패 시 에러 처리 코드를 추가했습니다.
auto scrub 수행이 실패하는 경우는 scrub thread 생성에 실패하는 경우밖에 없습니다.