### PR TITLE
DOC: fix wrong link

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,12 @@ $ kill -INT <pid>
 ## ASCII Protocol
 
 Please refer to
-[Arcus cache server ascii protocol](/doc/arcus-ascii-protocol.md)
+[Arcus cache server ascii protocol](doc/ch00-arcus-ascii-protocol.md)
 for details on Arcus ASCII commands.
 
 You can use telnet interface to test simply Arcus ASCII commands on Arcus cache server.
 To know the usage of telnet interface,
-refer to [Arcus telnet interface guide](/doc/arcus-telnet-interface.md).
+refer to [Arcus telnet interface guide](doc/ap01-arcus-telnet-interface.md).
 
 ## Issues
 

--- a/doc/ch04-command-key-value.md
+++ b/doc/ch04-command-key-value.md
@@ -5,7 +5,7 @@ Arcus cache server는 memcached 1.4의 key-value 명령을 그대로 지원하�
 이에 추가하여 incr/decr 명령은 그 기능을 확장 지원한다.
 
 Simple key-value 명령들의 요약은 아래와 같다.
-이들 명령들의 자세한 정보는 [memcached 1.4의 기존 ascii protocol](/doc/protocol.txt)를 참고하기 바란다.
+이들 명령들의 자세한 정보는 [memcached 1.4의 기존 ascii protocol](https://github.com/naver/arcus-memcached/blob/master/doc/protocol.txt)를 참고하기 바란다.
 
 ### storage 명령
 


### PR DESCRIPTION
- README의 링크가 작동하도록 수정
- 문서시스템에서 memcached protocol을 볼 수 있도록 깃허브 링크로 수정
   - 문서 시스템은 markdown 파일로 웹페이지를 생성하므로 txt 파일은 접근 불가 (github repo에 넣어놔도 페이지가 생성되지 않음) 