### PR TITLE
[persistence] refactoring cmdlog_file_apply.

### DIFF
--- a/engines/default/cmdlogrec.c
+++ b/engines/default/cmdlogrec.c
@@ -1391,11 +1391,9 @@ ENGINE_ERROR_CODE lrec_redo_from_record(LogRec *logrec)
 #endif
     if (logrec_func[logrec->header.logtype].redo != NULL) {
         return logrec_func[logrec->header.logtype].redo(logrec);
-    } else {
-        logger->log(EXTENSION_LOG_WARNING, NULL, "lrec_redo_from_record(logtype=%s) "
-                    "is not supported.\n", get_logtype_text(logrec->header.logtype));
-        return ENGINE_ENOTSUP;
     }
+    /* exist some log records don't need to redo (ex. SnapshotDoneLog). */
+    return ENGINE_SUCCESS;
 }
 
 /* Construct Log Record Functions */


### PR DESCRIPTION
- cmdlog_file_apply 함수 리팩토링
- lrec_redo_from_record 함수에서 redo=NULL 인 경우 ENGINE_SUCCESS 반환 
   - 현재 snapshotDoneLog 읽으면 redo=NULL이여서 에러 메세지 출력하고 있었네요.

@jhpark816 리뷰 요청드립니다.