### PR TITLE
[persistence] change the type of roffset in LogSN

### DIFF
--- a/engines/default/cmdlogmgr.h
+++ b/engines/default/cmdlogmgr.h
@@ -46,9 +46,15 @@ enum upd_type {
     UPD_NONE
 };
 
+/* Change the type of roffset from uint32_t to uint64_t.
+ * 1. There is no guarantee that the checkpoint will always succeed,
+ *    the cmdlog record offset can exceed 4GB during retries.
+ * 2. Depending on the memlimit, a checkpoint can occur when offset exceeds 4GB.
+ */
 typedef struct logsn {
     uint32_t filenum;  /* cmdlog file number : 1, 2, ... */
-    uint32_t roffset;  /* cmdlog record offset */
+    uint32_t rsvd32;   /* reserved 4 bytes */
+    uint64_t roffset;  /* cmdlog record offset */
 } LogSN;
 
 /* command log manager entry structure */


### PR DESCRIPTION
#460 관련 PR 입니다.
기존에 cmdlog record의 offset을 표현하던 LogSN.roffset 의 type이
uint32_t로 4GB 까지밖에 표현하지 못하는 문제가 있어 checkpoint 실패로 재시도 하거나
memlimit이 클 경우 에러가 발생할 수 있어서 uint64_t type으로 변경 했습니다.

@jhpark816 
확인 요청 드립니다.