### PR TITLE
ENHANCE: optimize do_item_replace()

### DIFF
--- a/engines/default/items.c
+++ b/engines/default/items.c
@@ -1235,15 +1235,78 @@ static hash_item *do_item_get(const char *key, const uint32_t nkey, bool do_upda
     return it;
 }
 
-static void do_item_replace(hash_item *old_it, hash_item *new_it)
+static ENGINE_ERROR_CODE do_item_replace(hash_item *old_it, hash_item *new_it)
 {
     MEMCACHED_ITEM_REPLACE(item_get_key(old_it), old_it->nkey, old_it->nbytes,
-                           item_get_key(new_it), new_it->nkey, new_it->nbytes);
-    do_item_unlink(old_it, ITEM_UNLINK_REPLACE);
+            item_get_key(new_it), new_it->nkey, new_it->nbytes);
+
+    /* cause: item unlink cause will be used, later */
+    enum item_unlink_cause cause = ITEM_UNLINK_REPLACE;
+
+    const char *old_key = item_get_key(old_it);
+    const char *new_key = item_get_key(new_it);
+
+    if ((old_it->iflag & ITEM_LINKED) != 0) {
+        /* replace the item from LRU list */
+        if (old_it->slabs_clsid == new_it->slabs_clsid) {
+            item_replace_q(old_it, new_it);
+        } else {
+            CLOG_ITEM_UNLINK(old_it, cause);
+            /* unlink the item from LUR list */
+            item_unlink_q(old_it);
+            /* link the item to LRU list */
+            item_link_q(new_it);
+            CLOG_ITEM_LINK(new_it);
+        }
+
+        /* unlink the item from hash table */
+        assoc_delete(old_key, old_it->nkey, old_it->khash);
+        old_it->iflag &= ~ITEM_LINKED;
+
+        /* link the item to the hash table */
+        new_it->iflag |= ITEM_LINKED;
+        new_it->time = svcore->get_current_time();
+        new_it->khash = GEN_ITEM_KEY_HASH(new_key, new_it->nkey);
+        assoc_insert(new_it, new_it->khash);
+
+        /* replace the item from prefix info */
+        size_t old_stotal = ITEM_stotal(old_it);
+        size_t new_stotal = ITEM_stotal(new_it);
+
+        /* Allocate a new CAS ID on link. */
+        item_set_cas(new_it, get_cas_id());
+
+        if (new_stotal != old_stotal) {
+            /* update item statistics */
+            do_item_stat_unlink(old_it, old_stotal);
+            prefix_replace(old_it, new_it, old_stotal, new_stotal);
+            /* update item statistics */
+            do_item_stat_link(new_it, new_stotal);
+        } else {
+            assert(new_stotal == new_stotal);
+            prefix_replace(old_it, new_it, old_stotal, new_stotal);
+        }
+
+        if (IS_COLL_ITEM(old_it)) {
+            /* IMPORTANT NOTE)
+             * The element space statistics has already been decreased.
+             * So, we must not decrease the space statistics any more
+             * even if the elements are freed later.
+             * For that purpose, we set info->stotal to 0 like below.
+             */
+            coll_meta_info *info = (coll_meta_info *)item_get_meta(old_it);
+            info->stotal = 0;
+        }
+
+        /* free the item if no one reference it */
+        if (old_it->refcount == 0) {
+            do_item_free(old_it);
+        }
+    }
     /* Cache item replacement does not drop the prefix item even if it's empty.
      * So, the below do_item_link function always return SUCCESS.
      */
-    (void)do_item_link(new_it);
+    return ENGINE_SUCCESS;
 }
 
 /*

--- a/engines/default/prefix.c
+++ b/engines/default/prefix.c
@@ -245,6 +245,30 @@ ENGINE_ERROR_CODE prefix_link(hash_item *it, const uint32_t item_size, bool *int
     return ENGINE_SUCCESS;
 }
 
+void prefix_replace(hash_item* old_it, hash_item* new_it, const uint32_t old_item_size, const uint32_t new_item_size)
+{
+    prefix_t *pt = old_it->pfxptr;
+    new_it->pfxptr = old_it->pfxptr;
+    old_it->pfxptr = NULL;
+    assert(pt != NULL);
+
+    /* update prefix information */
+    int item_type = GET_ITEM_TYPE(old_it);
+    if (new_item_size != old_item_size) {
+        if (new_item_size > old_item_size) {
+            uint32_t item_size = new_item_size - old_item_size;
+            pt->items_bytes[item_type] += item_size;
+            pt->total_bytes_exclusive += item_size;
+        } else {
+            uint32_t item_size = old_item_size - new_item_size;
+            pt->items_bytes[item_type] -= item_size;
+            pt->total_bytes_exclusive -= item_size;
+        }
+    } else {
+       /* if they have the same item_size do nothing */
+    }
+}
+
 void prefix_unlink(hash_item *it, const uint32_t item_size, bool drop_if_empty)
 {
     prefix_t *pt = it->pfxptr;

--- a/engines/default/prefix.h
+++ b/engines/default/prefix.h
@@ -61,6 +61,7 @@ void              prefix_final(struct default_engine *engine);
 prefix_t *        prefix_find(const char *prefix, const int nprefix);
 ENGINE_ERROR_CODE prefix_link(hash_item *it, const uint32_t item_size, bool *internal);
 void              prefix_unlink(hash_item *it, const uint32_t item_size, bool drop_if_empty);
+void              prefix_replace(hash_item* old_it, hash_item* new_it, const uint32_t old_item_size, const uint32_t new_item_size);
 bool              prefix_issame(prefix_t *pt, const char *prefix, const int nprefix);
 void              prefix_bytes_incr(prefix_t *pt, ENGINE_ITEM_TYPE item_type, const uint32_t bytes);
 void              prefix_bytes_decr(prefix_t *pt, ENGINE_ITEM_TYPE item_type, const uint32_t bytes);


### PR DESCRIPTION
do_item_replace () 함수를 최적화 하였습니다.

BEFORE:
```
do_item_unlink(old_it)
       - unlink from LRU list
       - assoc_delete
       - prefix unlink
       - update stats
do_item_link(new_it)
       - set cas
       - prefix link
       - assoc_insert
       - link to LRU list
       - update stats
```

AFTER 
```
- replace items from the LRU list when in the same class 
- assoc_delete
- assoc_insert
- prefix_replace
- update stats when needed
```