### PR TITLE
DOC: remove hyphen in documents chapter title

### DIFF
--- a/doc/arcus-ascii-protocol.md
+++ b/doc/arcus-ascii-protocol.md
@@ -1,4 +1,4 @@
-Arcus-memcached Ascii Protocol
+Arcus memcached Ascii Protocol
 ==============================
 
 Arcus cache server가 제공하는 명령들에 대한 ascii protocol을 기술한다.

--- a/doc/arcus-telnet-interface.md
+++ b/doc/arcus-telnet-interface.md
@@ -29,7 +29,7 @@ telnet 명령으로 memcached에 연결한 이후에는 Arcus ASCII 명령을 �
 아래에서 그 예들을 든다. Arcus ASCII 명령의 자세한 설명은 [Arcus cache server ascii protocol](/doc/arcus-ascii-protocol.md)을 참고하기 바란다.
 
 
-### 예제 1 - get/set
+### 예제 1.  get/set
 
 하나의 key-value item으로 <"foo", "fooval">을 저장하기 위해, set 명령을 입력한다.
 
@@ -60,7 +60,7 @@ fooval
 END
 ```
 
-### 예제 2 - b+tree
+### 예제 2.  b+tree
 
 하나의 b+tree item을 생성하면서 5개의 elements를 추가하기 위해,
 아래의 5개 bop insert 명령을 차례로 수행한다.

--- a/doc/command-btree-collection.md
+++ b/doc/command-btree-collection.md
@@ -38,7 +38,7 @@ Ranking 시스템에서는 특정 score를 bkey로 하여 해당 elements를 저
 조회는 최고/최저 score 기준으로 몇번째 위치 또는 위치의 범위에 해당하는 element를 찾는 경우가 많다.
 
 
-### bop create - B+tree Collection 생성
+### bop create (B+tree Collection 생성)
 
 B+tree collection을 empty 상태로 생성한다.
 
@@ -59,7 +59,7 @@ Response string과 그 의미는 아래와 같다.
 - “CLIENT_ERROR bad command line format” - protocol syntax 틀림
 - “SERVER_ERROR out of memory” - 메모리 부족
 
-### bop insert/upsert - B+Tree Element 삽입/대체
+### bop insert/upsert (B+Tree Element 삽입/대체)
 
 B+tree collection에 하나의 element를 추가하는 명령으로
 (1) 하나의 element를 삽입하는 bop insert 명령과
@@ -114,7 +114,7 @@ END\r\n
 - “CLIENT_ERROR bad data chunk” - 삽입할 데이터의 길이가 <bytes>와 다르거나 "\r\n"으로 끝나지 않음
 - “SERVER_ERROR out of memory” - 메모리 부족
 
-### bop update - B+Tree Element 변경
+### bop update (B+Tree Element 변경)
 
 B+tree collection에서 하나의 element에 대해 eflag 변경 그리고/또는 data 변경을 수행한다.
 현재 다수 elements에 대한 변경 연산은 제공하지 않고 있다.
@@ -150,7 +150,7 @@ Response string과 그 의미는 아래와 같다.
 - “CLIENT_ERROR bad data chunk” - 변경할 데이터의 길이가 <bytes>와 다르거나 "\r\n"으로 끝나지 않음
 - “SERVER_ERROR out of memory” - 메모리 부족
 
-### bop delete - B+Tree Element 삭제
+### bop delete (B+Tree Element 삭제)
 
 b+tree collection에서 하나의 bkey 또는 bkey range 조건과 eflag filter 조건을 만족하는
 N 개의 elements를 삭제한다.
@@ -181,7 +181,7 @@ Response string과 그 의미는 아래와 같다.
 - "NOT_SUPPORTED" - 지원하지 않음
 - “CLIENT_ERROR bad command line format” - protocol syntax 틀림
 
-### bop get - B+Tree Element 조회
+### bop get (B+Tree Element 조회)
 
 B+tree collection에서 하나의 bkey 또는 bkey range 조건과 eflag filter 조건을 만족하는 
 elements에서 offset 개를 skip한 후 count 개의 elements를 조회한다.
@@ -239,7 +239,7 @@ END|TRIMMED|DELETED|DELETED_DROPPED\r\n
 - “CLIENT_ERROR bad command line format” - protocol syntax 틀림
 - “SERVER_ERROR out of memory [writing get response]” - 메모리 부족
 
-### bop count - B+Tree Element 개수 계산
+### bop count (B+Tree Element 개수 계산)
 
 b+tree collection에서 하나의 bkey 또는 bkey range 조건과 eflag filter 조건을 만족하는
 elements 개수를 구한다.
@@ -270,7 +270,7 @@ COUNT=<count>
 - "NOT_SUPPORTED" - 지원하지 않음
 - “CLIENT_ERROR bad command line format” - protocol syntax 틀림
 
-### bop incr/decr - B+Tree Element 값의 증감
+### bop incr/decr (B+Tree Element 값의 증감)
 
 B+tree collection 특정 하나의 eleement에 있는 데이터를 increment 또는 decrement하고,
 증감된 데이터를 반환한다.
@@ -315,7 +315,7 @@ Increment/decrement 수행 후의 데이터 값이다.
 - “CLIENT_ERROR bad command line format” - protocol syntax 틀림
 - “SERVER_ERROR out of memory [writing get response]” - 메모리 부족
 
-### bop mget - B+Tree Multiple Get
+### bop mget (B+Tree Multiple Get)
 
 여러 b+tree들에 대해 동일 조회 조건(bkey range와 eflag filter)으로 element들을 한꺼번에 조회한다.
 여러 b+tree들에 대한 동일 조회 조건을 사용하므로, 대상 b+tree들은 동일 bkey 유형을 가져야 한다.
@@ -388,7 +388,7 @@ flags와 ecount를 포함하여 조회된 element 정보가 생략된다.
 - “CLIENT_ERROR bad value” - bop mget 명령의 제약 조건을 위배함.
 - “SERVER_ERROR out of memory [writing get response]” - 메모리 부족
 
-### bop smget - B+Tree Sort Merge Get
+### bop smget (B+Tree Sort Merge Get)
 
 여러 b+tree들에서 bkey range 조건과 eflag filter 조건을 모두 만족하는
 elements를 sort merge 형태로 조회하면서 count 개의 elements를 가져온다.
@@ -539,7 +539,7 @@ smget 수행의 실패 시의 response string은 다음과 같다.
 - “SERVER_ERROR out of memory [writing get response]” - 메모리 부족
 
 
-### bop position - B+Tree Position 조회
+### bop position (B+Tree Position 조회)
 
 b+tree collection에서 특정 element의 position을 조회한다.
 Element의 position이란 b+tree에서의 위치 정보로서,
@@ -571,7 +571,7 @@ POSITION=<position>\r\n
 - "NOT_SUPPORTED" - 지원하지 않음
 - “CLIENT_ERROR bad command line format” - protocol syntax 틀림
 
-### bop gbp - B+Tree Get By Position
+### bop gbp (B+Tree Get By Position)
 
 B+tree collection에서 position 기반으로 elements를 조회한다.
 
@@ -607,7 +607,7 @@ END\r\n
 - “CLIENT_ERROR bad command line format” - protocol syntax 틀림
 - “SERVER_ERROR out of memory [writing get response]” - 메모리 부족
 
-### bop pwg - B+Tree Find Position with Get (version 1.8.0)
+### bop pwg (B+Tree Find Position with Get [version 1.8.0])
 
 B+tree collection에서 특정 bkey의 position을 조회하면서,
 그 bkey를 가진 element를 포함하여 앞뒤에(양방향) 위치한 element N개 씩을 한번에 조회한다.

--- a/doc/command-item-attribute.md
+++ b/doc/command-item-attribute.md
@@ -7,7 +7,7 @@ Arcus에서 어떤 item attributes를 제공하는 지를 알고자 한다면,
 [Item Attibute 설명](/doc/arcus-item-attribute.md)을 참고 바란다.
 
 
-### getattr - Item Attribute 조회
+### getattr (Item Attribute 조회)
 
 Item attributes를 조회하는 getattr 명령은 아래와 같다.
 
@@ -36,7 +36,7 @@ END\r\n
 - “CLIENT_ERROR bad command line format” - protocol syntax 틀림
 
 
-### setattr - Item Attribute 변경
+### setattr (Item Attribute 변경)
 
 Item attributes를 변경하는 setattr 명령은 아래와 같다.
 모든 attributes에 대해 조회가 가능하지만, 변경은 일부 attributes에 대해서만 가능하다.

--- a/doc/command-list-collection.md
+++ b/doc/command-list-collection.md
@@ -12,7 +12,7 @@ List element에 관한 명령은 아래와 같다.
 - [List element 삭제: lop delete](command-list-collection.md#lop-delete---list-element-%EC%82%AD%EC%A0%9C)
 - [List element 조회: lop get](command-list-collection.md#lop-get---list-element-%EC%A1%B0%ED%9A%8C)
 
-### lop create - List Collection 생성
+### lop create (List Collection 생성)
 
 List collection을 empty 상태로 생성한다.
 
@@ -33,7 +33,7 @@ Response string과 그 의미는 아래와 같다.
 - “CLIENT_ERROR bad command line format” - protocol syntax 틀림
 - “SERVER_ERROR out of memory” - 메모리 부족
 
-### lop insert - List Element 삽입
+### lop insert (List Element 삽입)
 
 List collection에 하나의 element를 삽입한다.
 List collection을 생성하면서 하나의 element를 삽입할 수도 있다.
@@ -69,7 +69,7 @@ Response string과 그 의미는 아래와 같다.
 - “CLIENT_ERROR bad data chunk” - 삽입할 데이터 길이가 \<bytes\>와 다르거나 "\r\n"으로 끝나지 않음
 - “SERVER_ERROR out of memory” - 메모리 부족
 
-### lop delete - List Element 삭제
+### lop delete (List Element 삭제)
 
 List collection에 하나의 index 또는 index range에 해당하는 elements를 삭제한다.
 
@@ -100,7 +100,7 @@ Response string과 그 의미는 아래와 같다.
 - "NOT_SUPPORTED" - 지원하지 않음
 - “CLIENT_ERROR bad command line format” - protocol syntax 틀림
 
-### lop get - List Element 조회
+### lop get (List Element 조회)
 
 List collection에 하나의 index 또는 index range에 해당하는 elements를 조회한다.
 

--- a/doc/command-map-collection.md
+++ b/doc/command-map-collection.md
@@ -13,7 +13,7 @@ Map element에 관한 명령은 아래와 같다.
 - [Map element 삭제: mop delete](command-map-collection.md#mop-delete---map-element-삭제)
 - [Map element 조회: mop get](command-map-collection.md#mop-get---map-field-element-조회)
 
-### mop create - Map Collection 생성
+### mop create (Map Collection 생성)
 
 Map collection을 empty 상태로 생성한다.
 
@@ -34,7 +34,7 @@ Response string과 그 의미는 아래와 같다.
 - “CLIENT_ERROR bad command line format” - protocol syntax 틀림
 - “SERVER_ERROR out of memory” - 메모리 부족
 
-### mop insert - Map Element 삽입
+### mop insert (Map Element 삽입)
 
 Map collection에 하나의 field, element를 삽입한다.
 Map collection을 생성하면서 \<field, value\>로 구성된 하나의 element를 삽입할 수도 있다.
@@ -68,7 +68,7 @@ Response string과 그 의미는 아래와 같다.
 - “CLIENT_ERROR invalid prefix name” - 유효하지(존재하지) 않는 prefix 명
 - “SERVER_ERROR out of memory” - 메모리 부족
 
-### mop update - Map Element 변경
+### mop update (Map Element 변경)
 
 Map collection에서 하나의 field에 대해 element 변경을 수행한다.
 현재 다수 field에 대한 변경연산은 제공하지 않는다.
@@ -96,7 +96,7 @@ Response string과 그 의미는 아래와 같다.
 - “CLIENT_ERROR bad data chunk” - 삽입할 데이터 길이가 \<bytes\>와 다르거나 "\r\n"으로 끝나지 않음
 - “SERVER_ERROR out of memory” - 메모리 부족
 
-### mop delete - Map Element 삭제
+### mop delete (Map Element 삭제)
 
 Map collection에서 하나 이상의 field 이름을 주어, 그에 해당하는 element를 삭제한다.
 
@@ -123,7 +123,7 @@ Response string과 그 의미는 아래와 같다.
 - "NOT_SUPPORTED" - 지원하지 않음
 - “CLIENT_ERROR bad command line format” - protocol syntax 틀림
 
-### mop get - Map Field, Element 조회
+### mop get (Map Field, Element 조회)
 
 Map collection에서 하나 이상의 field 이름을 주어, 그에 해당하는 element를 조회한다.
 

--- a/doc/command-set-collection.md
+++ b/doc/command-set-collection.md
@@ -13,7 +13,7 @@ Set element에 관한 명령은 아래와 같다.
 - [Set element 조회: sop get](command-set-collection.md#sop-get---set-element-%EC%A1%B0%ED%9A%8C)
 - [Set element 존재유무 검사: sop exist](command-set-collection.md#sop-exist---set-element-%EC%A1%B4%EC%9E%AC%EC%9C%A0%EB%AC%B4-%EA%B2%80%EC%82%AC)
 
-### sop create - Set Collection 생성
+### sop create (Set Collection 생성)
 
 Set collection을 empty 상태로 생성한다.
 
@@ -34,7 +34,7 @@ Response string과 그 의미는 아래와 같다.
 - “CLIENT_ERROR bad command line format” - protocol syntax 틀림
 - “SERVER_ERROR out of memory” - 메모리 부족
 
-### sop insert - Set Element 삽입
+### sop insert (Set Element 삽입)
 
 Set collection에 하나의 element를 삽입한다.
 Set collection을 생성하면서 하나의 element를 삽입할 수도 있다.
@@ -66,7 +66,7 @@ Response string과 그 의미는 아래와 같다.
 - “CLIENT_ERROR bad data chunk” - 삽입할 데이터 길이가 \<bytes\>와 다르거나 "\r\n"으로 끝나지 않음
 - “SERVER_ERROR out of memory” - 메모리 부족
 
-### sop delete - Set Element 삭제
+### sop delete (Set Element 삭제)
 
 Set collection에서 하나의 element를 삭제한다.
 
@@ -93,7 +93,7 @@ Response string과 그 의미는 아래와 같다.
 - “CLIENT_ERROR too large value” - 삭제할 데이터가 4KB 보다 큼
 - “CLIENT_ERROR bad data chunk” - 삭제할 데이터의 길이가 \<bytes\>와 다르거나 “\r\n”으로 끝나지 않음
 
-### sop get - Set Element 조회
+### sop get (Set Element 조회)
 
 Set collection에서 N 개의 elements를 조회한다.
 
@@ -131,7 +131,7 @@ END|DELETED|DELETED_DROPPED\r\n
 - “CLIENT_ERROR bad command line format” - protocol syntax 틀림
 - "SERVER_ERROR out of memory [writing get response]”	- 메모리 부족
 
-### sop exist - Set Element 존재유무 검사
+### sop exist (Set Element 존재유무 검사)
 
 Set collection에 특정 element의 존재 유무를 검사한다.
 


### PR DESCRIPTION
docsify와 github의 링크 호환을 위해 제목에서 하이픈을 지우고 자연스러운 형태로 바꿨습니다.