### PR TITLE
CLEANUP: move thread function declarations to thread.h

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -77,6 +77,7 @@ memcached_SOURCES = \
                     sasl_defs.h \
                     stats.c stats.h \
                     thread.c \
+                    thread.h \
                     mc_util.c \
                     mc_util.h \
                     topkeys.c \

--- a/memcached.c
+++ b/memcached.c
@@ -75,6 +75,29 @@ static int ARCUS_ELEMENT_BYTES_MAX = 32*1024;
 static int MAX_ELEMENT_BYTES = 16*1024;
 #endif
 
+/* Lock for global stats */
+static pthread_mutex_t stats_lock = PTHREAD_MUTEX_INITIALIZER;
+
+
+void STATS_LOCK() {
+    pthread_mutex_lock(&stats_lock);
+}
+
+void STATS_UNLOCK() {
+    pthread_mutex_unlock(&stats_lock);
+}
+
+/* Lock for global settings */
+static pthread_mutex_t setting_lock = PTHREAD_MUTEX_INITIALIZER;
+
+void SETTING_LOCK() {
+    pthread_mutex_lock(&setting_lock);
+}
+
+void SETTING_UNLOCK() {
+    pthread_mutex_unlock(&setting_lock);
+}
+
 /* The item must always be called "it" */
 #define SLAB_GUTS(conn, thread_stats, slab_op, thread_op) \
     thread_stats->slab_stats[c->hinfo.clsid].slab_op++;

