### PR TITLE
ENHANCE: optimize do_item_replace()

### DIFF
--- a/engines/default/assoc.c
+++ b/engines/default/assoc.c
@@ -209,6 +209,21 @@ int assoc_insert(hash_item *it, uint32_t hash)
     return 1;
 }
 
+void assoc_replace(hash_item *old_it, hash_item *new_it)
+{
+    hash_item **before = _hashitem_before(item_get_key(old_it), old_it->nkey, old_it->khash);
+
+    /* The DTrace probe cannot be triggered as the last instruction
+     * due to possible tail-optimization by the compiler
+     */
+    MEMCACHED_ASSOC_DELETE(key, old_it->nkey, assocp->hash_items);
+    new_it->h_next = old_it->h_next;
+    *before = new_it;
+    (old_it)->h_next = NULL;
+
+    MEMCACHED_ASSOC_INSERT(item_get_key(new_it), new_it->nkey, assocp->hash_items);
+}
+
 void assoc_delete(const char *key, const uint32_t nkey, uint32_t hash)
 {
     hash_item **before = _hashitem_before(key, nkey, hash);

--- a/engines/default/assoc.h
+++ b/engines/default/assoc.h
@@ -62,6 +62,7 @@ void              assoc_final(struct default_engine *engine);
 
 hash_item *       assoc_find(const char *key, const uint32_t nkey, uint32_t hash);
 int               assoc_insert(hash_item *item, uint32_t hash);
+void              assoc_replace(hash_item *old_it, hash_item *new_it);
 void              assoc_delete(const char *key, const uint32_t nkey, uint32_t hash);
 
 /* assoc scan functions */

--- a/engines/default/items.c
+++ b/engines/default/items.c
@@ -1204,11 +1204,59 @@ static void do_item_replace(hash_item *old_it, hash_item *new_it)
 {
     MEMCACHED_ITEM_REPLACE(item_get_key(old_it), old_it->nkey, old_it->nbytes,
                            item_get_key(new_it), new_it->nkey, new_it->nbytes);
-    do_item_unlink(old_it, ITEM_UNLINK_REPLACE);
-    /* Cache item replacement does not drop the prefix item even if it's empty.
-     * So, the below do_item_link function always return SUCCESS.
-     */
-    (void)do_item_link(new_it);
+
+    assert((old_it->iflag & ITEM_LINKED) != 0);
+
+    CLOG_ITEM_UNLINK(old_it, ITEM_UNLINK_REPLACE);
+
+    /* unlink the item from LUR list */
+    item_unlink_q(old_it);
+
+    /* Allocate a new CAS ID on link. */
+    item_set_cas(new_it, get_cas_id());
+
+    /* link the item to the hash table */
+    new_it->iflag |= ITEM_LINKED;
+    new_it->time = svcore->get_current_time();
+    new_it->khash = old_it->khash;
+
+    /* replace the item from hash table */
+    assoc_replace(old_it, new_it);
+    old_it->iflag &= ~ITEM_LINKED;
+
+    /* update prefix information */
+    prefix_t *pt = old_it->pfxptr;
+    new_it->pfxptr = old_it->pfxptr;
+    old_it->pfxptr = NULL;
+    assert(pt != NULL);
+
+    /* if old_it->iflag has ITEM_INTERNAL */
+    if (old_it->iflag & ITEM_INTERNAL) {
+        new_it->iflag |= ITEM_INTERNAL;
+    }
+
+    /* update prefix info and stats */
+    do_item_stat_replace(old_it, new_it);
+
+    if (IS_COLL_ITEM(old_it)) {
+        /* IMPORTANT NOTE)
+         * The element space statistics has already been decreased.
+         * So, we must not decrease the space statistics any more
+         * even if the elements are freed later.
+         * For that purpose, we set info->stotal to 0 like below.
+         */
+        coll_meta_info *info = (coll_meta_info *)item_get_meta(old_it);
+        info->stotal = 0;
+    }
+
+    /* free the item if no one reference it */
+    if (old_it->refcount == 0) {
+        do_item_free(old_it);
+    }
+
+    /* link the item to LRU list */
+    item_link_q(new_it);
+    CLOG_ITEM_LINK(new_it);
 }
 
 /*

--- a/engines/default/prefix.c
+++ b/engines/default/prefix.c
@@ -300,7 +300,7 @@ bool prefix_issame(prefix_t *pt, const char *prefix, const int nprefix)
 void prefix_bytes_incr(prefix_t *pt, ENGINE_ITEM_TYPE item_type, const uint32_t bytes)
 {
     /* It's called when a collection element is inserted */
-    assert(item_type > ITEM_TYPE_KV && item_type < ITEM_TYPE_MAX);
+    assert(item_type < ITEM_TYPE_MAX);
 
     pt->items_bytes[item_type] += bytes;
     pt->total_bytes_exclusive += bytes;
@@ -318,7 +318,7 @@ void prefix_bytes_incr(prefix_t *pt, ENGINE_ITEM_TYPE item_type, const uint32_t 
 void prefix_bytes_decr(prefix_t *pt, ENGINE_ITEM_TYPE item_type, const uint32_t bytes)
 {
     /* It's called when a collection element is removed */
-    assert(item_type > ITEM_TYPE_KV && item_type < ITEM_TYPE_MAX);
+    assert(item_type < ITEM_TYPE_MAX);
 
     pt->items_bytes[item_type] -= bytes;
     pt->total_bytes_exclusive -= bytes;


### PR DESCRIPTION
do_item_replace() 함수를 최적화 하였습니다.

기존의 item_unlink(), item_link() 함수를 호출하는 방식에서
replace 함수 이름에 맞게 대체 해주는 방식으로 최적화 하였습니다.

 - assoc_replace() 함수 생성 및 대체하는 과정에서 일어나는 불필요한 코드 제거
 - prefix_replace() 함수 생성 및 대체하는 과정에서 일어나는 불필요한 코드 제거
 - do_item_stat_replace() 함수를 생성 및 stotal 변경 사항을 한번에 적용함으로써 최적화