### PR TITLE
FEATURE: add max_element_bytes config

### DIFF
--- a/doc/arcus-basic-concept.md
+++ b/doc/arcus-basic-concept.md
@@ -15,7 +15,7 @@ Arcus cache server의 key-value 모델은 아래의 기본 제약 사항을 가�
   - Value의 최대 크기는 1MB(trailing 문자인 “\r\n” 포함한 길이) 이다.
 - Collection 제약 사항
   - 하나의 collection에 들어갈 수 있는 최대 element 개수는 50,000개이다.
-  - Collection의 각 element가 가지는 value의 최대 크기는 4KB(trailing 문자인 “\r\n” 포함한 길이) 이다.
+  - Collection의 각 element가 가지는 value의 최대 크기는 16KB(trailing 문자인 “\r\n” 포함한 길이)이며 이는 설정으로 변경 가능하다.
 
 ### Cache Key
 

--- a/doc/command-administration.md
+++ b/doc/command-administration.md
@@ -268,6 +268,7 @@ Arcus cache server는 특정 configuration에 대해 동적으로 변경하거�
 - memlimit
 - zkfailstop
 - maxconns
+- max_element_bytes
 
 **config verbosity**
 
@@ -312,6 +313,15 @@ config maxconns [<maxconn>]\r\n
 
 \<maxconn\>는 새로 지정할 최대 연결 수로서, 현재의 연결 수보다 10% 이상의 큰 값으로만 설정이 가능하다.
 이 인자가 생략되면 현재 설정되어 있는 최대 연결 수 값을 조회한다.
+
+**config max_element_bytes**
+
+Collection element가 가지는 value의 최대 크기를 byte 단위로 설정한다. 기본 설정은 16KB이며 1~32KB까지 설정 가능하다.
+
+```
+config max_element_bytes [<maxbytes>]\r\n
+```
+
 
 ### Command Logging 명령
 

