### PR TITLE
FIX: miscalculation of snprintf string size

### DIFF
--- a/engines/default/items.c
+++ b/engines/default/items.c
@@ -8572,7 +8572,7 @@ static int item_dump_write_key(char *buffer, hash_item *it, rel_time_t mc_curtim
 #endif
     } else {
         if (it->exptime > mc_curtime) {
-            snprintf(bufptr, 12, " %u\n", it->exptime - mc_curtime);
+            snprintf(bufptr, 13, " %u\n", it->exptime - mc_curtime);
             length += strlen(bufptr);
         } else {
             memcpy(bufptr, " -2\n", 4); /* this case may not occur */


### PR DESCRIPTION
snprintf 시에 널문자까지 계산하여 size를 계산해야합니다. 문자열 크기가 최대일 때 개행문자가 제대로 버퍼에 들어가지 않는 문제가 발생할 수 있어서 수정하였습니다.