### PR TITLE
FIX: enable email notification for pull request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ after_success:
 
 notifications:
   email:
-    if: fork = false
+    if: (fork = false) OR (type = pull_request AND head_repo = naver/arcus-memcached)
     recipients:
       - junhyun.park@jam2in.com
       - minkikim89@jam2in.com


### PR DESCRIPTION
noti 조건을 변경했습니다.

기존의 조건: forked repo가 아닐 때에만 noti

변경된 조건: forked repo가 아니거나, naver 저장소에 PR을 했을 때에만 noti