--- a/memcached.h
+++ b/memcached.h
@@ -196,165 +196,6 @@ enum network_transport {
 
 #define IS_UDP(x) (x == udp_transport)
 
-/** Stats stored per slab (and per thread). */
-struct slab_stats {
-    uint64_t  cmd_set;
-    uint64_t  get_hits;
-    uint64_t  delete_hits;
-    uint64_t  cas_hits;
-    uint64_t  cas_badval;
-};
-
-/**
- * Stats stored per-thread.
- */
-struct thread_stats {
-    pthread_mutex_t   mutex;
-    uint64_t          cmd_get;
-    uint64_t          cmd_incr;
-    uint64_t          cmd_decr;
-    uint64_t          cmd_delete;
-    uint64_t          get_misses;
-    uint64_t          delete_misses;
-    uint64_t          incr_misses;
-    uint64_t          decr_misses;
-    uint64_t          incr_hits;
-    uint64_t          decr_hits;
-    uint64_t          cmd_cas;
-    uint64_t          cas_misses;
-    uint64_t          bytes_read;
-    uint64_t          bytes_written;
-    uint64_t          cmd_flush;
-    uint64_t          cmd_flush_prefix;
-    uint64_t          conn_yields; /* # of yields for connections (-R option)*/
-    uint64_t          auth_cmds;
-    uint64_t          auth_errors;
-    /* list command stats */
-    uint64_t          cmd_lop_create;
-    uint64_t          cmd_lop_insert;
-    uint64_t          cmd_lop_delete;
-    uint64_t          cmd_lop_get;
-    /* set command stats */
-    uint64_t          cmd_sop_create;
-    uint64_t          cmd_sop_insert;
-    uint64_t          cmd_sop_delete;
-    uint64_t          cmd_sop_get;
-    uint64_t          cmd_sop_exist;
-    /* map command stats */
-    uint64_t          cmd_mop_create;
-    uint64_t          cmd_mop_insert;
-    uint64_t          cmd_mop_update;
-    uint64_t          cmd_mop_delete;
-    uint64_t          cmd_mop_get;
-    /* btree command stats */
-    uint64_t          cmd_bop_create;
-    uint64_t          cmd_bop_insert;
-    uint64_t          cmd_bop_update;
-    uint64_t          cmd_bop_delete;
-    uint64_t          cmd_bop_get;
-    uint64_t          cmd_bop_count;
-    uint64_t          cmd_bop_position;
-    uint64_t          cmd_bop_pwg;
-    uint64_t          cmd_bop_gbp;
-#ifdef SUPPORT_BOP_MGET
-    uint64_t          cmd_bop_mget;
-#endif
-#ifdef SUPPORT_BOP_SMGET
-    uint64_t          cmd_bop_smget;
-#endif
-    uint64_t          cmd_bop_incr;
-    uint64_t          cmd_bop_decr;
-    /* attr command stats */
-    uint64_t          cmd_getattr;
-    uint64_t          cmd_setattr;
-    /* list hit & miss stats */
-    uint64_t          lop_create_oks;
-    uint64_t          lop_insert_hits;
-    uint64_t          lop_insert_misses;
-    uint64_t          lop_delete_elem_hits;
-    uint64_t          lop_delete_none_hits;
-    uint64_t          lop_delete_misses;
-    uint64_t          lop_get_elem_hits;
-    uint64_t          lop_get_none_hits;
-    uint64_t          lop_get_misses;
-    /* set hit & miss stats */
-    uint64_t          sop_create_oks;
-    uint64_t          sop_insert_hits;
-    uint64_t          sop_insert_misses;
-    uint64_t          sop_delete_elem_hits;
-    uint64_t          sop_delete_none_hits;
-    uint64_t          sop_delete_misses;
-    uint64_t          sop_get_elem_hits;
-    uint64_t          sop_get_none_hits;
-    uint64_t          sop_get_misses;
-    uint64_t          sop_exist_hits;
-    uint64_t          sop_exist_misses;
-    /* map hit & miss stats */
-    uint64_t          mop_create_oks;
-    uint64_t          mop_insert_hits;
-    uint64_t          mop_insert_misses;
-    uint64_t          mop_update_elem_hits;
-    uint64_t          mop_update_none_hits;
-    uint64_t          mop_update_misses;
-    uint64_t          mop_delete_elem_hits;
-    uint64_t          mop_delete_none_hits;
-    uint64_t          mop_delete_misses;
-    uint64_t          mop_get_elem_hits;
-    uint64_t          mop_get_none_hits;
-    uint64_t          mop_get_misses;
-    /* btree hit & miss stats */
-    uint64_t          bop_create_oks;
-    uint64_t          bop_insert_hits;
-    uint64_t          bop_insert_misses;
-    uint64_t          bop_update_elem_hits;
-    uint64_t          bop_update_none_hits;
-    uint64_t          bop_update_misses;
-    uint64_t          bop_delete_elem_hits;
-    uint64_t          bop_delete_none_hits;
-    uint64_t          bop_delete_misses;
-    uint64_t          bop_get_elem_hits;
-    uint64_t          bop_get_none_hits;
-    uint64_t          bop_get_misses;
-    uint64_t          bop_count_hits;
-    uint64_t          bop_count_misses;
-    uint64_t          bop_position_elem_hits;
-    uint64_t          bop_position_none_hits;
-    uint64_t          bop_position_misses;
-    uint64_t          bop_pwg_elem_hits;
-    uint64_t          bop_pwg_none_hits;
-    uint64_t          bop_pwg_misses;
-    uint64_t          bop_gbp_elem_hits;
-    uint64_t          bop_gbp_none_hits;
-    uint64_t          bop_gbp_misses;
-#ifdef SUPPORT_BOP_MGET
-    uint64_t          bop_mget_oks;
-#endif
-#ifdef SUPPORT_BOP_SMGET
-    uint64_t          bop_smget_oks;
-#endif
-    uint64_t          bop_incr_elem_hits;
-    uint64_t          bop_incr_none_hits;
-    uint64_t          bop_incr_misses;
-    uint64_t          bop_decr_elem_hits;
-    uint64_t          bop_decr_none_hits;
-    uint64_t          bop_decr_misses;
-    /* attr hit & miss stats */
-    uint64_t          getattr_hits;
-    uint64_t          getattr_misses;
-    uint64_t          setattr_hits;
-    uint64_t          setattr_misses;
-    struct slab_stats slab_stats[MAX_SLAB_CLASSES];
-};
-
-
-/**
- * The stats structure the engine keeps track of
- */
-struct independent_stats {
-    topkeys_t *topkeys;
-    struct thread_stats thread_stats[];
-};
-
 /**
  * Global stats.
  */
@@ -426,50 +267,10 @@ extern struct stats stats;
 extern struct settings settings;
 extern EXTENSION_LOGGER_DESCRIPTOR *mc_logger;
 
-enum thread_type {
-    GENERAL = 11
-};
-
-typedef struct {
-    pthread_t thread_id;        /* unique ID of this thread */
-    struct event_base *base;    /* libevent handle this thread uses */
-    struct event notify_event;  /* listen event for notify pipe */
-    int notify_receive_fd;      /* receiving end of notify pipe */
-    int notify_send_fd;         /* sending end of notify pipe */
-    struct conn_queue *new_conn_queue; /* queue of new connections to handle */
-    cache_t *suffix_cache;      /* suffix cache */
-    pthread_mutex_t mutex;      /* Mutex to lock protect access to the pending_io */
-    bool is_locked;
-    struct conn *pending_io;    /* List of connection with pending async io ops */
-    struct conn *conn_list;     /* connection list managed by this thread */
-    int index;                  /* index of this thread in the threads array */
-    enum thread_type type;      /* Type of IO this thread processes */
-    token_buff_t token_buff;    /* token buffer */
-    mblck_pool_t mblck_pool;    /* memory block pool */
-} LIBEVENT_THREAD;
-
-#define LOCK_THREAD(t)                          \
-    if (pthread_mutex_lock(&t->mutex) != 0) {   \
-        abort();                                \
-    }                                           \
-    assert(t->is_locked == false);              \
-    t->is_locked = true;
-
-#define UNLOCK_THREAD(t)                         \
-    assert(t->is_locked == true);                \
-    t->is_locked = false;                        \
-    if (pthread_mutex_unlock(&t->mutex) != 0) {  \
-        abort();                                 \
-    }
-
-typedef struct {
-    pthread_t thread_id;        /* unique ID of this thread */
-    struct event_base *base;    /* libevent handle this thread uses */
-} LIBEVENT_DISPATCHER_THREAD;
-
-
 typedef struct conn conn;
 typedef bool (*STATE_FUNC)(conn *);
+
+#include "thread.h"
 
 /**
  * The structure representing a connection into memcached.
@@ -676,51 +477,24 @@ extern int daemonize(int nochdir, int noclose);
 #include "hash.h"
 #include <memcached/util.h>
 
-/*
- * Functions such as the libevent-related calls that need to do cross-thread
- * communication in multithreaded mode (rather than actually doing the work
- * in the current thread) are called via "dispatch_" frontends, which are
- * also #define-d to directly call the underlying code in singlethreaded mode.
- */
-
-void thread_init(int nthreads, struct event_base *main_base);
-void threads_shutdown(void);
-
-int  dispatch_event_add(int thread, conn *c);
-void dispatch_conn_new(int sfd, STATE_FUNC init_state, int event_flags,
-                       int read_buffer_size, enum network_transport transport);
-
 /* Lock wrappers for cache functions that are called from main loop. */
 void accept_new_conns(const bool do_accept);
 conn *conn_from_freelist(void);
 bool  conn_add_to_freelist(conn *c);
-int   is_listen_thread(void);
 
 void STATS_LOCK(void);
 void STATS_UNLOCK(void);
-void threadlocal_stats_clear(struct thread_stats *stats);
-void threadlocal_stats_reset(struct thread_stats *thread_stats);
-void threadlocal_stats_aggregate(struct thread_stats *thread_stats, struct thread_stats *stats);
-void slab_stats_aggregate(struct thread_stats *stats, struct slab_stats *out);
 
 /* Stat processing functions */
 void append_stat(const char *name, ADD_STAT add_stats, conn *c,
                  const char *fmt, ...);
 
-void notify_io_complete(const void *cookie, ENGINE_ERROR_CODE status);
 void conn_set_state(conn *c, STATE_FUNC state);
 const char *state_text(STATE_FUNC state);
 void safe_close(int sfd);
 
 void SETTING_LOCK(void);
 void SETTING_UNLOCK(void);
-
-// Number of times this connection is in the given pending list
-int number_of_pending(conn *c, conn *pending);
-bool has_cycle(conn *c);
-bool list_contains(conn *h, conn *n);
-conn *list_remove(conn *h, conn *n);
-size_t list_to_array(conn **dest, size_t max_items, conn **l);
 
 void init_check_stdin(struct event_base *base);
 

--- a/thread.h
+++ b/thread.h
@@ -1,0 +1,241 @@
+/* -*- Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ * arcus-memcached - Arcus memory cache server
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2020 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef THREAD_H
+#define THREAD_H
+
+#include <event.h>
+#include "cache.h"
+#include "topkeys.h"
+#include "mc_util.h"
+
+#define LOCK_THREAD(t)                          \
+    if (pthread_mutex_lock(&t->mutex) != 0) {   \
+        abort();                                \
+    }                                           \
+    assert(t->is_locked == false);              \
+    t->is_locked = true;
+
+#define UNLOCK_THREAD(t)                         \
+    assert(t->is_locked == true);                \
+    t->is_locked = false;                        \
+    if (pthread_mutex_unlock(&t->mutex) != 0) {  \
+        abort();                                 \
+    }
+
+/** Stats stored per slab (and per thread). */
+struct slab_stats {
+    uint64_t  cmd_set;
+    uint64_t  get_hits;
+    uint64_t  delete_hits;
+    uint64_t  cas_hits;
+    uint64_t  cas_badval;
+};
+
+/**
+ * Stats stored per-thread.
+ */
+struct thread_stats {
+    pthread_mutex_t   mutex;
+    uint64_t          cmd_get;
+    uint64_t          cmd_incr;
+    uint64_t          cmd_decr;
+    uint64_t          cmd_delete;
+    uint64_t          get_misses;
+    uint64_t          delete_misses;
+    uint64_t          incr_misses;
+    uint64_t          decr_misses;
+    uint64_t          incr_hits;
+    uint64_t          decr_hits;
+    uint64_t          cmd_cas;
+    uint64_t          cas_misses;
+    uint64_t          bytes_read;
+    uint64_t          bytes_written;
+    uint64_t          cmd_flush;
+    uint64_t          cmd_flush_prefix;
+    uint64_t          conn_yields; /* # of yields for connections (-R option)*/
+    uint64_t          auth_cmds;
+    uint64_t          auth_errors;
+    /* list command stats */
+    uint64_t          cmd_lop_create;
+    uint64_t          cmd_lop_insert;
+    uint64_t          cmd_lop_delete;
+    uint64_t          cmd_lop_get;
+    /* set command stats */
+    uint64_t          cmd_sop_create;
+    uint64_t          cmd_sop_insert;
+    uint64_t          cmd_sop_delete;
+    uint64_t          cmd_sop_get;
+    uint64_t          cmd_sop_exist;
+    /* map command stats */
+    uint64_t          cmd_mop_create;
+    uint64_t          cmd_mop_insert;
+    uint64_t          cmd_mop_update;
+    uint64_t          cmd_mop_delete;
+    uint64_t          cmd_mop_get;
+    /* btree command stats */
+    uint64_t          cmd_bop_create;
+    uint64_t          cmd_bop_insert;
+    uint64_t          cmd_bop_update;
+    uint64_t          cmd_bop_delete;
+    uint64_t          cmd_bop_get;
+    uint64_t          cmd_bop_count;
+    uint64_t          cmd_bop_position;
+    uint64_t          cmd_bop_pwg;
+    uint64_t          cmd_bop_gbp;
+#ifdef SUPPORT_BOP_MGET
+    uint64_t          cmd_bop_mget;
+#endif
+#ifdef SUPPORT_BOP_SMGET
+    uint64_t          cmd_bop_smget;
+#endif
+    uint64_t          cmd_bop_incr;
+    uint64_t          cmd_bop_decr;
+    /* attr command stats */
+    uint64_t          cmd_getattr;
+    uint64_t          cmd_setattr;
+    /* list hit & miss stats */
+    uint64_t          lop_create_oks;
+    uint64_t          lop_insert_hits;
+    uint64_t          lop_insert_misses;
+    uint64_t          lop_delete_elem_hits;
+    uint64_t          lop_delete_none_hits;
+    uint64_t          lop_delete_misses;
+    uint64_t          lop_get_elem_hits;
+    uint64_t          lop_get_none_hits;
+    uint64_t          lop_get_misses;
+    /* set hit & miss stats */
+    uint64_t          sop_create_oks;
+    uint64_t          sop_insert_hits;
+    uint64_t          sop_insert_misses;
+    uint64_t          sop_delete_elem_hits;
+    uint64_t          sop_delete_none_hits;
+    uint64_t          sop_delete_misses;
+    uint64_t          sop_get_elem_hits;
+    uint64_t          sop_get_none_hits;
+    uint64_t          sop_get_misses;
+    uint64_t          sop_exist_hits;
+    uint64_t          sop_exist_misses;
+    /* map hit & miss stats */
+    uint64_t          mop_create_oks;
+    uint64_t          mop_insert_hits;
+    uint64_t          mop_insert_misses;
+    uint64_t          mop_update_elem_hits;
+    uint64_t          mop_update_none_hits;
+    uint64_t          mop_update_misses;
+    uint64_t          mop_delete_elem_hits;
+    uint64_t          mop_delete_none_hits;
+    uint64_t          mop_delete_misses;
+    uint64_t          mop_get_elem_hits;
+    uint64_t          mop_get_none_hits;
+    uint64_t          mop_get_misses;
+    /* btree hit & miss stats */
+    uint64_t          bop_create_oks;
+    uint64_t          bop_insert_hits;
+    uint64_t          bop_insert_misses;
+    uint64_t          bop_update_elem_hits;
+    uint64_t          bop_update_none_hits;
+    uint64_t          bop_update_misses;
+    uint64_t          bop_delete_elem_hits;
+    uint64_t          bop_delete_none_hits;
+    uint64_t          bop_delete_misses;
+    uint64_t          bop_get_elem_hits;
+    uint64_t          bop_get_none_hits;
+    uint64_t          bop_get_misses;
+    uint64_t          bop_count_hits;
+    uint64_t          bop_count_misses;
+    uint64_t          bop_position_elem_hits;
+    uint64_t          bop_position_none_hits;
+    uint64_t          bop_position_misses;
+    uint64_t          bop_pwg_elem_hits;
+    uint64_t          bop_pwg_none_hits;
+    uint64_t          bop_pwg_misses;
+    uint64_t          bop_gbp_elem_hits;
+    uint64_t          bop_gbp_none_hits;
+    uint64_t          bop_gbp_misses;
+#ifdef SUPPORT_BOP_MGET
+    uint64_t          bop_mget_oks;
+#endif
+#ifdef SUPPORT_BOP_SMGET
+    uint64_t          bop_smget_oks;
+#endif
+    uint64_t          bop_incr_elem_hits;
+    uint64_t          bop_incr_none_hits;
+    uint64_t          bop_incr_misses;
+    uint64_t          bop_decr_elem_hits;
+    uint64_t          bop_decr_none_hits;
+    uint64_t          bop_decr_misses;
+    /* attr hit & miss stats */
+    uint64_t          getattr_hits;
+    uint64_t          getattr_misses;
+    uint64_t          setattr_hits;
+    uint64_t          setattr_misses;
+    struct slab_stats slab_stats[MAX_SLAB_CLASSES];
+};
+
+/**
+ * The stats structure the engine keeps track of
+ */
+struct independent_stats {
+    topkeys_t *topkeys;
+    struct thread_stats thread_stats[];
+};
+
+enum thread_type {
+    GENERAL = 11
+};
+
+typedef struct {
+    pthread_t thread_id;        /* unique ID of this thread */
+    struct event_base *base;    /* libevent handle this thread uses */
+    struct event notify_event;  /* listen event for notify pipe */
+    int notify_receive_fd;      /* receiving end of notify pipe */
+    int notify_send_fd;         /* sending end of notify pipe */
+    struct conn_queue *new_conn_queue; /* queue of new connections to handle */
+    cache_t *suffix_cache;      /* suffix cache */
+    pthread_mutex_t mutex;      /* Mutex to lock protect access to the pending_io */
+    bool is_locked;
+    struct conn *pending_io;           /* List of connection with pending async io ops */
+    struct conn *conn_list;            /* connection list managed by this thread */
+    int index;                  /* index of this thread in the threads array */
+    enum thread_type type;      /* Type of IO this thread processes */
+    token_buff_t token_buff;    /* token buffer */
+    mblck_pool_t mblck_pool;    /* memory block pool */
+} LIBEVENT_THREAD;
+
+// Number of times this connection is in the given pending list
+int    number_of_pending(struct conn *c, struct conn *pending);
+bool   has_cycle(struct conn *c);
+bool   list_contains(struct conn *h, struct conn *n);
+struct conn  *list_remove(struct conn *h, struct conn *n);
+size_t list_to_array(struct conn **dest, size_t max_items, struct conn **l);
+
+void notify_io_complete(const void *cookie, ENGINE_ERROR_CODE status);
+int  dispatch_event_add(int thread, struct conn *c);
+void dispatch_conn_new(int sfd, STATE_FUNC init_state, int event_flags,
+                       int read_buffer_size, enum network_transport transport);
+int  is_listen_thread(void);
+
+void threadlocal_stats_clear(struct thread_stats *stats);
+void threadlocal_stats_reset(struct thread_stats *thread_stats);
+void threadlocal_stats_aggregate(struct thread_stats *thread_stats, struct thread_stats *stats);
+void slab_stats_aggregate(struct thread_stats *stats, struct slab_stats *out);
+
+void thread_init(int nthreads, struct event_base *main_base);
+void threads_shutdown(void);
+#endif


### PR DESCRIPTION
thread.h 만들고 관련 함수들 이동시켰습니다.
사용되지 않는 함수들도 있는데 일단은 헤더에 함께 포함시켰습니다.