### PR TITLE
FEATURE: set engine configuration in config file and load it.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,6 +34,9 @@ endif
 
 noinst_LTLIBRARIES=libmcd_util.la
 
+# Engine configuration file
+engineconfdir = $(prefix)/conf
+dist_engineconf_DATA =
 
 # Test application to test stuff from C
 testapp_SOURCES = testapp.c
@@ -146,6 +149,7 @@ default_engine_la_SOURCES= \
 default_engine_la_DEPENDENCIES= libmcd_util.la
 default_engine_la_LIBADD= libmcd_util.la $(LIBM)
 default_engine_la_LDFLAGS= -avoid-version -shared -module -no-undefined
+dist_engineconf_DATA += engines/default/default_engine.conf
 
 # The demo storage engine
 demo_engine_la_SOURCES= \
@@ -158,6 +162,7 @@ demo_engine_la_SOURCES= \
 demo_engine_la_DEPENDENCIES= libmcd_util.la
 demo_engine_la_LIBADD= libmcd_util.la $(LIBM)
 demo_engine_la_LDFLAGS= -avoid-version -shared -module -no-undefined
+dist_engineconf_DATA += engines/demo/demo_engine.conf
 
 if BUILD_DTRACE
 BUILT_SOURCES += memcached_dtrace.h

