### PR TITLE
FIX: clear azk_count during zookeeper rejoin process

### DIFF
--- a/arcus_zk.c
+++ b/arcus_zk.c
@@ -340,6 +340,13 @@ static void inc_count(int delta)
     pthread_mutex_unlock(&azk_mtx);
 }
 
+static void clear_count(void)
+{
+    pthread_mutex_lock(&azk_mtx);
+    azk_count = 0;
+    pthread_mutex_unlock(&azk_mtx);
+}
+
 static int wait_count(int timeout)
 {
     struct timeval  tv;
@@ -1673,6 +1680,8 @@ int arcus_zk_get_ensemble(char *buf, int size)
 int arcus_zk_rejoin_ensemble()
 {
     int ret = 0;
+
+    clear_count();
 
     pthread_mutex_lock(&zk_lock);
 


### PR DESCRIPTION
azk_count는 zookeeper의 async operation을 sync 하기 위해 사용하는 값으로,
sync가 필요한 부분에서 azk_count가 `<= 0`이 될 때 까지 timed wait 하는 형태로 동작합니다.
현재 arcus-memcached에서 timed wait가 필요한 부분은 아래 두 가지 동작 입니다.
- 처음 구동 시 zookeeper_init
- rejoin 동작에서 zookeeper_init

처음 구동 시 zookeeper_init은 azk_count 값이 0으로 의도한 대로 동작하지만,
rejoin 동작에서 zookeeper_init은 azk_count 값이 이미 `< 0`일 가능성이 있어
0으로 초기화 한 뒤 rejoin 동작을 수행해야 합니다.
`< 0`일 가능성은, 기존에 연결되어있던 zookeeper의 session state가
네트워크 상황에 따라 "CONNECTED -> CONNECTING -> CONNECTED"로 상태 변이가 가능하며
CONNECTED session event를 받을 때 마다 `inc_count(-1)`을 수행해주기 때문에 `< 0`일 수 있습니다.

CONNECTED session event 처리에서 현재 연결이 완료된 상태에서 상태 변이인지,
새롭게 연결을 요청한 상태에서 상태 변이인지 구분해서 새롭게 연결을 요청한 상태에서만
`inc_count(-1)`을 수행해도 되지만 구분을 위해 별도로 변수가 필요하고,
평소에는 정확하게 유지할 필요가 없는 값이므로 rejoin 동작에서 clear 하고 수행하는 방식으로 수정 했습니다.

@jhpark816 
확인 요청 드립니다.