### PR TITLE
DOC: fix indentation of list items

### DIFF
--- a/doc/ch05-command-list-collection.md
+++ b/doc/ch05-command-list-collection.md
@@ -48,9 +48,9 @@ lop insert <key> <index> <bytes> [create <attributes>] [noreply|pipe]\r\n<data>\
   - -1, -2, -3, ... : list의 뒤에서 시작하여 각 element 위치를 나타냄
 - \<bytes\> - 삽입할 데이터 길이 (trailing 문자인 "\r\n"을 제외한 길이)
 - create \<attributes\> - list collection 없을 시에 list 생성 요청.
-                    [Item Attribute 설명](ch03-item-attributes.md)을 참조 바란다.
-- noreply or pipe - 명시하면, response string을 전달받지 않는다. 
-                    pipe 사용은 [Command Pipelining](ch09-command-pipelining.md)을 참조 바란다.
+[Item Attribute 설명](ch03-item-attributes.md)을 참조 바란다.
+- noreply or pipe - 명시하면, response string을 전달받지 않는다.
+pipe 사용은 [Command Pipelining](ch09-command-pipelining.md)을 참조 바란다.
 - \<data\> - 삽입할 데이터 (최대 크기는 [기본제약사항](ch01-arcus-basic-concept.md#기본-제약-사항)을 참고)
 
  
@@ -61,8 +61,8 @@ Response string과 그 의미는 아래와 같다.
 - “NOT_FOUND” - key miss
 - “TYPE_MISMATCH” - 해당 item이 list collection이 아님
 - “OVERFLOWED” - overflow 발생
-- “OUT_OF_RANGE” - 삽입 위치가 list의 현재 element index 범위를 넘어섬,
-                   예를 들어, 10개 element가 있는 상태에서 삽입 위치가 20인 경우임
+- “OUT_OF_RANGE” - 삽입 위치가 list의 현재 element index 범위를 넘어섬.
+예를 들어, 10개 element가 있는 상태에서 삽입 위치가 20인 경우임
 - "NOT_SUPPORTED" - 지원하지 않음
 - “CLIENT_ERROR bad command line format” - protocol syntax 틀림
 - “CLIENT_ERROR too large value” - 삽입할 데이터가 element value의 최대 크기보다 큼
@@ -87,8 +87,8 @@ lop delete 명령에서 각 인자의 설명은 아래와 같다.
   - 4..2 : 앞의 5번째 element 부터 앞의 3번째 element까지 (backward 순서)
   - -1..0: 마지막 element 부터 첫째 element 까지 (backward 순서)
 - drop - element 삭제로 인해 empty list가 될 경우, 그 list를 drop할 것인지를 지정한다.
-- noreply or pipe - 명시하면, response string을 전달받지 않는다. 
-                    pipe 사용은 [Command Pipelining](ch09-command-pipelining.md)을 참조 바란다.
+- noreply or pipe - 명시하면, response string을 전달받지 않는다.
+pipe 사용은 [Command Pipelining](ch09-command-pipelining.md)을 참조 바란다.
 
 Response string과 그 의미는 아래와 같다.
 
@@ -110,8 +110,8 @@ lop get <key> <index or "index range"> [delete|drop]\r\n
 
 - \<key\> - 대상 item의 key string
 - \<index or "index range"\> - 조회할 element의 index or index range. "lop delete" 명령의 인자 참조
-- delete or drop - element 조회하면서 그 element를 delete할 것인지
-                   그리고 delete로 인해 empty list가 될 경우 그 list를 drop할 것인지를 지정한다.
+- delete or drop - element 조회하면서 그 element를 delete할 것인지,
+그리고 delete로 인해 empty list가 될 경우 그 list를 drop할 것인지를 지정한다.
 
 성공 시의 response string은 아래와 같다.
 VALUE 라인의 \<count\>는 조회된 element 개수를 의미한다.

--- a/doc/ch06-command-set-collection.md
+++ b/doc/ch06-command-set-collection.md
@@ -46,9 +46,9 @@ sop insert <key> <bytes> [create <attributes>] [noreply|pipe]\r\n<data>\r\n
 - \<key\> - 대상 item의 key string
 - \<bytes\> - 삽입할 데이터 길이 (trailing 문자인 "\r\n"을 제외한 길이)
 - create \<attributes\> - set collection 없을 시에 set 생성 요청.
-                    [Item Attribute 설명](ch03-item-attributes.md)을 참조 바란다.
-- noreply or pipe - 명시하면, response string을 전달받지 않는다. 
-                    pipe 사용은 [Command Pipelining](ch09-command-pipelining.md)을 참조 바란다.
+[Item Attribute 설명](ch03-item-attributes.md)을 참조 바란다.
+- noreply or pipe - 명시하면, response string을 전달받지 않는다.
+pipe 사용은 [Command Pipelining](ch09-command-pipelining.md)을 참조 바란다.
 - \<data\> - 삽입할 데이터 (최대 크기는 [기본제약사항](ch01-arcus-basic-concept.md#기본-제약-사항)을 참고)
 
 Response string과 그 의미는 아래와 같다.
@@ -76,8 +76,8 @@ sop delete <key> <bytes> [drop] [noreply|pipe]\r\n<data>\r\n
 - \<key\> - 대상 item의 key string
 - \<bytes\> - 삭제할 데이터 길이 (trailing 문자인 "\r\n"을 제외한 길이)
 - drop - element 삭제로 인해 empty set이 될 경우, 그 set을 drop할 것인지를 지정한다.
-- noreply or pipe - 명시하면, response string을 전달받지 않는다. 
-                    pipe 사용은 [Command Pipelining](ch09-command-pipelining.md)을 참조 바란다.
+- noreply or pipe - 명시하면, response string을 전달받지 않는다.
+pipe 사용은 [Command Pipelining](ch09-command-pipelining.md)을 참조 바란다.
 - \<data\> - 삭제할 데이터
 
 Response string과 그 의미는 아래와 같다.
@@ -102,8 +102,8 @@ sop get <key> <count> [delete|drop]\r\n
 
 - \<key\> - 대상 item의 key string
 - \<count\> - 조회할 elements 개수를 지정. 0이면 전체 elements를 의미한다.
-- delete or drop - element 조회하면서 그 element를 delete할 것인지
-                   그리고 delete로 인해 empty set이 될 경우 그 set을 drop할 것인지를 지정한다.
+- delete or drop - element 조회하면서 그 element를 delete할 것인지,
+그리고 delete로 인해 empty set이 될 경우 그 set을 drop할 것인지를 지정한다.
 
 성공 시의 response string은 아래와 같다.
 VALUE 라인의 \<count\>는 조회된 element 개수를 의미한다. 
@@ -140,8 +140,8 @@ sop exist <key> <bytes> [pipe]\r\n<data>\r\n
 
 - \<key\> - 대상 item의 key string
 - \<bytes\>와 \<data\> - 존재 유무를 검사할 데이터의 길이와 데이터 그 자체
-- pipe - 명시하면, response string을 전달받지 않는다. 
-         [Command Pipelining](ch09-command-pipelining.md)을 참조 바란다.
+- pipe - 명시하면, response string을 전달받지 않는다.
+[Command Pipelining](ch09-command-pipelining.md)을 참조 바란다.
 
 Response string과 그 의미는 아래와 같다.
 

--- a/doc/ch07-command-map-collection.md
+++ b/doc/ch07-command-map-collection.md
@@ -47,9 +47,9 @@ mop insert <key> <field> <bytes> [create <attributes>] [noreply|pipe]\r\n<data>\
 - \<field\> - 삽입할 element의 field string
 - \<bytes\> - 삽입할 element의 데이터 길이 (trailing 문자인 "\r\n"을 제외한 길이)
 - create \<attributes\> - 해당 map collection 없을 시에 map 생성 요청.
-                    [Item Attribute 설명](ch03-item-attributes.md)을 참조 바란다.
-- noreply or pipe - 명시하면, response string을 전달받지 않는다. 
-                    pipe 사용은 [Command Pipelining](ch09-command-pipelining.md)을 참조 바란다.
+[Item Attribute 설명](ch03-item-attributes.md)을 참조 바란다.
+- noreply or pipe - 명시하면, response string을 전달받지 않는다.
+pipe 사용은 [Command Pipelining](ch09-command-pipelining.md)을 참조 바란다.
 - \<data\> - 삽입할 데이터 (최대 크기는 [기본제약사항](ch01-arcus-basic-concept.md#기본-제약-사항)을 참고)
 
 Response string과 그 의미는 아래와 같다.
@@ -79,8 +79,8 @@ mop update <key> <field> <bytes> [noreply|pipe]\r\n<data>\r\n
 - \<key\> - 대상 item의 key string
 - \<field\> - 대상 element의 field string
 - \<bytes\> - 변경할 데이터 길이 (trailing 문자인 "\r\n"을 제외한 길이)
-- noreply or pipe - 명시하면, response string을 전달받지 않는다. 
-                    pipe 사용은 [Command Pipelining](ch09-command-pipelining.md)을 참조 바란다.
+- noreply or pipe - 명시하면, response string을 전달받지 않는다.
+pipe 사용은 [Command Pipelining](ch09-command-pipelining.md)을 참조 바란다.
 - \<data\> - 변경할 데이터 자체
 
 Response string과 그 의미는 아래와 같다.
@@ -105,12 +105,12 @@ mop delete <key> <lenfields> <numfields> [drop] [noreply|pipe]\r\n
 ```
 
 - "space separated fields" - 대상 map의 field list로, 스페이스(' ')로 구분한다.
-                           - 하위 호환성(1.10.X 이하 버전)을 위해 콤마(,)도 지원하지만 권장하지 않는다.
+                       - 하위 호환성(1.10.X 이하 버전)을 위해 콤마(,)도 지원하지만 권장하지 않는다.
 - \<key\> - 대상 item의 key string
 - \<lenfields>\과 \<numfields>\ - field list 문자열의 길이와 field 개수를 나타낸다. 0이면 전체 field, element를 의미한다.
 - drop - field, element 삭제로 인해 empty map이 될 경우, 그 map을 drop할 것인지를 지정한다.
-- noreply or pipe - 명시하면, response string을 전달받지 않는다. 
-                    pipe 사용은 [Command Pipelining](ch09-command-pipelining.md)을 참조 바란다.
+- noreply or pipe - 명시하면, response string을 전달받지 않는다.
+pipe 사용은 [Command Pipelining](ch09-command-pipelining.md)을 참조 바란다.
 
 Response string과 그 의미는 아래와 같다.
 
@@ -132,11 +132,11 @@ mop get <key> <lenfields> <numfields> [delete|drop]\r\n
 ```
 
 - "space separated fields" - 대상 map의 field list로, 스페이스(' ')로 구분한다.
-                           - 하위 호환성(1.10.X 이하 버전)을 위해 콤마(,)도 지원하지만 권장하지 않는다.
+                       - 하위 호환성(1.10.X 이하 버전)을 위해 콤마(,)도 지원하지만 권장하지 않는다.
 - \<key\> - 대상 item의 key string
 - \<lenfields\> 과 \<numfields>\ - field list 문자열의 길이와 field 개수를 나타낸다. 0이면 전체 field, element를 의미한다.
-- delete or drop - field, element 조회하면서 그 field, element를 delete할 것인지
-                   그리고 delete로 인해 empty map이 될 경우 그 map을 drop할 것인지를 지정한다.
+- delete or drop - field, element 조회하면서 그 field, element를 delete할 것인지,
+그리고 delete로 인해 empty map이 될 경우 그 map을 drop할 것인지를 지정한다.
 
 성공 시의 response string은 아래와 같다.
 VALUE 라인의 \<count\>는 조회된 field 개수를 의미한다. 

--- a/doc/ch08-command-btree-collection.md
+++ b/doc/ch08-command-btree-collection.md
@@ -46,7 +46,8 @@ bop create <key> <attributes> [noreply]\r\n
 ```
 
 - \<key\> - 대상 item의 key string
-- \<attributes\> - 설정할 item attributes. [Item Attribute 설명](ch03-item-attribute.md)을 참조 바란다.
+- \<attributes\> - 설정할 item attributes.
+[Item Attribute 설명](ch03-item-attributes.md)을 참조 바란다.
 - noreply - 명시하면, response string을 전달받지 않는다.
 
 Response string과 그 의미는 아래와 같다.
@@ -62,7 +63,7 @@ Response string과 그 의미는 아래와 같다.
 B+tree collection에 하나의 element를 추가하는 명령으로
 (1) 하나의 element를 삽입하는 bop insert 명령과
 (2) 현재 삽입하는 bkey를 가진 element가 없으면 현재의 element를 삽입하고
-    그 bkey를 가진 element가 있으면 현재의 element로 대체시키는 bop upsert 명령이 있다.
+그 bkey를 가진 element가 있으면 현재의 element로 대체시키는 bop upsert 명령이 있다.
 이들 명령 수행에서 b+tree collection을 생성하면서 하나의 element를 추가할 수도 있다.
 
 ```
@@ -76,11 +77,11 @@ bop upsert <key> <bkey> [<eflag>] <bytes> [create <attributes>] [noreply|pipe|ge
 - \<eflag\> - 삽입할 element의 optional flag
 - \<bytes\>와 \<data\> - 삽입할 element의 데이터의 길이와 데이터 그 자체 (최대 크기는 [기본제약사항](ch01-arcus-basic-concept.md#기본-제약-사항)을 참고)
 - create \<attributes\> - b+tree collection 없을 시에 b+tree 생성 요청.
-                    [Item Attribute 설명](ch03-item-attributes.md)을 참조 바란다.
-- noreply or pipe - 명시하면, response string을 전달받지 않는다. 
-                    pipe 사용은 [Command Pipelining](ch09-command-pipelining.md)을 참조 바란다.
+[Item Attribute 설명](ch03-item-attributes.md)을 참조 바란다.
+- noreply or pipe - 명시하면, response string을 전달받지 않는다.
+pipe 사용은 [Command Pipelining](ch09-command-pipelining.md)을 참조 바란다.
 - getrim - 새로운 element 추가로 maxcount 제약에 의한 overflow trim이 발생할 경우,
-           trim된 element 정보를 가져온다.
+trim된 element 정보를 가져온다.
 
 Trimmed element 정보가 리턴되는 경우, 그 response string은 아래와 같다.
 
@@ -100,11 +101,10 @@ END\r\n
 - "BKEY_MISMATCH" - 삽입할 bkey 유형과 대상 b+tree의 bkey 유형이 다름
 - “OVERFLOWED” - overflow 발생
 - “OUT_OF_RANGE” - 새로운 element 삽입이 maxcount 또는 maxbkeyrange 제약을 위배하면서
-                   그 element의 bkey 값이 overflowaction에 의해 자동 삭제되는 경우이어서
-                   삽입이 실패하는 경우이다.
-                   예를 들어, smallest_trim 상황에서
-                   새로 삽입할 element의 bkey 값이 b+tree의 smallest bkey 보다 작으면서
-                   maxcount 개의 elements가 이미 존재하거나 maxbkeyrange를 벗어나는 경우가 이에 해당된다.
+그 element의 bkey 값이 overflowaction에 의해 자동 삭제되는 경우이어서 삽입이 실패하는 경우이다.
+예를 들어, smallest_trim 상황에서 새로 삽입할 element의 bkey 값이 b+tree의
+smallest bkey 보다 작으면서 maxcount 개의 elements가 이미 존재하거나
+maxbkeyrange를 벗어나는 경우가 이에 해당된다.
 - "ELEMENT_EXISTS" - 동일 bkey를 가진 element가 존재
 - "NOT_SUPPORTED" - 지원하지 않음
 - “CLIENT_ERROR bad command line format” - protocol syntax 틀림
@@ -125,11 +125,10 @@ bop update <key> <bkey> [<eflag_update>] <bytes> [noreply|pipe]\r\n[<data>\r\n]
 - \<key\> - 대상 item의 key string
 - \<bkey\> - 대상 element의 bkey
 - \<eflag_update\> - eflag update 명시.
-                     [Collection 기본 개념](ch02-collection-items.md)에서 eflag update를 참조 바란다.
-- \<bytes\>와 \<data\> - 새로 변경할 데이터의 길이와 데이터 그 자체
-                         데이터 변경을 원치 않으면 \<bytes\>를 -1로 하고 \<data\>를 생략하면 된다.         
-- noreply or pipe - 명시하면, response string을 전달받지 않는다. 
-                    pipe 사용은 [Command Pipelining](ch09-command-pipelining.md)을 참조 바란다.
+[Collection 기본 개념](ch02-collection-items.md)에서 eflag update를 참조 바란다.
+- \<bytes\>와 \<data\> - 새로 변경할 데이터의 길이와 데이터 그 자체. 데이터 변경을 원치 않으면 \<bytes\>를 -1로 하고 \<data\>를 생략하면 된다.         
+- noreply or pipe - 명시하면, response string을 전달받지 않는다.
+pipe 사용은 [Command Pipelining](ch09-command-pipelining.md)을 참조 바란다.
 
 Response string과 그 의미는 아래와 같다.
 
@@ -139,8 +138,8 @@ Response string과 그 의미는 아래와 같다.
 - “TYPE_MISMATCH” - 해당 item이 b+tree colleciton이 아님
 - "BKEY_MISMATCH" - 명령 인자로 주어진 bkey 유형과 대상 b+tree의 bkey 유형이 다름
 - "EFLAG_MISMATCH" - 해당 element의 eflag 값에 대해 \<eflag_update\>를 적용할 수 없음.
-                     예를 들어, 변경하고자 하는 eflag가 존재하지 않거나,
-                     존재하더라도 \<eflag_update\> 조건으로 명시된 부분의 데이터를 가지지 않은 상태이다.
+예를 들어, 변경하고자 하는 eflag가 존재하지 않거나, 존재하더라도 \<eflag_update\>
+조건으로 명시된 부분의 데이터를 가지지 않은 상태이다.
 - “NOTHING_TO_UPDATE” - eflag 변경과 data 변경 중 어느 하나도 명시되지 않은 상태
 - "NOT_SUPPORTED" - 지원하지 않음
 - “CLIENT_ERROR bad command line format” - protocol syntax 틀림
@@ -160,13 +159,13 @@ bop delete <key> <bkey or "bkey range"> [<eflag_filter>] [<count>] [drop] [norep
 
 - \<key\> - 대상 item의 key string
 - \<bkey or "bkey range"\> - 하나의 bkey 또는 bkey range 조회 조건.
-                             Bkey range는 "bkey1..bkey2" 형식으로 표현한다.
+Bkey range는 "bkey1..bkey2" 형식으로 표현한다.
 - \<eflag_filter\> - eflag filter 조건.
-                    [Collection 기본 개념](ch02-collection-items.md)에서 eflag filter 참조 바란다.
+[Collection 기본 개념](ch02-collection-items.md)에서 eflag filter 참조 바란다.
 - \<count\> - 삭제할 elements 개수 지정
 - drop - element 삭제로 인해 empty b+tree가 될 경우, 그 b+tree를 drop할 것인지를 지정한다.
-- noreply or pipe - 명시하면, response string을 전달받지 않는다. 
-                    pipe 사용은 [Command Pipelining](ch09-command-pipelining.md)을 참조 바란다.
+- noreply or pipe - 명시하면, response string을 전달받지 않는다.
+pipe 사용은 [Command Pipelining](ch09-command-pipelining.md)을 참조 바란다.
 
 Response string과 그 의미는 아래와 같다.
 
@@ -190,13 +189,11 @@ bop get <key> <bkey or "bkey range"> [<eflag_filter>] [[<offset>] <count>] [dele
 ```
 
 - \<key\> - 대상 item의 key string
-- \<bkey or "bkey range"\> - 하나의 bkey 또는 bkey range 조회 조건.
-                             Bkey range는 "bkey1..bkey2" 형식으로 표현한다.
-- \<eflag_filter\> - eflag filter 조건.
-                    [Collection 기본 개념](ch02-collection-items.md)에서 eflag filter 참조 바란다.
+- \<bkey or "bkey range"\> - 하나의 bkey 또는 bkey range 조회 조건. Bkey range는 "bkey1..bkey2" 형식으로 표현한다.
+- \<eflag_filter\> - eflag filter 조건. [Collection 기본 개념](ch02-collection-items.md)에서 eflag filter 참조 바란다.
 - [\<offset\>] \<count\> - 조회 조건을 만족하는 elements에서 skip 개수와 실제 조회할 개수
-- delete or drop - element 조회하면서 그 element를 delete할 것인지 그리고 delete로 인해 empty b+tree가 될 경우
-                   그 b+tree를 drop할 것인지를 지정한다.
+- delete or drop - element 조회하면서 그 element를 delete할 것인지
+그리고 delete로 인해 empty b+tree가 될 경우 그 b+tree를 drop할 것인지를 지정한다.
 
 성공 시의 response string은 아래와 같다.
 VALUE 라인의 \<count\>는 조회된 element 개수를 나타내며,
@@ -228,8 +225,7 @@ END|TRIMMED|DELETED|DELETED_DROPPED\r\n
 - “NOT_FOUND” - key miss
 - “NOT_FOUND_ELEMENT” - element miss (조회 조건을 만족하는 element가 없음)
 - “OUT_OF_RANGE” - 조회 조건을 만족하는 element가 없으며,
-                   또한 주어진 bkey range가 b+tree의 overflowaction에 의해
-                   trim된 bkey 영역과 overlap 되었음을 나타낸다.
+또한 주어진 bkey range가 b+tree의 overflowaction에 의해 trim된 bkey 영역과 overlap 되었음을 나타낸다.
 - “TYPE_MISMATCH” - 해당 item이 b+tree collection이 아님
 - “BKEY_MISMATCH” - 명령 인자로 주어진 bkey 유형과 대상 b+tree의 bkey 유형이 다름
 - “UNREADABLE” - 해당 item이 unreadable item임
@@ -249,9 +245,9 @@ bop count <key> <bkey or "bkey range"> [<eflag_filter>]\r\n
 
 - \<key\> - 대상 item의 key string
 - \<bkey or "bkey range"\> - 하나의 bkey 또는 bkey range 조회 조건.
-                             Bkey range는 "bkey1..bkey2" 형식으로 표현한다.
+Bkey range는 "bkey1..bkey2" 형식으로 표현한다.
 - \<eflag_filter\> - eflag filter 조건.
-                    [Collection 기본 개념](ch02-collection-items.md)에서 eflag filter 참조 바란다.
+[Collection 기본 개념](ch02-collection-items.md)에서 eflag filter 참조 바란다.
 
 성공 시의 response string은 아래와 같다.
 
@@ -301,12 +297,11 @@ Increment/decrement 수행 후의 데이터 값이다.
 - “NOT_FOUND_ELEMENT” - element miss
 - “TYPE_MISMATCH” - 해당 item이 b+tree collection이 아님
 - “BKEY_MISMATCH” - 명령 인자로 주언진 bkey 유형과 대상 b+tree의 bkey 유형이 다름
-- “OUT_OF_RANGE” - 새로운 element 삽입이 maxcount 또는 maxbkeyrange 제약을 위배하면서
-                   그 element의 bkey 값이 overflowaction에 의해 자동 삭제되는 경우이어서
-                   삽입이 실패하는 경우이다.
-                   예를 들어, smallest_trim 상황에서
-                   새로 삽입할 element의 bkey 값이 b+tree의 smallest bkey 보다 작으면서
-                   maxcount 개의 elements가 이미 존재하거나 maxbkeyrange를 벗어나는 경우가 이에 해당된다.
+- “OUT_OF_RANGE” - 새로운 element 삽입이 maxcount 또는 maxbkeyrange 제약을 
+위배하면서 그 element의 bkey 값이 overflowaction에 의해 자동 삭제되는 경우이어서 
+삽입이 실패하는 경우이다. 예를 들어, smallest_trim 상황에서 새로 삽입할 element의 
+bkey 값이 b+tree의 smallest bkey 보다 작으면서 maxcount 개의 elements가 이미 
+존재하거나 maxbkeyrange를 벗어나는 경우가 이에 해당된다.
 - “OVERFLOWED” - overflow 발생
 - "NOT_SUPPORTED" - 지원하지 않음
 - “CLIENT_ERROR cannot increment or decrement non-numeric value” - 해당 element의 데이터가 숫자형이 아님.
@@ -326,12 +321,10 @@ bop mget <lenkeys> <numkeys> <bkey or "bkey range"> [<eflag_filter>] [<offset>] 
 ```
 
 - \<”space separated keys”\> - 대상 b+tree들의 key list로, 스페이스(' ')로 구분한다.
-                             - 하위 호환성(1.10.X 이하 버전)을 위해 콤마(,)도 지원하지만 권장하지 않는다.
+     - 하위 호환성(1.10.X 이하 버전)을 위해 콤마(,)도 지원하지만 권장하지 않는다.
 - \<lenkeys\>과 \<numkeys> - key list 문자열의 길이와 key 개수를 나타낸다.
-- \<bkey or "bkey range"\> - 하나의 bkey 또는 bkey range 조회 조건.
-                             Bkey range는 "bkey1..bkey2" 형식으로 표현한다.
-- \<eflag_filter\> - eflag filter 조건.
-                    [Collection 기본 개념](ch02-collection-items.md)에서 eflag filter 참조 바란다.
+- \<bkey or "bkey range"\> - 하나의 bkey 또는 bkey range 조회 조건. Bkey range는 "bkey1..bkey2" 형식으로 표현한다.
+- \<eflag_filter\> - eflag filter 조건. [Collection 기본 개념](ch02-collection-items.md)에서 eflag filter 참조 바란다.
 - [\<offset\>] \<count\> - 조회 조건을 만족하는 elements에서 skip 개수와 실제 조회할 개수
 
 bop mget 명령은 O(small N) 수행 원칙을 위하여 다음의 제약 사항을 가진다.
@@ -436,12 +429,12 @@ bop smget <lenkeys> <numkeys> <bkey or "bkey range"> [<eflag_filter>] <count> [d
 ```
 
 - \<”space separated keys”\> - 대상 b+tree들의 key list로, 스페이스(' ')로 구분한다.
-                             - 하위 호환성(1.10.X 이하 버전)을 위해 콤마(,)도 지원하지만 권장하지 않는다.
+     - 하위 호환성(1.10.X 이하 버전)을 위해 콤마(,)도 지원하지만 권장하지 않는다.
 - \<lenkeys\>과 \<numkeys> - key list 문자열의 길이와 key 개수를 나타낸다.
 - \<bkey or "bkey range"\> - 하나의 bkey 또는 bkey range 조회 조건.
-                             Bkey range는 "bkey1..bkey2" 형식으로 표현한다.
+Bkey range는 "bkey1..bkey2" 형식으로 표현한다.
 - \<eflag_filter\> - eflag filter 조건.
-                    [Collection 기본 개념](ch02-collection-items.md)에서 eflag filter 참조 바란다.
+[Collection 기본 개념](ch02-collection-items.md)에서 eflag filter 참조 바란다.
 - \<count\> - 조회할 element 개수
 - [duplicate|unique] - smget 동작 방식을 지정한다.
   - 생략되면, 예전 smget 동작을 수행한다.
@@ -532,7 +525,7 @@ smget 수행의 실패 시의 response string은 다음과 같다.
 - "NOT_SUPPORTED" - 지원하지 않음
 - “CLIENT_ERROR bad command line format” - protocol syntax 틀림
 - “CLIENT_ERROR bad data chunk”	- 주어진 key 리스트에 중복 key가 존재하거나
-              주어진 key 리스트의 길이가 \<lenkeys\> 길이와 다르거나 “\r\n”으로 끝나지 않음.
+주어진 key 리스트의 길이가 \<lenkeys\> 길이와 다르거나 “\r\n”으로 끝나지 않음.
 - “CLIENT_ERROR bad value” - 앞서 기술한 smget 연산의 제약 조건을 위배
 - “SERVER_ERROR out of memory [writing get response]” - 메모리 부족
 
@@ -581,7 +574,7 @@ bop gbp <key> <order> <position or "position range">\r\n
 - \<key\> - 대상 item의 key string
 - \<order\> - 어떤 bkey 정렬 기준으로 position을 적용할 지를 명시
 - \<position or "position range"\> - 조회할 elements의 하나의 position 또는 position range.
-                                     Position range는 "position1..position2" 형식으로 표현.
+Position range는 "position1..position2" 형식으로 표현.
 
 성공 시의 response string은 아래와 같다.
 bop get 성공 시의 response string을 참조 바란다.


### PR DESCRIPTION
list item 표기 도중 들여쓰기를 할 경우, 문서시스템에서는 인용문으로 처리되는 문제가 있어 들여쓰기를 제거하였고, develop 브랜치와의

참고로 들여쓰기를 제거해도 github에서 보이는 문서의 view는 그대로 입니다. 기존 문서도 raw 파일 상에서는 들여쓰기가 되어있지만 한 줄로 붙어나오고 있습니다. 수정한 결과도 마찬가지입니다. 한 줄로 쭉 붙여써도 되지만, 라인이 너무 길어지면 raw file을 볼 때 불편한 점이 있으므로 개행은 유지했습니다. 

merge되면 문서시스템에 반영하겠습니다. 