### PR TITLE
FIX: disable travis_ci notification in forked repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ after_success:
 
 notifications:
   email:
-    - junhyun.park@jam2in.com
-    - minkikim89@jam2in.com
-    - alsdn653@jam2in.com
+    if: fork = false
+    recipients:
+      - junhyun.park@jam2in.com
+      - minkikim89@jam2in.com
+      - alsdn653@jam2in.com


### PR DESCRIPTION
forked된 저장소에서 이메일 알림이 가지 않도록 설정을 수정했습니다. 

travis ci에는 빌드가 성공, 실패할 때 지정된 이메일로 알림을 주는 기능이 있는데, 이것이 forked된 저장소에서도 작동해 불필요한 noti가 발생하는 상황입니다. 

travis.yml 에 if문을 통해 다양한 조건을 걸 수 있는데, 조건중에 fork 여부도 포함되어 있습니다. ([링크](https://docs.travis-ci.com/user/notifications/)의 conditional notification 파트 참조) 이 기능을 이용해 포크된 저장소가 아닐 때에만 이메일이 가도록 했습니다.

if문의 정상 작동 여부는 개인 저장소에서 이메일 주소를 제 것으로 바꾸어 테스트 했습니다.