--- a/engine_loader.c
+++ b/engine_loader.c
@@ -78,6 +78,15 @@ bool init_engine(ENGINE_HANDLE * engine,
         engine_v1 = (ENGINE_HANDLE_V1*)engine;
 
         // validate that the required engine interface is implemented:
+#ifdef LOAD_ENGINE_CONFFILE
+        if (engine_v1->get_info == NULL || engine_v1->get_config == NULL ||
+            engine_v1->initialize == NULL || engine_v1->destroy == NULL ||
+            engine_v1->allocate == NULL || engine_v1->remove == NULL ||
+            engine_v1->release == NULL || engine_v1->get == NULL ||
+            engine_v1->store == NULL || engine_v1->arithmetic == NULL ||
+            engine_v1->flush == NULL || engine_v1->get_stats == NULL ||
+            engine_v1->reset_stats == NULL || engine_v1->get_item_info == NULL)
+#else
         if (engine_v1->get_info == NULL || engine_v1->initialize == NULL ||
             engine_v1->destroy == NULL || engine_v1->allocate == NULL ||
             engine_v1->remove == NULL || engine_v1->release == NULL ||
@@ -85,6 +94,7 @@ bool init_engine(ENGINE_HANDLE * engine,
             engine_v1->arithmetic == NULL || engine_v1->flush == NULL ||
             engine_v1->get_stats == NULL || engine_v1->reset_stats == NULL ||
             engine_v1->get_item_info == NULL)
+#endif
         {
             logger->log(EXTENSION_LOG_WARNING, NULL,
                         "Failed to initialize engine; it does not implement the engine interface.");

--- a/engines/default/default_engine.conf
+++ b/engines/default/default_engine.conf
@@ -1,0 +1,20 @@
+# This is a default engine config file
+#
+# Engine configuration
+#
+# Note on memory size units:
+# 1KB: 1024 bytes
+# 1MB: 1024*1024 bytes
+# 1GB: 1024*1024*1024 bytes
+# 1TB: 1024*1024*1024*1024 bytes
+#
+# collection max size (default: 50000)
+# The collection max size limits the maximum number of elements that can be stored
+# in each collection item. Its hard limit is 1000000.
+max_list_size=50000
+max_set_size=50000
+max_map_size=50000
+max_btree_size=50000
+#
+# max element bytes (default: 16KB, min: 1KB, max: 32KB)
+max_element_bytes=16KB

--- a/engines/demo/demo_engine.conf
+++ b/engines/demo/demo_engine.conf
@@ -1,0 +1,20 @@
+# This is a demo engine config file
+#
+# Engine configuration
+#
+# Note on memory size units:
+# 1KB: 1024 bytes
+# 1MB: 1024*1024 bytes
+# 1GB: 1024*1024*1024 bytes
+# 1TB: 1024*1024*1024*1024 bytes
+#
+# collection max size (default: 50000)
+# The collection max size limits the maximum number of elements that can be stored
+# in each collection item. Its hard limit is 1000000.
+#max_list_size=50000
+#max_set_size=50000
+#max_map_size=50000
+#max_btree_size=50000
+#
+# max element bytes (default: 16KB, min: 1KB, max: 32KB)
+#max_element_bytes=16KB

--- a/include/memcached/engine.h
+++ b/include/memcached/engine.h
@@ -197,6 +197,15 @@ extern "C" {
          */
         const engine_info* (*get_info)(ENGINE_HANDLE* handle);
 
+#ifdef LOAD_ENGINE_CONFFILE
+        /**
+         * Get engine configuration as a "<key>=<value>;" format string.
+         *
+         * @param handle the engine handle
+         * @param config_buffer buffer for containing engine configuration string.
+         */
+        void (*get_config)(ENGINE_HANDLE* handle, char* config_buffer);
+#endif
         /**
          * Initialize an engine instance.
          * This is called *after* creation, but before the engine may be used.

--- a/include/memcached/types.h
+++ b/include/memcached/types.h
@@ -31,6 +31,7 @@ struct iovec {
 #include <sys/uio.h>
 #endif
 
+#define LOAD_ENGINE_CONFFILE
 #define MAX_ELEMENT_BYTES_CONFIG
 #define PROXY_SUPPORT
 #define BOP_COUNT_OPTIMIZE


### PR DESCRIPTION
엔진 설정 파일 처리와 관련된 PR입니다.
- 엔진 설정 샘플 파일을 소스 디렉토리에 생성해둠. (engines/default/XX_engine.conf).
- 엔진 설정 샘플 파일은 make install 시에 $(prefix)/conf 디렉토리로 복사됨(conf 디렉토리 없으면 생성). make uninstall 은 설정 파일 삭제.
- 파일에 명시한 설정은 engine 에서 validation 검사 후 core 로 key=value 형태의 스트링으로 넘겨 settings에 반영.


-Makefile.am 수정 사항 설명
```
# Engine configuration file
engineconfdir = $(prefix)/conf
dist_engineconf_DATA = engines/default/default_engine.conf engines/demo/demo_engine.conf
```
make 명령 수행에 대상이 되는 파일을 `${prefix}_XX_${primary}` 와 같은 형태로 선언하는 rule 이 있음.
primary는 make install, make uninstall 과 같은 명령 대상이 되기 위한 symbol.
primary 는 _PROGRAMS, _SCRIPTS, _DATA, _LIBRARIES 등이 있고 파일 성격에 따라 선택.
일반적으로 컴파일된 바이너리가 대상일 때는 _PROGRAMS 를(_SOURCES를 필요로함.), _SCRIPTS 는 script를,  _DATA 는 보통 파일에 쓰임. 둘 다 _SOURCES 를 필요로 하지 않기 때문에 비슷하나 _SCRIPTS 는 실행 가능 파일, _DATA는  실행불가능한 파일에 주로 쓰임.
XX는 파일이 설치될 경로를 의미. 경로는 XXdir 변수의 값을 사용. 따라서 engineconfdir 의 값을 경로로 사용하며 make install 시에 이 경로가 없으면 자동으로 생성함. make uninstall 하면 이 경로 안에 있는 dist_engineconf_DATA를 제거. (모든 파일 제거 아님.)
prefix 도 여러가지가 있는데 그 중 dist_ 를 사용한 이유는 _DATA primary를 선언한 파일은 make dist 명령에서 제외되기 때문에 dist 를 넣어줌으로써 대상이 되도록 함.

- make install 수행 (prefix=test_dir, xx 파일은 임의로 넣어둔것)
![Screen Shot 2020-04-10 at 3 49 29 PM](https://user-images.githubusercontent.com/28725891/78969824-e2b82b80-7b42-11ea-8e0d-f01f15533fc6.png)
- make uninstall 수행
![Screen Shot 2020-04-10 at 3 51 28 PM](https://user-images.githubusercontent.com/28725891/78969962-3165c580-7b43-11ea-80b8-2dfad6c3f042.png)


@MinWooJin 리뷰 요청드립니다.
