### PR TITLE
FIX: appropriate to set E2BIG error as a CLIENT_ERROR

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -8369,7 +8369,7 @@ static void process_update_command(conn *c, token_t *tokens, const size_t ntoken
     case ENGINE_E2BIG:
     case ENGINE_ENOMEM:
         if (ret == ENGINE_E2BIG) {
-            out_string(c, "SERVER_ERROR object too large for cache");
+            out_string(c, "CLIENT_ERROR object too large for cache");
         } else {
             out_string(c, "SERVER_ERROR out of memory storing object");
         }

--- a/t/getset.t
+++ b/t/getset.t
@@ -106,7 +106,7 @@ while ($len < 1024*1028) {
         # Ensure causing a memory overflow doesn't leave stale data.
         $cmd = "set foo_$len 0 0 3"; $rst = "STORED";
         mem_cmd_is($sock, $cmd, "MOO", $rst);
-        $cmd = "set foo_$len 0 0 $len"; $rst = "SERVER_ERROR object too large for cache";
+        $cmd = "set foo_$len 0 0 $len"; $rst = "CLIENT_ERROR object too large for cache";
         $msg = "failed to store size $len";
         mem_cmd_is($sock, $cmd, $val, $rst, $msg);
         $cmd = "get foo_$len";

--- a/t/lru.t
+++ b/t/lru.t
@@ -26,7 +26,7 @@ ok(length($big) < 1024 * 1024, "buffer is less than 1m");
 my $too_big = $big . $big . $big;
 my $len = length($too_big);
 $cmd = "set too_big 0 0 $len"; $val = "$too_big";
-$rst = "SERVER_ERROR object too large for cache"; $msg = "too_big not stored";
+$rst = "CLIENT_ERROR object too large for cache"; $msg = "too_big not stored";
 mem_cmd_is($sock, $cmd, $val, $rst, $msg);
 
 # set the big value

--- a/t/set_with_largest_slab.t
+++ b/t/set_with_largest_slab.t
@@ -24,7 +24,7 @@ while ($len < 1024*1028) {
         # Ensure causing a memory overflow doesn't leave stale data.
         $cmd = "set foo_$len 0 0 3"; $rst = "STORED";
         mem_cmd_is($sock, $cmd, "MOO", $rst);
-        $cmd = "set foo_$len 0 0 $len"; $rst = "SERVER_ERROR object too large for cache";
+        $cmd = "set foo_$len 0 0 $len"; $rst = "CLIENT_ERROR object too large for cache";
         mem_cmd_is($sock, $cmd, $val, $rst, "failed to store size $len");
         $cmd = "get foo_$len"; $rst = "END";
         mem_cmd_is($sock, $cmd, "", $rst);


### PR DESCRIPTION
E2BIG 에러는 (1) 엘리먼트 크기가 제한(16K)보다 큰 경우 (2) 아이템 크기가 slab largest class 보다 큰 경우 발생합니다.
(1)은 CLIENT_ERROR로 반환하고 있는데,
```
static void process_sop_prepare_nread(conn *c, int cmd, size_t vlen, char *key, size_t nkey)
{
    if (vlen > MAX_ELEMENT_BYTES) {
        ret = ENGINE_E2BIG;
...
    if (ret == ENGINE_E2BIG)       out_string(c, "CLIENT_ERROR too large value");
}
```
(2)는 PR 코드에서 보듯이 SERVER_ERROR로 반환하고 있습니다.
(2)도 (1)과 같이 요청 데이터가 적절하지 않아 발생한 에러이므로, CLIENT_ERROR로 리턴해야 한다고 봅니다.
```
static ENGINE_ERROR_CODE
default_item_allocate(ENGINE_HANDLE* handle, const void* cookie,
                      item **item,
                      const void* key, const size_t nkey,
                      const size_t nbytes,
                      const int flags, const rel_time_t exptime,
                      const uint64_t cas)
{
    struct default_engine* engine = get_handle(handle);
    size_t ntotal = sizeof(hash_item) + nkey + nbytes;
    if (engine->config.use_cas) {
        ntotal += sizeof(uint64_t);
    }
    unsigned int id = slabs_clsid(ntotal);
    if (id == 0) {
        return ENGINE_E2BIG;
    }
```