### PR TITLE
DOC: remove unnecessary line

### DIFF
--- a/doc/ap01-arcus-telnet-interface.md
+++ b/doc/ap01-arcus-telnet-interface.md
@@ -1,5 +1,4 @@
 # Arcus Telnet Interface
-----------------------
 
 Arcus cache server의 동작을 간단히 확인하는 방법으로, telnet interface를 이용할 수 있다.
 

--- a/doc/ch00-arcus-ascii-protocol.md
+++ b/doc/ch00-arcus-ascii-protocol.md
@@ -1,5 +1,4 @@
 # Arcus memcached Ascii Protocol
-==============================
 
 Arcus cache server가 제공하는 명령들에 대한 ascii protocol을 기술한다.
 Arcus cache server의 현재 버전은 1.7.0이며, 이 기준으로 작성한다.

--- a/doc/ch01-arcus-basic-concept.md
+++ b/doc/ch01-arcus-basic-concept.md
@@ -1,5 +1,4 @@
 # Chapter 1. Arcus Basic Concept
--------------------
 
 Arcus cache server는 하나의 데이터만을 value로 가지는 simple key-value 외에도
 여러 데이터를 구조화된 형태로 저장하는 collection을 하나의 value로 가지는

--- a/doc/ch02-collection-items.md
+++ b/doc/ch02-collection-items.md
@@ -1,5 +1,4 @@
 # Chapter 2. Collection Concept
-------------------
 
 ### Collection 구조와 특징
 

--- a/doc/ch03-item-attributes.md
+++ b/doc/ch03-item-attributes.md
@@ -1,5 +1,4 @@
 # Chapter 3. Item Attribute 설명
-------------------
 
 Arcus cache server는 collection 기능 지원으로 인해,
 기존 key-value item 유형 외에 list, set, map, b+tree item 유형을 가진다.

--- a/doc/ch04-command-key-value.md
+++ b/doc/ch04-command-key-value.md
@@ -1,5 +1,4 @@
 # Chapter 4. Simple Key-Value 명령
----------------------
 
 Arcus cache server는 memcached 1.4의 key-value 명령을 그대로 지원하며, 
 이에 추가하여 incr/decr 명령은 그 기능을 확장 지원한다.

--- a/doc/ch05-command-list-collection.md
+++ b/doc/ch05-command-list-collection.md
@@ -1,5 +1,4 @@
 # Chapter 5. LIST 명령
----------
 
 List collection에 관한 명령은 아래와 같다.
 

--- a/doc/ch06-command-set-collection.md
+++ b/doc/ch06-command-set-collection.md
@@ -1,5 +1,4 @@
 # Chapter 6. SET 명령
---------
 
 Set collection에 관한 명령은 아래와 같다.
 

--- a/doc/ch07-command-map-collection.md
+++ b/doc/ch07-command-map-collection.md
@@ -1,5 +1,4 @@
 # Chapter 7. MAP 명령
---------
 
 Map collection에 관한 명령은 아래와 같다.
 

--- a/doc/ch08-command-btree-collection.md
+++ b/doc/ch08-command-btree-collection.md
@@ -1,5 +1,4 @@
 # Chapter 8. B+Tree 명령
------------
 
 B+tree collection에 관한 명령은 아래와 같다.
 

--- a/doc/ch09-command-pipelining.md
+++ b/doc/ch09-command-pipelining.md
@@ -1,5 +1,4 @@
 # Chapter 9. Command Pipelining
-------------------
 
 Command pipelining은
 “pipe” 키워드를 통해 여러 collection 명령들을 pipelining하여 cache server에 전달하고,

--- a/doc/ch10-command-item-attribute.md
+++ b/doc/ch10-command-item-attribute.md
@@ -1,5 +1,4 @@
 # Chapter 10. Item Attribute 명령
--------------------
 
 Item attributes를 조회하는 getattr 명령과 변경하는 setattr 명령을 소개한다.
 

--- a/doc/ch11-command-administration.md
+++ b/doc/ch11-command-administration.md
@@ -1,5 +1,4 @@
 # Chapter 11. Admin & Monitoring 명령
------------------------
 
 - FLUSH 명령
 - SCRUB 명령


### PR DESCRIPTION
github markdown에서 H1(#) 수준의 제목은 자동으로 구분선이 생기기 때문에 별도로 그어져 있던 구분선을 제거하였습니다. 