### PR TITLE
FIX: reflect item_size_max setting

### DIFF
--- a/engines/default/items.c
+++ b/engines/default/items.c
@@ -1011,7 +1011,6 @@ static ENGINE_ERROR_CODE do_item_link(hash_item *it)
 {
     const char *key = item_get_key(it);
     assert((it->iflag & ITEM_LINKED) == 0);
-    assert(it->nbytes < (1024 * 1024));  /* 1MB max size */
 
     MEMCACHED_ITEM_LINK(key, it->nkey, it->nbytes);
 

--- a/engines/demo/dm_items.c
+++ b/engines/demo/dm_items.c
@@ -185,7 +185,6 @@ static ENGINE_ERROR_CODE do_item_link(struct demo_engine *engine, hash_item *it)
     const char *key = dm_item_get_key(it);
     size_t stotal = ITEM_stotal(engine, it);
     assert((it->iflag & ITEM_LINKED) == 0);
-    assert(it->nbytes < (1024 * 1024));  /* 1MB max size */
 
     MEMCACHED_ITEM_LINK(key, it->nkey, it->nbytes);
 

--- a/t/item_size_max.t
+++ b/t/item_size_max.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 use strict;
-use Test::More tests => 7;
+use Test::More tests => 9;
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
@@ -67,6 +67,19 @@ my $stats = mem_stats($server->sock, ' settings');
 is($stats->{item_size_max}, 33554432);
 $server->stop();
 
+
+# Test sets up to a large size around 2MB.
+$server = get_memcached($engine, '-I 2m');
+my $stats = mem_stats($server->sock, ' settings');
+is($stats->{item_size_max}, 2097152);
+my $added_len = 128; # keylen + item meta size
+my $len = 2 * 1024 * 1024 - $added_len;
+my $val = "B"x$len;
+my $cmd = "set foo_$len 0 0 $len";
+my $rst = "STORED";
+my $msg = "stored size $len";
+mem_cmd_is($server->sock, $cmd, $val, $rst);
+$server->stop();
 
 # after test
 release_memcached($engine, $server);


### PR DESCRIPTION
#490 관련 PR 입니다.

ARCUS-memcached는 구동 옵션(-I)으로 item의 최대 크기 제한을 변경할 수 있지만,
기존 default engine과 demo engine에서 value의 최대 크기를 1MB로 제한하는 버그가 있었습니다.
do_item_link에서 value size는 이미 item allocate 에서 item_size_max보다 작음이 확인된 값으로,
중복으로 확인할 필요가 없을 것으로 판단되어 제거 했습니다.

@jhpark816 
확인 요청 드립니다.