### PR TITLE
FEATURE: support zookeeper dynamic reconfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ $ make install
 
 The use of ZooKeeper based clustering is optional.
 To enable it, use `--enable-zk-integration` along with `--with-zookeeper` when running configure.
-Make sure to use the ZooKeeper library with Arcus modifications.
+
+Note that ZooKeeper dynamic reconfig was included in it.
+So, you must use the ZooKeeper library 3.5.7 or higher version with Arcus modifications.
+If you want to turn off the ZooKeeper dynamic reconfig, add `--without-zk-reconfig` to the above configure options.
 
 To test arcus-memcached, you can execute `make test`. If any problem exists in compilation, please refer to [compilation FAQ](/doc/compilation_faq.md).
 

--- a/configure.ac
+++ b/configure.ac
@@ -406,6 +406,12 @@ AC_ARG_ENABLE(zk-integration,
 if test "x$enable_zk_integration" = "xyes"; then
   AC_DEFINE([ENABLE_ZK_INTEGRATION],[1],[Set to nonzero if you want to make zookeeper integration])
   AC_DEFINE([ENABLE_CLUSTER_AWARE],1,[Set to nonzero if you want to make memcached cluster-aware])
+
+  AC_ARG_WITH(zk-reconfig,
+      [AS_HELP_STRING([--without-zk-reconfig],[Disable zookeeper dynamic reconfiguration])], ,
+      [AC_DEFINE([ENABLE_ZK_RECONFIG],1,[Set to nonzero if you want to use zookeeper dynamic reconfig])]
+  )
+
   tryzookeeperdir=""
   AC_ARG_WITH(zookeeper,
       [  --with-zookeeper=PATH   specify path to zookeeper installation ],
@@ -476,6 +482,8 @@ if test "x$enable_zk_integration" = "xyes"; then
   ])
     fi
   ])
+  AC_DEFINE([THREADED],1,[Enable ZooKeeper multi thread mode])
+
 #  LIBS="$LIBS -lzookeeper_mt"
   if test $ac_cv_zookeeper_dir != "(system)"; then
     if test -d "$ac_cv_zookeeper_dir/lib" ; then


### PR DESCRIPTION
ZooKeeper dynamic reconfiguration 기능 지원을 위한 PR 입니다.

arcus-memcached에서 zk reconfig 기능을 enable 하기 위해 `--with-zk-reconfig` 구동 옵션을 추가 했습니다.
reconfig code는 ENABLE_ZK_RECONFIG code tag로 관리하며 `--with-zk-reconfig` 옵션으로 컴파일 되도록 했습니다.
zookeeper 3.5 버전부터는 컴파일 옵션에 `THREADED` 를 추가해야 multi thread mode로 동작할 수 있어 컴파일 옵션을 추가 했습니다.

zookeeper initialize 시점에 `/zookeeper/config` znode와 data를 조회하고
reconfig watcher를 enable/disable 합니다.
조회한 configuration data는 필요한 정보들을 parsing 하고 현재 version과 비교하여,
변경이 필요한 경우만 ZK server list를 업데이트 하도록 했습니다.

config data가 잘못되었을 때 에러 핸들링은,
watcher는 유지하는 상태에서 ZK server list에 반영하지 않도록 했습니다.

@minkikim89 @jhpark816 
확인 요청 드립니다.