### PR TITLE
DOC: fix document style to sync with the document system

### DIFF
--- a/doc/arcus-ascii-protocol.md
+++ b/doc/arcus-ascii-protocol.md
@@ -1,4 +1,4 @@
-Arcus memcached Ascii Protocol
+# Arcus memcached Ascii Protocol
 ==============================
 
 Arcus cache server가 제공하는 명령들에 대한 ascii protocol을 기술한다.

--- a/doc/arcus-basic-concept.md
+++ b/doc/arcus-basic-concept.md
@@ -1,4 +1,4 @@
-Arcus Basic Concept
+# Chapter 1. Arcus Basic Concept
 -------------------
 
 Arcus cache server는 하나의 데이터만을 value로 가지는 simple key-value 외에도

--- a/doc/arcus-collection-concept.md
+++ b/doc/arcus-collection-concept.md
@@ -1,4 +1,4 @@
-Collection Concept
+# Collection Concept
 ------------------
 
 ### Collection 구조와 특징

--- a/doc/arcus-item-attribute.md
+++ b/doc/arcus-item-attribute.md
@@ -1,4 +1,4 @@
-Item Attribute 설명
+# Item Attribute 설명
 ------------------
 
 Arcus cache server는 collection 기능 지원으로 인해,

--- a/doc/arcus-telnet-interface.md
+++ b/doc/arcus-telnet-interface.md
@@ -1,4 +1,4 @@
-Arcus Telnet Interface
+# Arcus Telnet Interface
 ----------------------
 
 Arcus cache server의 동작을 간단히 확인하는 방법으로, telnet interface를 이용할 수 있다.

--- a/doc/command-administration.md
+++ b/doc/command-administration.md
@@ -1,4 +1,4 @@
-Admin & Monitoring 명령
+# Chapter 9. Admin & Monitoring 명령
 -----------------------
 
 - FLUSH 명령

--- a/doc/command-btree-collection.md
+++ b/doc/command-btree-collection.md
@@ -1,4 +1,4 @@
-B+Tree 명령
+# Chapter 6. B+Tree 명령
 -----------
 
 B+tree collection에 관한 명령은 아래와 같다.

--- a/doc/command-item-attribute.md
+++ b/doc/command-item-attribute.md
@@ -1,4 +1,4 @@
-Item Attribute 명령
+# Chapter 8. Item Attribute 명령
 -------------------
 
 Item attributes를 조회하는 getattr 명령과 변경하는 setattr 명령을 소개한다.

--- a/doc/command-key-value.md
+++ b/doc/command-key-value.md
@@ -1,4 +1,4 @@
-Simple Key-Value 명령
+# Chapter 2. Simple Key-Value 명령
 ---------------------
 
 Arcus cache server는 memcached 1.4의 key-value 명령을 그대로 지원하며, 
@@ -7,7 +7,7 @@ Arcus cache server는 memcached 1.4의 key-value 명령을 그대로 지원하�
 Simple key-value 명령들의 요약은 아래와 같다.
 이들 명령들의 자세한 정보는 [memcached 1.4의 기존 ascii protocol](/doc/protocol.txt)를 참고하기 바란다.
 
-**storage 명령**
+### storage 명령
 
 set, add, replace, append, prepend, cas 명령이 있으며 syntax는 다음과 같다.
 
@@ -26,7 +26,7 @@ Response string과 그 의미는 아래와 같다.
 - "CLIENT_ERROR" - 클라이언트에서 잘못된 질의를 했음을 의미. 이어 나오는 문자열을 통해 오류의 원인을 파악 가능. 예) bad command line format
 - "SERVER ERROR" - 서버 측의 오류로 저장하지 못했음을 의미. 이어 나오는 문자열을 통해 오류의 원인을 파악 가능. 예) out of memory
 
-**retrieval 명령**
+### retrieval 명령
 
 하나의 cache item을 조회하는 get, gets 명령이 있으며, syntax는 다음과 같다.
 get 명령은 value만 조회하는 반면 gets 명령은 value와 함께 cas value도 조회한다.
@@ -66,7 +66,7 @@ END\r\n
 
 mget 명령에서 메모리 부족으로 일부 key에 대해서만 정상 조회한 후 실패한 경우, 전체 연산을 서버 에러 처리한다.
 
-**deletion 명령**
+### deletion 명령
 
 delete 명령이 있으며 syntax는 다음과 같다.
 
@@ -80,7 +80,7 @@ Response string과 그 의미는 아래와 같다.
 - "NOT_FOUND" - key miss
 - "CLIENT_ERROR" - 클라이언트에서 잘못된 질의를 했음을 의미. 이어 나오는 문자열을 통해 오류의 원인을 파악 가능. 예) bad command line format
 
-**Increment/Decrement 명령**
+### Increment/Decrement 명령
 
 incr, decr 명령이 있으며, syntax는 아래와 같다.
 Arcus cache server는 이 명령을 확장하여,

--- a/doc/command-list-collection.md
+++ b/doc/command-list-collection.md
@@ -1,4 +1,4 @@
-LIST 명령
+# Chapter 3. LIST 명령
 ---------
 
 List collection에 관한 명령은 아래와 같다.

--- a/doc/command-map-collection.md
+++ b/doc/command-map-collection.md
@@ -1,4 +1,4 @@
-MAP 명령
+# Chapter 5. MAP 명령
 --------
 
 Map collection에 관한 명령은 아래와 같다.

--- a/doc/command-pipelining.md
+++ b/doc/command-pipelining.md
@@ -1,4 +1,4 @@
-Command Pipelining
+# Chapter 7. Command Pipelining
 ------------------
 
 Command pipelining은

--- a/doc/command-set-collection.md
+++ b/doc/command-set-collection.md
@@ -1,4 +1,4 @@
-SET 명령
+# Chapter 4. SET 명령
 --------
 
 Set collection에 관한 명령은 아래와 같다.


### PR DESCRIPTION
문서 시스템과의 양식을 맞추기 위해 PR 합니다.

- 수정 내용
  - 목차에서 최상위 제목을 제외시키기 위해 h1(#)으로 설정
  - 제목에 챕터 번호 부여
  - 굵은 글씨(**) 였던 부분을 제목(###)으로 변경(목차에 노출시키기 위함)

챕터 번호는 관련 이슈에서 지정한 대로([링크](https://github.com/jam2in/arcus-memcached-EE/issues/854#issuecomment-545372695)) 붙인 것인데 arcus-ascii-protocol과 arcus-collection-concept는 챕터 구성에서 빠진 상태 입니다. (문서시스템에도 노출하지 않고 있음.) 그래서 일단 챕터 번호를 붙이지 않고 PR합니다.

arcus-ascii-protocol의 경우 문서간 navigation용으로 제공되는 문서로 보여서 사이드바로 전체 목차가 제공되는 문서시스템에는 노출할 필요가 별로 없다고 생각합니다.

반면 arcus-collection-concept 에는 꽤 중요한 내용이 있습니다. bkey가 hex형과 정수형으로 나누어진다는 정보는 btree 문서에는 없고 여기에만 있습니다. 관련 내용을 btree로 옮기던지 정식 챕터로 편입하던지 하는 것이 좋을 듯 합니다. 