### PR TITLE
DOC: cleanup docs style and contents

### DIFF
--- a/doc/ch02-collection-items.md
+++ b/doc/ch02-collection-items.md
@@ -45,16 +45,16 @@ map의 최상위 hash table 구조, b+tree의 root node 주소가 이에 해당�
 
 Collection 유형에 따른 element 구조는 아래와 같다.
 
-- list/set element : \< data \>
+- list/set element : \<data\>
 
   각 element는 하나의 데이터 만을 가진다.
 
-- map element : \<field(map element key), data \>
+- map element : \<field(map element key), data\>
 
   map에서 각 element를 구분하기 위한 field를 필수적으로 가지며,
   field는 중복을 허용하지 않는다.
   
-- b+tree element : \< bkey(b+tree key), eflag(element flag), data \>
+- b+tree element : \<bkey(b+tree key), eflag(element flag), data\>
 
   b+tree에서 elements를 어떤 기준으로 정렬하기 위한 bkey를 필수적으로 가지며,
   옵션 사항으로 bkey 기반의 scan 시에 특정 element를 filtering하기 위한 eflag를 가질 수 있으며,

--- a/doc/ch07-command-map-collection.md
+++ b/doc/ch07-command-map-collection.md
@@ -105,7 +105,7 @@ mop delete <key> <lenfields> <numfields> [drop] [noreply|pipe]\r\n
 ```
 
 - "space separated fields" - 대상 map의 field list로, 스페이스(' ')로 구분한다.
-                       - 하위 호환성(1.10.X 이하 버전)을 위해 콤마(,)도 지원하지만 권장하지 않는다.
+  - 하위 호환성(1.10.X 이하 버전)을 위해 콤마(,)도 지원하지만 권장하지 않는다.
 - \<key\> - 대상 item의 key string
 - \<lenfields>\과 \<numfields>\ - field list 문자열의 길이와 field 개수를 나타낸다. 0이면 전체 field, element를 의미한다.
 - drop - field, element 삭제로 인해 empty map이 될 경우, 그 map을 drop할 것인지를 지정한다.
@@ -132,7 +132,7 @@ mop get <key> <lenfields> <numfields> [delete|drop]\r\n
 ```
 
 - "space separated fields" - 대상 map의 field list로, 스페이스(' ')로 구분한다.
-                       - 하위 호환성(1.10.X 이하 버전)을 위해 콤마(,)도 지원하지만 권장하지 않는다.
+  - 하위 호환성(1.10.X 이하 버전)을 위해 콤마(,)도 지원하지만 권장하지 않는다.
 - \<key\> - 대상 item의 key string
 - \<lenfields\> 과 \<numfields>\ - field list 문자열의 길이와 field 개수를 나타낸다. 0이면 전체 field, element를 의미한다.
 - delete or drop - field, element 조회하면서 그 field, element를 delete할 것인지,

--- a/doc/ch11-command-administration.md
+++ b/doc/ch11-command-administration.md
@@ -274,12 +274,12 @@ END
 
 명령 별 주요 통계를 정리하면 다음과 같다.
 
-- cmd_<command_name>: 해당 명령의 수행 횟수
-- <command_name>_hits: 해당 명령의 key hit 횟수
-- <command_name>_misses: 해당 명령의 key miss 횟수
+- cmd_\<command_name\>: 해당 명령의 수행 횟수
+- \<command_name\>_hits: 해당 명령의 key hit 횟수
+- \<command_name\>_misses: 해당 명령의 key miss 횟수
 - 콜렉션 명령의 key hit 횟수는 따로 제공하지 않으며, 아래 횟수의 합으로 계산할 수 있다.
-  - <collection_name>\_<command_name>\_elem_hits: 콜렉션 명령의 key hit 그리고 element hit 횟수 
-  - <collection_name>\_<command_name>\_none_hits: 콜렉션 명령의 key hit 그러나 element miss 횟수
+  - \<collection_name\>_\<command_name\>_elem_hits: 콜렉션 명령의 key hit 그리고 element hit 횟수
+  - \<collection_name\>_\<command_name\>_none_hits: 콜렉션 명령의 key hit 그러나 element miss 횟수
 
 다음은 그 외의 개별 통계이다. 
 


### PR DESCRIPTION
수정 사항

- 불필요한 공백 제거
  - \<\> 사이에 공백을 넣는 것은 이전에 쓰던 툴에서 부등호 사이의 문자가 보이지 않는 현상이 있었기 때문인데, 현재 툴에선 공백을 넣지 않아도 escape만 하면 잘 보임.
- escape 문자 추가
  - escape 없이 \<\>를 사용한 곳 수정(escape 문자 없을 시 표기되지 않음)  
- list item indentation 시 quote box 생기는 현상(이전 PR에서 누락됨)
