### PR TITLE
[persistence] rename functions.

### DIFF
--- a/engines/default/cmdlogbuf.h
+++ b/engines/default/cmdlogbuf.h
@@ -22,14 +22,14 @@
 #include "cmdlogrec.h"
 
 /* external log functions */
-void log_record_write(LogRec *logrec, log_waiter_t *waiter, bool dual_write);
-void log_file_sync(void);
-void log_buffer_flush(LogSN *upto_lsn);
+void cmdlog_buff_write(LogRec *logrec, log_waiter_t *waiter, bool dual_write);
+void cmdlog_buff_flush(LogSN *upto_lsn);
+void cmdlog_file_sync(void);
 
 /* FIXME: remove later, if not used */
 //void log_get_write_lsn(LogSN *lsn);
-void log_get_flush_lsn(LogSN *lsn);
-void log_get_fsync_lsn(LogSN *lsn);
+void cmdlog_get_flush_lsn(LogSN *lsn);
+void cmdlog_get_fsync_lsn(LogSN *lsn);
 
 int               cmdlog_file_open(char *path);
 size_t            cmdlog_file_getsize(void);


### PR DESCRIPTION
issue https://github.com/naver/arcus-memcached/issues/410 와 관련한 PR입니다. 함수 명 변경부터 반영하겠습니다. 간단한 PR이므로 코드 태그는 생략하였습니다.

내부 함수와 용어를 맞추기 위해 cmdlog_buf_write, cmdlog_buf_flush 대신 cmdlog_buff_write, cmdlog_buff_flush 로 변경하였습니다.

@MinWooJin 리뷰 요청드립니다.