### PR TITLE
FIX: prevent memory out-of-range while printing out key on log.

### DIFF
--- a/engines/default/items.c
+++ b/engines/default/items.c
@@ -1155,13 +1155,21 @@ static hash_item *do_item_get(const char *key, const uint32_t nkey, bool do_upda
         }
     }
     if (config->verbose > 2) {
-        if (it) {
-            logger->log(EXTENSION_LOG_INFO, NULL, "> FOUND KEY %s\n",
-                        (const char*)item_get_key(it));
+        char keybuf[MAX_HKEY_LEN];
+        if (nkey < MAX_HKEY_LEN) {
+            memcpy(keybuf, key, nkey);
+            keybuf[nkey] = '\0';
         } else {
-            logger->log(EXTENSION_LOG_INFO, NULL, "> NOT FOUND %s\n",
-                        key);
+            memcpy(keybuf, key, MAX_HKEY_LEN-4);
+            keybuf[MAX_HKEY_LEN-4] = '#';
+            keybuf[MAX_HKEY_LEN-3] = '#';
+            keybuf[MAX_HKEY_LEN-2] = '#';
+            keybuf[MAX_HKEY_LEN-1] = '\0';
         }
+
+        logger->log(EXTENSION_LOG_INFO, NULL, "> %s %s\n",
+                    it ? "FOUND KEY" : "NOT FOUND",
+                    keybuf);
     }
     return it;
 }


### PR DESCRIPTION
Issue : https://github.com/naver/arcus-memcached/issues/477

```
추가된 3개 문자 포함하여 출력하는 전체 길이가 MAX_HKEY_LEN이었으면 합니다.
```
위 요구사항에 대해 null character를 고려(포함)하여 처리하였습니다.