### PR TITLE
CLEANUP: show zk config in stats settings.

### DIFF
--- a/arcus_zk.c
+++ b/arcus_zk.c
@@ -173,9 +173,9 @@ typedef struct {
 #endif
     pthread_mutex_t lock;
     bool    init;               // is this structure initialized?
-} arcus_zk_conf;
+} arcus_zk_config;
 
-arcus_zk_conf arcus_conf = {
+arcus_zk_config arcus_conf = {
     .svc            = NULL,
     .mc_ipport      = NULL,
     .mc_hostnameport    = NULL,
@@ -1869,12 +1869,16 @@ int arcus_zk_get_hbfailstop(void)
 void arcus_zk_get_stats(arcus_zk_stats *stats)
 {
     stats->zk_connected = (main_zk != NULL && main_zk->zh != NULL) ? true : false;
-    stats->zk_failstop = arcus_conf.zk_failstop;
-    stats->zk_timeout = arcus_conf.zk_timeout;
-    stats->hb_timeout = arcus_conf.hb_timeout;
-    stats->hb_failstop = arcus_conf.hb_failstop;
     stats->hb_count = azk_stat.hb_count;
     stats->hb_latency = azk_stat.hb_latency;
+}
+
+void arcus_zk_get_confs(arcus_zk_confs *confs)
+{
+    confs->zk_failstop = arcus_conf.zk_failstop;
+    confs->zk_timeout = arcus_conf.zk_timeout;
+    confs->hb_timeout = arcus_conf.hb_timeout;
+    confs->hb_failstop = arcus_conf.hb_failstop;
 }
 
 #ifdef ENABLE_CLUSTER_AWARE

--- a/arcus_zk.h
+++ b/arcus_zk.h
@@ -26,13 +26,16 @@
 
 typedef struct {
     bool     zk_connected;  // ZooKeeper-memcached connection state
+    uint64_t hb_count;      // heartbeat accumulated count
+    uint64_t hb_latency;    // heartbeat accumulated latency (unit: ms) */
+} arcus_zk_stats;
+
+typedef struct {
     bool     zk_failstop;   // memcached automatic failstop
     uint32_t zk_timeout;    // Zookeeper session timeout (unit: ms)
     uint32_t hb_timeout;    // memcached heartbeat timeout (unit: ms)
     uint32_t hb_failstop;   // memcached heartbeat failstop (unit: ms)
-    uint64_t hb_count;      // heartbeat accumulated count
-    uint64_t hb_latency;    // heartbeat accumulated latency (unit: ms) */
-} arcus_zk_stats;
+} arcus_zk_confs;
 
 /* Interface between memcached.c and arcus_zk.c */
 
@@ -59,6 +62,7 @@ int  arcus_zk_get_hbtimeout(void);
 int  arcus_zk_set_hbfailstop(int hbfailstop);
 int  arcus_zk_get_hbfailstop(void);
 void arcus_zk_get_stats(arcus_zk_stats *stats);
+void arcus_zk_get_confs(arcus_zk_confs *confs);
 
 #ifdef ENABLE_CLUSTER_AWARE
 int  arcus_key_is_mine(const char *key, size_t nkey, bool *mine);

--- a/memcached.c
+++ b/memcached.c
@@ -8108,10 +8108,6 @@ static void server_stats(ADD_STAT add_stats, conn *c, bool aggregate)
     APPEND_STAT("pointer_size", "%d", (int)(8 * sizeof(void *)));
 #ifdef ENABLE_ZK_INTEGRATION
     APPEND_STAT("zk_connected", "%s", zk_stats.zk_connected ? "true" : "false");
-    APPEND_STAT("zk_failstop", "%s", zk_stats.zk_failstop ? "on" : "off");
-    APPEND_STAT("zk_timeout", "%u", zk_stats.zk_timeout);
-    APPEND_STAT("hb_timeout", "%u", zk_stats.hb_timeout);
-    APPEND_STAT("hb_failstop", "%u", zk_stats.hb_failstop);
     APPEND_STAT("hb_count", "%"PRIu64, zk_stats.hb_count);
     APPEND_STAT("hb_latency", "%"PRIu64, zk_stats.hb_latency);
 #endif
@@ -8268,6 +8264,10 @@ static void server_stats(ADD_STAT add_stats, conn *c, bool aggregate)
 static void process_stat_settings(ADD_STAT add_stats, void *c)
 {
     assert(add_stats);
+#ifdef ENABLE_ZK_INTEGRATION
+    arcus_zk_confs zk_confs;
+    arcus_zk_get_confs(&zk_confs);
+#endif
     APPEND_STAT("maxbytes", "%llu", (unsigned long long)settings.maxbytes);
     APPEND_STAT("maxconns", "%d", settings.maxconns);
     APPEND_STAT("tcpport", "%d", settings.port);
@@ -8316,6 +8316,12 @@ static void process_stat_settings(ADD_STAT add_stats, void *c)
     APPEND_STAT("max_element_bytes", "%d", settings.max_element_bytes);
 #endif
     APPEND_STAT("topkeys", "%d", settings.topkeys);
+#ifdef ENABLE_ZK_INTEGRATION
+    APPEND_STAT("zk_failstop", "%s", zk_confs.zk_failstop ? "on" : "off");
+    APPEND_STAT("zk_timeout", "%u", zk_confs.zk_timeout);
+    APPEND_STAT("hb_timeout", "%u", zk_confs.hb_timeout);
+    APPEND_STAT("hb_failstop", "%u", zk_confs.hb_failstop);
+#endif
 
     for (EXTENSION_DAEMON_DESCRIPTOR *ptr = settings.extensions.daemons;
          ptr != NULL;


### PR DESCRIPTION
이슈([링크](https://github.com/jam2in/arcus-memcached-EE/issues/389))에서 전달 받은 스탯을 stat settings로 옮겼습니다.

그외 stats 에서 stats settings으로 옮길만한 항목이 있는지 검토해봤는데 나머지는 수정이 필요 없을 듯 합니다.

stats는 사용자의 설정과 무관한 단순 통계, stats settings는 사용자가 실행 도중 명령을 통해 바꿀 수 있는 설정값을 보여주는게 적합하다고 생각해,  stats에 설정이 가능한 항목이 있는지 봤습니다. 이번 PR에 포함된 항목을 제외하면 다음과 같습니다. 

- limit_maxbytes (config memlimit 명령을 통해 변경)
- sticky_limit 
- engine_maxbytes (config memlimit 명령을 통해 변경)

maxbytes와 sticky_limit이 stats settings에도 포함되어 있어 수정이 필요없다고 봤습니다. 


