### PR TITLE
[persistence] amended condition of closing fd in cmdlog_file_close().

### DIFF
--- a/engines/default/checkpoint.c
+++ b/engines/default/checkpoint.c
@@ -249,7 +249,9 @@ static int do_checkpoint(chkpt_st *cs)
             ret = CHKPT_ERROR;
         }
 
-        cmdlog_file_close(false);
+        /* close the current log file when the first checkpoint has failed. */
+        bool first_chkpt_fail = (ret == CHKPT_ERROR && cs->lasttime == -1);
+        cmdlog_file_close(first_chkpt_fail);
         if (oldtime != -1) {
             if (do_chkpt_remove_files(cs, oldtime) < 0) {
                 ret = CHKPT_ERROR_FILE_REMOVE;

--- a/engines/default/cmdlogbuf.h
+++ b/engines/default/cmdlogbuf.h
@@ -33,7 +33,9 @@ void cmdlog_get_fsync_lsn(LogSN *lsn);
 
 int               cmdlog_file_open(char *path);
 size_t            cmdlog_file_getsize(void);
-void              cmdlog_file_close(bool shutdown);
+void              cmdlog_file_close(bool first_chkpt_fail);
+void              cmdlog_file_init(void);
+void              cmdlog_file_final(void);
 int               cmdlog_file_apply(void);
 void              cmdlog_complete_dual_write(bool success);
 ENGINE_ERROR_CODE cmdlog_buf_init(struct default_engine *engine);


### PR DESCRIPTION
issue : cmdlog_file_open과 cmdlog_file_close의 구동 실패 동작 점검 https://github.com/naver/arcus-memcached/issues/436

- cmdlog_file_close() 에서 fd 를 close 하는 조건을 변경하였습니다. 
- shutdown 에 대한 동작은 cmdlog_file_final()에서 처리합니다.

@MinWooJin 리뷰 요청드립니다.