--- a/include/memcached/types.h
+++ b/include/memcached/types.h
@@ -31,6 +31,7 @@ struct iovec {
 #include <sys/uio.h>
 #endif
 
+#define MAX_ELEMENT_BYTES_CONFIG
 #define PROXY_SUPPORT
 #define BOP_COUNT_OPTIMIZE
 //#define NEW_PREFIX_STATS_MANAGEMENT

--- a/memcached.c
+++ b/memcached.c
@@ -68,6 +68,13 @@ static int MAX_SET_SIZE   = 50000;
 static int MAX_MAP_SIZE   = 50000;
 static int MAX_BTREE_SIZE = 50000;
 
+#ifdef MAX_ELEMENT_BYTES_CONFIG
+/* max element bytes */
+static int ARCUS_ELEMENT_BYTES_MIN = 1024;
+static int ARCUS_ELEMENT_BYTES_MAX = 32*1024;
+static int MAX_ELEMENT_BYTES = 16*1024;
+#endif
+
 /* The item must always be called "it" */
 #define SLAB_GUTS(conn, thread_stats, slab_op, thread_op) \
     thread_stats->slab_stats[c->hinfo.clsid].slab_op++;
@@ -371,6 +378,9 @@ static void settings_init(void)
     settings.max_set_size = MAX_SET_SIZE;
     settings.max_map_size = MAX_MAP_SIZE;
     settings.max_btree_size = MAX_BTREE_SIZE;
+#ifdef MAX_ELEMENT_BYTES_CONFIG
+    settings.max_element_bytes = MAX_ELEMENT_BYTES;
+#endif
     settings.topkeys = 0;
     settings.require_sasl = false;
     settings.extensions.logger = get_stderr_logger();
@@ -8304,6 +8314,9 @@ static void process_stat_settings(ADD_STAT add_stats, void *c)
     APPEND_STAT("max_set_size", "%d", settings.max_set_size);
     APPEND_STAT("max_map_size", "%d", settings.max_map_size);
     APPEND_STAT("max_btree_size", "%d", settings.max_btree_size);
+#ifdef MAX_ELEMENT_BYTES_CONFIG
+    APPEND_STAT("max_element_bytes", "%d", settings.max_element_bytes);
+#endif
     APPEND_STAT("topkeys", "%d", settings.topkeys);
 
     for (EXTENSION_DAEMON_DESCRIPTOR *ptr = settings.extensions.daemons;
@@ -9281,6 +9294,35 @@ static void process_maxcollsize_command(conn *c, token_t *tokens, const size_t n
     }
 }
 
+#ifdef MAX_ELEMENT_BYTES_CONFIG
+static void process_maxelembytes_command(conn *c, token_t *tokens, const size_t ntokens)
+{
+    assert(c != NULL);
+    int32_t maxbytes;
+
+    if (ntokens == 3) {
+        char buf[50];
+        sprintf(buf, "max_element_bytes %d\r\nEND", settings.max_element_bytes);
+        out_string(c, buf);
+    }
+    else if (ntokens == 4 && safe_strtol(tokens[SUBCOMMAND_TOKEN+1].value, &maxbytes)) {
+        if (maxbytes < ARCUS_ELEMENT_BYTES_MIN || maxbytes > ARCUS_ELEMENT_BYTES_MAX) {
+            out_string(c, "CLIENT_ERROR bad value");
+            return;
+        }
+        SETTING_LOCK();
+        MAX_ELEMENT_BYTES = maxbytes;
+        settings.max_element_bytes = maxbytes;
+        SETTING_UNLOCK();
+        out_string(c, "END");
+    }
+    else {
+        print_invalid_command(c, tokens, ntokens);
+        out_string(c, "CLIENT_ERROR bad command line format");
+    }
+}
+#endif
+
 static void process_verbosity_command(conn *c, token_t *tokens, const size_t ntokens)
 {
     assert(c != NULL);
@@ -9354,6 +9396,11 @@ static void process_config_command(conn *c, token_t *tokens, const size_t ntoken
     else if (strcmp(tokens[SUBCOMMAND_TOKEN].value, "max_btree_size") == 0) {
         process_maxcollsize_command(c, tokens, ntokens, ITEM_TYPE_BTREE);
     }
+#ifdef MAX_ELEMENT_BYTES_CONFIG
+    else if (strcmp(tokens[SUBCOMMAND_TOKEN].value, "max_element_bytes") == 0) {
+        process_maxelembytes_command(c, tokens, ntokens);
+    }
+#endif
     else if (strcmp(tokens[SUBCOMMAND_TOKEN].value, "verbosity") == 0) {
         process_verbosity_command(c, tokens, ntokens);
     }
@@ -9605,6 +9652,9 @@ static void process_help_command(conn *c, token_t *tokens, const size_t ntokens)
         "\t" "config max_set_size [<maxsize>]\\r\\n" "\n"
         "\t" "config max_map_size [<maxsize>]\\r\\n" "\n"
         "\t" "config max_btree_size [<maxsize>]\\r\\n" "\n"
+#ifdef MAX_ELEMENT_BYTES_CONFIG
+        "\t" "config max_element_bytes [<maxbytes>]\\r\\n" "\n"
+#endif
 #ifdef ENABLE_ZK_INTEGRATION
         "\t" "config hbtimeout [<hbtimeout>]\\r\\n" "\n"
         "\t" "config hbfailstop [<hbfailstop>]\\r\\n" "\n"

--- a/memcached.h
+++ b/memcached.h
@@ -89,7 +89,10 @@
 #define MAX_MGET_KEY_COUNT 10000
 
 /* Max element value size */
-#define MAX_ELEMENT_BYTES  (4*1024)
+#ifdef MAX_ELEMENT_BYTES_CONFIG
+#else
+#define MAX_ELEMENT_BYTES          (4*1024)
+#endif
 
 #ifdef SUPPORT_BOP_MGET
 /* In bop mget, max limit on the number of given keys */
@@ -402,6 +405,9 @@ struct settings {
     int max_set_size;       /* Maximum elements in set collection */
     int max_map_size;       /* Maximum elements in map collection */
     int max_btree_size;     /* Maximum elements in b+tree collection */
+#ifdef MAX_ELEMENT_BYTES_CONFIG
+    int max_element_bytes;  /* Maximum element bytes of collections */
+#endif
     int topkeys;            /* Number of top keys to track */
     struct {
         EXTENSION_DAEMON_DESCRIPTOR *daemons;

--- a/t/coll_max_elembytes_test.t
+++ b/t/coll_max_elembytes_test.t
@@ -1,0 +1,84 @@
+#!/usr/bin/perl
+
+use strict;
+use Test::More tests => 19;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use MemcachedTest;
+
+my $engine = shift;
+my $server = get_memcached($engine);
+my $sock = $server->sock;
+
+my $cmd;
+my $rst;
+
+my $max16 = 16*1024;
+my $val16len = $max16 - 2;
+my $val16;
+for (1..$val16len) { $val16 .= chr( int(rand(25) + 65) ); }
+
+my $max32 = 32*1024;
+my $val32len = $max32 - 2;
+my $val32;
+for (1..$val32len) { $val32 .= chr( int(rand(25) + 65) ); }
+
+$cmd = "config max_element_bytes $max16"; $rst = "END";
+mem_cmd_is($sock, $cmd, "", $rst);
+$rst = "CREATED_STORED";
+$cmd = "lop insert lkey1 0 $val16len create 11 0 0";
+mem_cmd_is($sock, $cmd, $val16, $rst);
+$cmd = "sop insert skey1 $val16len create 11 0 0";
+mem_cmd_is($sock, $cmd, $val16, $rst);
+$cmd = "mop insert mkey1 0 $val16len create 11 0 0";
+mem_cmd_is($sock, $cmd, $val16, $rst);
+$cmd = "bop insert bkey1 0 $val16len create 11 0 0";
+mem_cmd_is($sock, $cmd, $val16, $rst);
+$rst = "CLIENT_ERROR too large value";
+$cmd = "lop insert lkey2 0 $val32len create 11 0 0";
+mem_cmd_is($sock, $cmd, $val32, $rst);
+$cmd = "sop insert skey2 $val32len create 11 0 0";
+mem_cmd_is($sock, $cmd, $val32, $rst);
+$cmd = "mop insert mkey2 0 $val32len create 11 0 0";
+mem_cmd_is($sock, $cmd, $val32, $rst);
+$cmd = "bop insert bkey2 0 $val32len create 11 0 0";
+mem_cmd_is($sock, $cmd, $val32, $rst);
+
+$cmd = "config max_element_bytes $max32"; $rst = "END";
+mem_cmd_is($sock, $cmd, "", $rst);
+$rst = "CREATED_STORED";
+$cmd = "lop insert lkey3 0 $val32len create 11 0 0";
+mem_cmd_is($sock, $cmd, $val32, $rst);
+$cmd = "sop insert skey3 $val32len create 11 0 0";
+mem_cmd_is($sock, $cmd, $val32, $rst);
+$cmd = "mop insert mkey3 0 $val32len create 11 0 0";
+mem_cmd_is($sock, $cmd, $val32, $rst);
+$cmd = "bop insert bkey3 0 $val32len create 11 0 0";
+mem_cmd_is($sock, $cmd, $val32, $rst);
+
+$val16 = "";
+for (1..$val16len) { $val16 .= 'a' ; }
+
+$val32 = "";
+for (1..$val32len) { $val32 .= 'b'; }
+
+$cmd = "bop create bkey4 11 0 0"; $rst="CREATED";
+mem_cmd_is($sock, $cmd, "", $rst);
+$rst = "STORED";
+$cmd = "bop insert bkey4 0 $val16len";
+mem_cmd_is($sock, $cmd, $val16, $rst);
+$cmd = "bop insert bkey4 1 $val32len";
+mem_cmd_is($sock, $cmd, $val32, $rst);
+$cmd = "bop get bkey4 0";
+$rst = "VALUE 11 1
+0 $val16len $val16
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "bop get bkey4 1";
+$rst = "VALUE 11 1
+1 $val32len $val32
+END";
+mem_cmd_is($sock, $cmd, "", $rst);
+
+# after test
+release_memcached($engine, $server);

--- a/t/tlist/engine_default_b.txt
+++ b/t/tlist/engine_default_b.txt
@@ -16,6 +16,7 @@
 ./t/bogus-commands.t
 ./t/cas.t
 ./t/cmd_extensions.t
+./t/coll_max_elembytes_test.t
 ./t/coll_bkeymismatch_test.t
 ./t/coll_bkeyoor_test.t
 ./t/coll_bop_attr_min_max_bkey.t

--- a/t/tlist/engine_default_s.txt
+++ b/t/tlist/engine_default_s.txt
@@ -9,6 +9,7 @@
 ./t/bogus-commands.t
 ./t/cas.t
 ./t/cmd_extensions.t
+./t/coll_max_elembytes_test.t
 ./t/coll_bkeymismatch_test.t
 ./t/coll_bkeyoor_test.t
 ./t/coll_bop_attr_min_max_bkey.t


### PR DESCRIPTION
최대 element 크기를 조절할 수 있도록 기능을 추가하였습니다.
기존에 이 크기에 대한 설정은 memcached.h에 매크로로 설정되어있었는데
collection size에 대한 설정들이 memcached.c 쪽에 있어서
해당 위치로 element 크기 설정도 옮기고 변수 이름도 비슷한 모습으로 만들어두었습니다.