### PR TITLE
[persistence] separate the cmdlogfile module from cmdlogbuf.c

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -153,6 +153,8 @@ default_engine_la_SOURCES= \
                     engines/default/cmdlogmgr.h \
                     engines/default/cmdlogbuf.c \
                     engines/default/cmdlogbuf.h \
+                    engines/default/cmdlogfile.c \
+                    engines/default/cmdlogfile.h \
                     engines/default/cmdlogrec.c \
                     engines/default/cmdlogrec.h
 default_engine_la_DEPENDENCIES= libmcd_util.la

--- a/engines/default/checkpoint.c
+++ b/engines/default/checkpoint.c
@@ -28,6 +28,7 @@
 #include "checkpoint.h"
 #include "mc_snapshot.h"
 #include "cmdlogbuf.h"
+#include "cmdlogfile.h"
 
 #define CHKPT_MAX_FILENAME_LENGTH  255
 #define CHKPT_FILE_NAME_FORMAT     "%s/%s%"PRId64
@@ -265,7 +266,7 @@ static bool do_checkpoint_needed(chkpt_st *cs)
 {
     struct engine_config *config = cs->config;
     size_t snapshot_file_size = cs->lastsize;
-    size_t cmdlog_file_size   = cmdlog_file_getsize();
+    size_t cmdlog_file_size   = cmdlog_get_file_size();
     size_t min_logsize        = config->chkpt_interval_min_logsize;
     int    pct_snapshot       = config->chkpt_interval_pct_snapshot;
 

--- a/engines/default/cmdlogbuf.c
+++ b/engines/default/cmdlogbuf.c
@@ -26,25 +26,14 @@
 #include "default_engine.h"
 #ifdef ENABLE_PERSISTENCE
 #include "cmdlogbuf.h"
+#include "cmdlogfile.h"
 
 /* FIXME: config log buffer size */
 #define CMDLOG_BUFFER_SIZE (100 * 1024 * 1024) /* 100 MB */
 #define CMDLOG_FLUSH_AUTO_SIZE (32 * 1024) /* 32 KB : see the nflush data type of log_FREQ */
 #define CMDLOG_RECORD_MIN_SIZE 16          /* 8 bytes header + 8 bytes body */
-#define CMDLOG_MAX_FILEPATH_LENGTH 255
 
 #define ENABLE_DEBUG 0
-
-/* log file structure */
-typedef struct _log_file {
-    char      path[CMDLOG_MAX_FILEPATH_LENGTH+1];
-    int       prev_fd;
-    int       fd;
-    int       next_fd;
-    size_t    size;
-    size_t    next_size;
-    bool      close_wait;
-} log_FILE;
 
 /* flush request structure */
 typedef struct _log_freq {
@@ -79,110 +68,22 @@ typedef struct _log_flusher {
     volatile bool    reqstop;
 } log_FLUSHER;
 
-/* log global structure */
-struct log_global {
-    log_FILE        log_file;
+/* log buffer global structure */
+struct log_buff_global {
     log_BUFFER      log_buffer;
     log_FLUSHER     log_flusher;
     LogSN           nxt_write_lsn;
     LogSN           nxt_flush_lsn;
-    LogSN           nxt_fsync_lsn;
     pthread_mutex_t log_write_lock;
-    pthread_mutex_t log_flush_lock;
-    pthread_mutex_t log_fsync_lock;
     pthread_mutex_t flush_lsn_lock;
-    pthread_mutex_t fsync_lsn_lock;
-    pthread_cond_t  log_flush_cond;
-    bool            async_mode;
     volatile bool   initialized;
 };
 
 /* global data */
 static EXTENSION_LOGGER_DESCRIPTOR* logger = NULL;
-static struct log_global log_gl;
-
-/*
- * Static Functions for DIsk IO
- * FIXME: These can be moved to a separate disk.c file later.
- */
-/***************/
-
-static int disk_open(const char *fname, int flags, int mode)
-{
-    int fd;
-    while (1) {
-        if ((fd = open(fname, flags, mode)) == -1) {
-            if (errno == EINTR) continue;
-        }
-        break;
-    }
-    return fd;
-}
-
-static off_t disk_lseek(int fd, off_t offset, int whence)
-{
-    off_t ret = lseek(fd, offset, whence);
-    return ret;
-}
-
-static ssize_t disk_read(int fd, void *buf, size_t count)
-{
-    char   *bfptr = (char*)buf;
-    ssize_t nleft = count;
-    ssize_t nread;
-
-    while (nleft > 0) {
-        nread = read(fd, bfptr, nleft);
-        if (nread == 0) break;
-        if (nread <  0) {
-            if (errno == EINTR) continue;
-            return nread;
-        }
-        nleft -= nread;
-        bfptr += nread;
-    }
-    return (count - nleft);
-}
-
-static ssize_t disk_write(int fd, void *buf, size_t count)
-{
-    char   *bfptr = (char*)buf;
-    ssize_t nleft = count;
-    ssize_t nwrite;
-
-    while (nleft > 0) {
-        nwrite = write(fd, bfptr, nleft);
-        if (nwrite == 0) break;
-        if (nwrite <  0) {
-            if (errno == EINTR) continue;
-            return nwrite;
-        }
-        nleft -= nwrite;
-        bfptr += nwrite;
-    }
-    return (count - nleft);
-}
-
-static int disk_fsync(int fd)
-{
-    if (fsync(fd) != 0) {
-        return -1;
-    }
-    return 0;
-}
-
-static int disk_close(int fd)
-{
-    while (1) {
-        if (close(fd) != 0) {
-            if (errno == EINTR) continue;
-            return -1;
-        }
-        break;
-    }
-    return 0;
-}
-/***************/
+static struct log_buff_global log_buff_gl;
+pthread_mutex_t log_flush_lock;
+pthread_cond_t  log_flush_cond;
 
 static void do_log_flusher_wakeup(log_FLUSHER *flusher)
 {
@@ -193,72 +94,15 @@ static void do_log_flusher_wakeup(log_FLUSHER *flusher)
     pthread_mutex_unlock(&flusher->lock);
 }
 
-static void do_log_file_close_waiter_wakeup(log_FILE *file)
-{
-    /* already locked with log_flush_lock */
-    if (file->close_wait) {
-        pthread_cond_signal(&log_gl.log_flush_cond);
-    }
-}
-
-static void do_log_file_write(char *log_ptr, uint32_t log_size, bool dual_write)
-{
-    log_FILE *logfile = &log_gl.log_file;
-    assert(logfile->fd != -1);
-
-    /* The log data is appended */
-    ssize_t nwrite = disk_write(logfile->fd, log_ptr, log_size);
-    if (nwrite != log_size) {
-        logger->log(EXTENSION_LOG_WARNING, NULL,
-                    "log file(%d) write - write(%ld!=%ld) error=(%d:%s)\n",
-                    logfile->fd, nwrite, (ssize_t)log_size,
-                    errno, strerror(errno));
-    }
-    /* FIXME::need error handling */
-    assert(nwrite == log_size);
-    logfile->size += log_size;
-
-    if (dual_write && logfile->next_fd != -1) {
-        /* next_fd is guaranteed concurrency by log_flush_lock */
-
-        /* The log data is appended */
-        nwrite = disk_write(logfile->next_fd, log_ptr, log_size);
-        if (nwrite != log_size) {
-            logger->log(EXTENSION_LOG_WARNING, NULL,
-                        "log file(%d) write - write(%ld!=%ld) error=(%d:%s)\n",
-                        logfile->next_fd, nwrite, (ssize_t)log_size,
-                        errno, strerror(errno));
-        }
-        /* FIXME::need error handling */
-        assert(nwrite == log_size);
-        logfile->next_size += log_size;
-    }
-}
-
-static void do_log_file_complete_dual_write(void)
-{
-    log_gl.log_file.prev_fd   = log_gl.log_file.fd;
-    log_gl.log_file.fd        = log_gl.log_file.next_fd;
-    log_gl.log_file.size      = log_gl.log_file.next_size;
-    log_gl.log_file.next_fd   = -1;
-    log_gl.log_file.next_size = 0;
-
-    if (log_gl.async_mode) {
-        (void)disk_close(log_gl.log_file.prev_fd);
-        log_gl.log_file.prev_fd = -1;
-        do_log_file_close_waiter_wakeup(&log_gl.log_file);
-    }
-}
-
 static uint32_t do_log_buff_flush(bool flush_all)
 {
-    log_BUFFER *logbuff = &log_gl.log_buffer;
+    log_BUFFER *logbuff = &log_buff_gl.log_buffer;
     uint32_t    nflush = 0;
     bool        dual_write_flag = false;
     bool        dual_write_complete_flag = false;
 
     /* computate flush size */
-    pthread_mutex_lock(&log_gl.log_write_lock);
+    pthread_mutex_lock(&log_buff_gl.log_write_lock);
     if (logbuff->fbgn == logbuff->dw_end) {
         logbuff->dw_end = -1;
         dual_write_complete_flag = true;
@@ -280,28 +124,27 @@ static uint32_t do_log_buff_flush(bool flush_all)
             logbuff->head = 0;
         }
     }
-    pthread_mutex_unlock(&log_gl.log_write_lock);
+    pthread_mutex_unlock(&log_buff_gl.log_write_lock);
 
     if (dual_write_complete_flag) {
-        if (log_gl.log_file.next_fd != -1) {
-            do_log_file_complete_dual_write();
-        }
-        pthread_mutex_lock(&log_gl.flush_lsn_lock);
-        log_gl.nxt_flush_lsn.filenum += 1;
-        log_gl.nxt_flush_lsn.roffset = 0;
-        pthread_mutex_unlock(&log_gl.flush_lsn_lock);
+        cmdlog_file_complete_dual_write();
+
+        pthread_mutex_lock(&log_buff_gl.flush_lsn_lock);
+        log_buff_gl.nxt_flush_lsn.filenum += 1;
+        log_buff_gl.nxt_flush_lsn.roffset = 0;
+        pthread_mutex_unlock(&log_buff_gl.flush_lsn_lock);
     }
 
     if (nflush > 0) {
-        do_log_file_write(&logbuff->data[logbuff->head], nflush, dual_write_flag);
+        cmdlog_file_write(&logbuff->data[logbuff->head], nflush, dual_write_flag);
 
         /* update nxt_flush_lsn */
-        pthread_mutex_lock(&log_gl.flush_lsn_lock);
-        log_gl.nxt_flush_lsn.roffset += nflush;
-        pthread_mutex_unlock(&log_gl.flush_lsn_lock);
+        pthread_mutex_lock(&log_buff_gl.flush_lsn_lock);
+        log_buff_gl.nxt_flush_lsn.roffset += nflush;
+        pthread_mutex_unlock(&log_buff_gl.flush_lsn_lock);
 
         /* update next flush position */
-        pthread_mutex_lock(&log_gl.log_write_lock);
+        pthread_mutex_lock(&log_buff_gl.log_write_lock);
         logbuff->head += nflush;
         if (logbuff->head == logbuff->last) {
             logbuff->last = -1;
@@ -311,20 +154,20 @@ static uint32_t do_log_buff_flush(bool flush_all)
         logbuff->fque[logbuff->fbgn].nflush = 0;
         logbuff->fque[logbuff->fbgn].dual_write = false;
         if ((++logbuff->fbgn) == logbuff->fqsz) logbuff->fbgn = 0;
-        pthread_mutex_unlock(&log_gl.log_write_lock);
+        pthread_mutex_unlock(&log_buff_gl.log_write_lock);
     }
     return nflush;
 }
 
 static LogSN do_log_buff_write(LogRec *logrec, bool dual_write)
 {
-    log_BUFFER *logbuff = &log_gl.log_buffer;
+    log_BUFFER *logbuff = &log_buff_gl.log_buffer;
     LogSN current_lsn;
     uint32_t total_length = sizeof(LogHdr) + logrec->header.body_length;
     uint32_t spare_length;
     assert(total_length < logbuff->size);
 
-    pthread_mutex_lock(&log_gl.log_write_lock);
+    pthread_mutex_lock(&log_buff_gl.log_write_lock);
 
     /* find the positon to write in log buffer */
     while (1) {
@@ -354,11 +197,11 @@ static LogSN do_log_buff_write(LogRec *logrec, bool dual_write)
             }
         }
         /* Lack of log buffer space: force flushing data on log buffer */
-        pthread_mutex_unlock(&log_gl.log_write_lock);
-        pthread_mutex_lock(&log_gl.log_flush_lock);
+        pthread_mutex_unlock(&log_buff_gl.log_write_lock);
+        pthread_mutex_lock(&log_flush_lock);
         (void)do_log_buff_flush(false);
-        pthread_mutex_unlock(&log_gl.log_flush_lock);
-        pthread_mutex_lock(&log_gl.log_write_lock);
+        pthread_mutex_unlock(&log_flush_lock);
+        pthread_mutex_lock(&log_buff_gl.log_write_lock);
     }
 
     /* write log record at the found location of log buffer */
@@ -366,8 +209,8 @@ static LogSN do_log_buff_write(LogRec *logrec, bool dual_write)
     logbuff->tail += total_length;
 
     /* update nxt_write_lsn */
-    current_lsn = log_gl.nxt_write_lsn;
-    log_gl.nxt_write_lsn.roffset += total_length;
+    current_lsn = log_buff_gl.nxt_write_lsn;
+    log_buff_gl.nxt_write_lsn.roffset += total_length;
 
     /* update log flush request */
     if (logbuff->fque[logbuff->fend].nflush > 0 &&
@@ -387,12 +230,12 @@ static LogSN do_log_buff_write(LogRec *logrec, bool dual_write)
         total_length -= spare_length;
     }
 
-    pthread_mutex_unlock(&log_gl.log_write_lock);
+    pthread_mutex_unlock(&log_buff_gl.log_write_lock);
 
     /* wake up log flush thread if flush requests exist */
     if (logbuff->fbgn != logbuff->fend) {
-        if (log_gl.log_flusher.sleep == true) {
-            do_log_flusher_wakeup(&log_gl.log_flusher);
+        if (log_buff_gl.log_flusher.sleep == true) {
+            do_log_flusher_wakeup(&log_buff_gl.log_flusher);
         }
     }
     return current_lsn;
@@ -400,9 +243,9 @@ static LogSN do_log_buff_write(LogRec *logrec, bool dual_write)
 
 static void do_log_buff_complete_dual_write(bool success)
 {
-    log_BUFFER *logbuff = &log_gl.log_buffer;
+    log_BUFFER *logbuff = &log_buff_gl.log_buffer;
 
-    pthread_mutex_lock(&log_gl.log_write_lock);
+    pthread_mutex_lock(&log_buff_gl.log_write_lock);
     if (success) {
         if (logbuff->fque[logbuff->fend].nflush > 0) {
             if ((++logbuff->fend) == logbuff->fqsz) logbuff->fend = 0;
@@ -412,8 +255,8 @@ static void do_log_buff_complete_dual_write(bool success)
         logbuff->dw_end = logbuff->fend;
 
         /* update nxt_write_lsn */
-        log_gl.nxt_write_lsn.filenum += 1;
-        log_gl.nxt_write_lsn.roffset = 0;
+        log_buff_gl.nxt_write_lsn.filenum += 1;
+        log_buff_gl.nxt_write_lsn.roffset = 0;
     } else {
         /* reset dual_write flag in flush reqeust queue */
         int index = logbuff->fbgn;
@@ -425,13 +268,13 @@ static void do_log_buff_complete_dual_write(bool success)
             if (index == logbuff->fbgn) break;
         }
     }
-    pthread_mutex_unlock(&log_gl.log_write_lock);
+    pthread_mutex_unlock(&log_buff_gl.log_write_lock);
 }
 
 /* Log Flush Thread */
 static void *log_flush_thread_main(void *arg)
 {
-    log_FLUSHER *flusher = &log_gl.log_flusher;
+    log_FLUSHER *flusher = &log_buff_gl.log_flusher;
     struct timeval  tv;
     struct timespec to;
     uint32_t nflush;
@@ -444,9 +287,9 @@ static void *log_flush_thread_main(void *arg)
             break;
         }
 
-        pthread_mutex_lock(&log_gl.log_flush_lock);
+        pthread_mutex_lock(&log_flush_lock);
         nflush = do_log_buff_flush(false);
-        pthread_mutex_unlock(&log_gl.log_flush_lock);
+        pthread_mutex_unlock(&log_flush_lock);
 
         if (nflush == 0) {
             /* nothing to flush: do 10 ms sleep */
@@ -488,448 +331,84 @@ void cmdlog_buff_flush(LogSN *upto_lsn)
     uint32_t nflush;
 
     do {
-        pthread_mutex_lock(&log_gl.log_flush_lock);
-        if (LOGSN_IS_LE(&log_gl.nxt_flush_lsn, upto_lsn)) {
+        pthread_mutex_lock(&log_flush_lock);
+        if (LOGSN_IS_LE(&log_buff_gl.nxt_flush_lsn, upto_lsn)) {
             nflush = do_log_buff_flush(true);
             assert(nflush > 0);
-            if (LOGSN_IS_GT(&log_gl.nxt_flush_lsn, upto_lsn)) {
+            if (LOGSN_IS_GT(&log_buff_gl.nxt_flush_lsn, upto_lsn)) {
                 nflush = 0;
             }
         } else {
             nflush = 0;
         }
-        pthread_mutex_unlock(&log_gl.log_flush_lock);
+        pthread_mutex_unlock(&log_flush_lock);
     } while (nflush > 0);
-}
-
-void cmdlog_file_sync(void)
-{
-    LogSN now_flush_lsn;
-    log_FILE *logfile = &log_gl.log_file;
-    int fd;
-    int prev_fd = -1;
-    int next_fd = -1;
-    int ret;
-
-    pthread_mutex_lock(&log_gl.log_fsync_lock);
-
-    /* get current fd info */
-    pthread_mutex_lock(&log_gl.log_flush_lock);
-    now_flush_lsn = log_gl.nxt_flush_lsn;
-    if (logfile->prev_fd != -1) {
-        prev_fd = logfile->prev_fd;
-    }
-    fd = logfile->fd;
-    if (logfile->next_fd != -1 && logfile->next_size > 0) {
-        next_fd = logfile->next_fd;
-    }
-    pthread_mutex_unlock(&log_gl.log_flush_lock);
-
-    if (prev_fd != -1) {
-        /* If prev_fd is set, the prev file access only the log sync thread,
-         * so log_fsync_lock is not needed to close the prev file.
-         */
-        ret = disk_fsync(prev_fd);
-        (void)disk_close(prev_fd);
-
-        pthread_mutex_lock(&log_gl.log_flush_lock);
-        logfile->prev_fd = -1;
-        do_log_file_close_waiter_wakeup(&log_gl.log_file);
-        pthread_mutex_unlock(&log_gl.log_flush_lock);
-    }
-
-    if (LOGSN_IS_GT(&now_flush_lsn, &log_gl.nxt_fsync_lsn)) {
-        do {
-            /* fsync curr fd */
-            ret = disk_fsync(fd);
-            if (ret < 0) {
-                logger->log(EXTENSION_LOG_WARNING, NULL,
-                            "log file fsync error (%d:%s)\n",
-                            errno, strerror(errno));
-                if (log_gl.async_mode == false) {
-                    /* [FATAL] untreatable error => abnormal shutdown by assertion */
-                    assert(ret == 0);
-                }
-                break;
-            }
-
-            if (next_fd != -1 && logfile->next_fd != -1) {
-                ret = disk_fsync(next_fd);
-                if (ret < 0) {
-                    logger->log(EXTENSION_LOG_WARNING, NULL,
-                                "log file fsync error (%d:%s)\n",
-                                errno, strerror(errno));
-                    break;
-                }
-            }
-
-            /* update nxt_fsync_lsn */
-            pthread_mutex_lock(&log_gl.fsync_lsn_lock);
-            log_gl.nxt_fsync_lsn = now_flush_lsn;
-            pthread_mutex_unlock(&log_gl.fsync_lsn_lock);
-        } while(0);
-    }
-    pthread_mutex_unlock(&log_gl.log_fsync_lock);
 }
 
 /* FIXME: remove later, if not used */
 /*
 void log_get_write_lsn(LogSN *lsn)
 {
-    pthread_mutex_lock(&log_gl.log_write_lock);
-    *lsn = log_gl.nxt_write_lsn;
-    pthread_mutex_unlock(&log_gl.log_write_lock);
+    pthread_mutex_lock(&log_buff_gl.log_write_lock);
+    *lsn = log_buff_gl.nxt_write_lsn;
+    pthread_mutex_unlock(&log_buff_gl.log_write_lock);
 }
 */
 
 void cmdlog_get_flush_lsn(LogSN *lsn)
 {
-    pthread_mutex_lock(&log_gl.flush_lsn_lock);
-    *lsn = log_gl.nxt_flush_lsn;
-    pthread_mutex_unlock(&log_gl.flush_lsn_lock);
+    pthread_mutex_lock(&log_buff_gl.flush_lsn_lock);
+    *lsn = log_buff_gl.nxt_flush_lsn;
+    pthread_mutex_unlock(&log_buff_gl.flush_lsn_lock);
 }
 
-void cmdlog_get_fsync_lsn(LogSN *lsn)
+size_t cmdlog_get_file_size(void)
 {
-    pthread_mutex_lock(&log_gl.fsync_lsn_lock);
-    *lsn = log_gl.nxt_fsync_lsn;
-    pthread_mutex_unlock(&log_gl.fsync_lsn_lock);
-}
-
-void cmdlog_complete_dual_write(bool success)
-{
-    pthread_mutex_lock(&log_gl.log_flush_lock);
-    if (log_gl.log_file.next_fd != -1) {
-        do_log_buff_complete_dual_write(success);
-    }
-    pthread_mutex_unlock(&log_gl.log_flush_lock);
-}
-
-int cmdlog_file_open(char *path)
-{
-    log_FILE *logfile = &log_gl.log_file;
-    int ret = 0;
-
-    pthread_mutex_lock(&log_gl.log_flush_lock);
-    /* prepare cmdlog file */
-    do {
-        int fd = disk_open(path, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR | S_IRGRP);
-        if (fd < 0) {
-            logger->log(EXTENSION_LOG_WARNING, NULL,
-                        "Failed to open the cmdlog file. path=%s err=%s\n",
-                        logfile->path, strerror(errno));
-            ret = -1;
-            break;
-        }
-        snprintf(logfile->path, CMDLOG_MAX_FILEPATH_LENGTH, "%s", path);
-        if (logfile->fd == -1) {
-            logfile->fd = fd;
-        } else {
-            /* fd != -1 means that a new cmdlog file is created by checkpoint */
-            logfile->next_fd = fd;
-        }
-    } while(0);
-    pthread_mutex_unlock(&log_gl.log_flush_lock);
-
-    return ret;
-}
-
-void cmdlog_file_close(bool chkpt_success)
-{
-    log_FILE *logfile = &log_gl.log_file;
-    int remove_fd = -1;
-
-    pthread_mutex_lock(&log_gl.log_flush_lock);
-    if (chkpt_success) {
-        /* wait until the previous file is closed */
-        while (logfile->next_fd != -1 || logfile->prev_fd != -1) {
-            logfile->close_wait = true;
-            pthread_cond_wait(&log_gl.log_flush_cond, &log_gl.log_flush_lock);
-            logfile->close_wait = false;
-        }
-    } else {
-        if (logfile->next_fd != -1) {
-            logfile->next_size = 0; /* prevent fsync() */
-            if (log_gl.async_mode) {
-                remove_fd = logfile->next_fd;
-                logfile->next_fd = -1;
-            }
-        } else { /* the first checkpoint */
-            assert(logfile->fd != -1);
-            remove_fd = logfile->fd;
-            logfile->fd = -1;
-        }
-    }
-    pthread_mutex_unlock(&log_gl.log_flush_lock);
-
-    if (logfile->next_fd != -1) {
-        /* only in sync mode and checkpoint failure */
-        pthread_mutex_lock(&log_gl.log_fsync_lock);
-        pthread_mutex_lock(&log_gl.log_flush_lock);
-        remove_fd = logfile->next_fd;
-        logfile->next_fd = -1;
-        pthread_mutex_unlock(&log_gl.log_flush_lock);
-        pthread_mutex_unlock(&log_gl.log_fsync_lock);
-    }
-    if (remove_fd != -1) {
-        (void)disk_close(remove_fd);
-    }
-}
-
-void cmdlog_file_init(void)
-{
-    log_FILE *logfile  = &log_gl.log_file;
-    logfile->path[0]   = '\0';
-    logfile->prev_fd   = -1;
-    logfile->fd        = -1;
-    logfile->next_fd   = -1;
-    logfile->size      = 0;
-    logfile->next_size = 0;
-    logfile->close_wait = false;
-    logger->log(EXTENSION_LOG_INFO, NULL, "CMDLOG FILE module initialized.\n");
-}
-
-void cmdlog_file_final(void)
-{
-     log_FILE *logfile = &log_gl.log_file;
-
-     /* Don't need to hold log_fsync_lock because this function is called
-      * after stopping cmdlog thread. See cmdlog_mgr_final().
-      */
-     if (logfile->fd != -1) {
-         (void)disk_fsync(logfile->fd);
-         (void)disk_close(logfile->fd);
-         logfile->fd = -1;
-     }
-     if (logfile->next_fd != -1) {
-         (void)disk_close(logfile->next_fd);
-         logfile->next_fd = -1;
-     }
-}
-
-size_t cmdlog_file_getsize(void)
-{
-    log_FILE *logfile = &log_gl.log_file;
     size_t file_size = 0;
 
-    pthread_mutex_lock(&log_gl.log_flush_lock);
-    pthread_mutex_lock(&log_gl.log_write_lock);
-    if (log_gl.log_buffer.dw_end == -1) {
-        file_size = logfile->size;
+    pthread_mutex_lock(&log_flush_lock);
+    pthread_mutex_lock(&log_buff_gl.log_write_lock);
+    if (log_buff_gl.log_buffer.dw_end == -1) {
+        file_size = cmdlog_get_current_file_size();
     }
-    pthread_mutex_unlock(&log_gl.log_write_lock);
-    pthread_mutex_unlock(&log_gl.log_flush_lock);
+    pthread_mutex_unlock(&log_buff_gl.log_write_lock);
+    pthread_mutex_unlock(&log_flush_lock);
 
     return file_size;
 }
 
-static int do_redo_pending_lrec(int fd, int start_offset, int end_offset)
+void cmdlog_complete_dual_write(bool success)
 {
-    char buf[MAX_LOG_RECORD_SIZE];
-    LogRec *logrec = (LogRec*)buf;
-    LogHdr *loghdr = &logrec->header;
-
-    int ret = 0;
-    ssize_t nread = 0;
-    int redo_offset = lseek(fd, (start_offset - end_offset), SEEK_CUR);
-    while (redo_offset < end_offset) {
-        nread = disk_read(fd, loghdr, sizeof(LogHdr));
-        if (nread != sizeof(LogHdr)) {
-            logger->log(EXTENSION_LOG_WARNING, NULL,
-                        "[RECOVERY - CMDLOG] failed : read header data "
-                        "nread(%zd) != header_length(%lu).\n", nread, sizeof(LogHdr));
-            ret = -1; break;
-        }
-        redo_offset += nread;
-        if (loghdr->body_length > 0) {
-            logrec->body = buf + nread;
-            nread = disk_read(fd, logrec->body, loghdr->body_length);
-            if (nread != loghdr->body_length) {
-                logger->log(EXTENSION_LOG_WARNING, NULL,
-                            "[RECOVERY - CMDLOG] failed : read body data "
-                            "nread(%zd) != body_length(%u).\n", nread, loghdr->body_length);
-                ret = -1; break;
-            }
-            redo_offset += nread;
-            ENGINE_ERROR_CODE err = lrec_redo_from_record(logrec);
-            if (err != ENGINE_SUCCESS) {
-                logger->log(EXTENSION_LOG_WARNING, NULL,
-                            "[RECOVERY - CMDLOG] warning : log record redo failed.\n");
-                if (err == ENGINE_ENOMEM) {
-                    logger->log(EXTENSION_LOG_WARNING, NULL,
-                                "[RECOVERY - CMDLOG] failed : out of memory.\n");
-                    ret = -1; break;
-                }
-            }
-        }
+    pthread_mutex_lock(&log_flush_lock);
+    if (cmdlog_get_next_fd() != -1) {
+        do_log_buff_complete_dual_write(success);
     }
-    return ret;
-}
-
-int cmdlog_file_apply(void)
-{
-    log_FILE *logfile = &log_gl.log_file;
-    assert(logfile->fd > 0);
-
-    logger->log(EXTENSION_LOG_INFO, NULL,
-                "[RECOVERY - CMDLOG] applying command log file. path=%s\n", logfile->path);
-
-    struct stat file_stat;
-    fstat(logfile->fd, &file_stat);
-    logfile->size = file_stat.st_size;
-    if (logfile->size == 0) {
-        logger->log(EXTENSION_LOG_INFO, NULL,
-                    "[RECOVERY - CMDLOG] log file is empty.\n");
-        return 0;
-    }
-
-    int  ret = 0;
-    int  seek_offset = 0;
-    int  pending_start_offset = 0;
-    int  pending_end_offset = 0;
-    bool pending = false;
-    char buf[MAX_LOG_RECORD_SIZE];
-    LogRec *logrec = (LogRec*)buf;
-    LogHdr *loghdr = &logrec->header;
-
-    while (log_gl.initialized && seek_offset < logfile->size) {
-
-        /* read header */
-        if (logfile->size - seek_offset < sizeof(LogHdr)) {
-            logger->log(EXTENSION_LOG_INFO, NULL,
-                        "[RECOVERY - CMDLOG] header of last log record was not completely written. "
-                        "header_length=%ld\n", sizeof(LogHdr));
-            break;
-        }
-
-        ssize_t nread = disk_read(logfile->fd, loghdr, sizeof(LogHdr));
-        if (nread != sizeof(LogHdr)) {
-            logger->log(EXTENSION_LOG_WARNING, NULL,
-                        "[RECOVERY - CMDLOG] failed : read header data "
-                        "nread(%zd) != header_length(%lu).\n", nread, sizeof(LogHdr));
-            ret = -1; break;
-        }
-        seek_offset += nread;
-
-        if (loghdr->logtype == LOG_OPERATION_BEGIN) {
-            if (pending == true) {
-                logger->log(EXTENSION_LOG_WARNING, NULL,
-                            "[RECOVERY - CMDLOG] failed : LOG_OPERATION_BEGIN recorded "
-                            "before previous kept log record is processed.\n");
-                ret = -1; break;
-            }
-            pending_start_offset = seek_offset;
-            pending = true;
-            continue;
-        }
-
-        if (loghdr->logtype == LOG_OPERATION_END) {
-            if (pending == false) {
-                logger->log(EXTENSION_LOG_WARNING, NULL,
-                            "[RECOVERY - CMDLOG] failed : "
-                            "LOG_OPERATION_END recorded without LOG_OPERATION_BEGIN.\n");
-                ret = -1; break;
-            }
-            /* redo pending normal log records */
-            pending_end_offset = seek_offset;
-            if (do_redo_pending_lrec(logfile->fd, pending_start_offset, pending_end_offset) < 0) {
-                logger->log(EXTENSION_LOG_WARNING, NULL,
-                            "[RECOVERY - CMDLOG] failed : pending log record redo failed\n");
-                ret = -1; break;
-            }
-
-            /* Complete redo of pending log records. cleanup pending info */
-            pending_start_offset = 0;
-            pending_end_offset = 0;
-            pending = false;
-            continue;
-        }
-
-        /* read body */
-        if (loghdr->body_length > 0) {
-            if (logfile->size - seek_offset < loghdr->body_length) {
-                logger->log(EXTENSION_LOG_INFO, NULL,
-                            "[RECOVERY - CMDLOG] body of last log record was not completely written. "
-                            "body_length=%d\n", loghdr->body_length);
-                seek_offset = disk_lseek(logfile->fd, -sizeof(LogHdr), SEEK_CUR);
-                if (seek_offset < 0) {
-                    logger->log(EXTENSION_LOG_WARNING, NULL,
-                                "[RECOVERY - CMDLOG] failed : lseek(SEEK_CUR-%zd). path=%s, error=%s.\n",
-                                sizeof(LogHdr), logfile->path, strerror(errno));
-                    ret = -1;
-                }
-                break;
-            }
-
-            int max_body_length = MAX_LOG_RECORD_SIZE - sizeof(LogHdr);
-            if (max_body_length < loghdr->body_length) {
-                logger->log(EXTENSION_LOG_WARNING, NULL,
-                            "[RECOVERY - CMDLOG] failed : body length is abnormally too big "
-                            "max_body_length(%d) < body_length(%u).\n",
-                            max_body_length, loghdr->body_length);
-                ret = -1; break;
-            }
-            logrec->body = buf + sizeof(LogHdr);
-            nread = disk_read(logfile->fd, logrec->body, loghdr->body_length);
-            if (nread != loghdr->body_length) {
-                logger->log(EXTENSION_LOG_WARNING, NULL,
-                            "[RECOVERY - CMDLOG] failed : read body data "
-                            "nread(%zd) != body_length(%u).\n", nread, loghdr->body_length);
-                ret = -1; break;
-            }
-            seek_offset += loghdr->body_length;
-        }
-
-        if (pending) continue;
-
-        /* redo log record */
-        ENGINE_ERROR_CODE err = lrec_redo_from_record(logrec);
-        if (err != ENGINE_SUCCESS) {
-            /* don't care a log record redo failure. read next log record and redo it. */
-            logger->log(EXTENSION_LOG_WARNING, NULL,
-                        "[RECOVERY - CMDLOG] warning : log record redo failed.\n");
-            if (err == ENGINE_ENOMEM) {
-                logger->log(EXTENSION_LOG_WARNING, NULL,
-                            "[RECOVERY - CMDLOG] failed : out of memory.\n");
-                ret = -1; break;
-            }
-        }
-    }
-    if (ret < 0) {
-        close(logfile->fd);
-    } else {
-        logfile->size = seek_offset;
-        logger->log(EXTENSION_LOG_INFO, NULL, "[RECOVERY - CMDLOG] success.\n");
-    }
-    return ret;
+    pthread_mutex_unlock(&log_flush_lock);
 }
 
 ENGINE_ERROR_CODE cmdlog_buf_init(struct default_engine* engine)
 {
     logger = engine->server.log->get_logger();
 
-    memset(&log_gl, 0, sizeof(log_gl));
+    memset(&log_buff_gl, 0, sizeof(log_buff_gl));
+
+    /* log buff global init */
+    log_buff_gl.nxt_flush_lsn.filenum = 1;
+    log_buff_gl.nxt_flush_lsn.roffset = 0;
+    log_buff_gl.nxt_write_lsn = log_buff_gl.nxt_flush_lsn;
+
+    pthread_mutex_init(&log_buff_gl.log_write_lock, NULL);
+    pthread_mutex_init(&log_buff_gl.flush_lsn_lock, NULL);
 
     /* log global init */
-    log_gl.async_mode = engine->config.async_logging;
-
-    log_gl.nxt_fsync_lsn.filenum = 1;
-    log_gl.nxt_fsync_lsn.roffset = 0;
-    log_gl.nxt_flush_lsn = log_gl.nxt_fsync_lsn;
-    log_gl.nxt_write_lsn = log_gl.nxt_fsync_lsn;
-
-    pthread_mutex_init(&log_gl.log_write_lock, NULL);
-    pthread_mutex_init(&log_gl.log_flush_lock, NULL);
-    pthread_mutex_init(&log_gl.log_fsync_lock, NULL);
-    pthread_mutex_init(&log_gl.flush_lsn_lock, NULL);
-    pthread_mutex_init(&log_gl.fsync_lsn_lock, NULL);
-    pthread_cond_init(&log_gl.log_flush_cond, NULL);
+    pthread_mutex_init(&log_flush_lock, NULL);
+    pthread_cond_init(&log_flush_cond, NULL);
 
     /* log file init */
-    cmdlog_file_init();
+    cmdlog_file_init(engine);
 
     /* log buffer init */
-    log_BUFFER *logbuff = &log_gl.log_buffer;
+    log_BUFFER *logbuff = &log_buff_gl.log_buffer;
 
     logbuff->size = CMDLOG_BUFFER_SIZE;
     logbuff->data = malloc(logbuff->size);
@@ -953,14 +432,14 @@ ENGINE_ERROR_CODE cmdlog_buf_init(struct default_engine* engine)
     logbuff->dw_end = -1;
 
     /* log flush thread init */
-    log_FLUSHER *flusher = &log_gl.log_flusher;
+    log_FLUSHER *flusher = &log_buff_gl.log_flusher;
     pthread_mutex_init(&flusher->lock, NULL);
     pthread_cond_init(&flusher->cond, NULL);
     flusher->sleep = false;
     flusher->running = RUNNING_UNSTARTED;
     flusher->reqstop = false;
 
-    log_gl.initialized = true;
+    log_buff_gl.initialized = true;
     logger->log(EXTENSION_LOG_INFO, NULL, "CMDLOG BUFFER module initialized.\n");
 
     return ENGINE_SUCCESS;
@@ -968,12 +447,12 @@ ENGINE_ERROR_CODE cmdlog_buf_init(struct default_engine* engine)
 
 void cmdlog_buf_final(void)
 {
-    if (log_gl.initialized == false) {
+    if (log_buff_gl.initialized == false) {
         return;
     }
 
     /* log buffer final */
-    log_BUFFER *logbuff = &log_gl.log_buffer;
+    log_BUFFER *logbuff = &log_buff_gl.log_buffer;
 
     if (logbuff->data != NULL) {
         free((void*)logbuff->data);
@@ -988,19 +467,24 @@ void cmdlog_buf_final(void)
     /* log file final */
     cmdlog_file_final();
 
-    pthread_mutex_destroy(&log_gl.log_write_lock);
-    pthread_mutex_destroy(&log_gl.log_flush_lock);
-    pthread_mutex_destroy(&log_gl.flush_lsn_lock);
-    log_gl.initialized = false;
+    /* log global final */
+    pthread_mutex_destroy(&log_flush_lock);
+    pthread_cond_destroy(&log_flush_cond);
+
+    /* log buff global final */
+    pthread_mutex_destroy(&log_buff_gl.log_write_lock);
+    pthread_mutex_destroy(&log_buff_gl.flush_lsn_lock);
+
+    log_buff_gl.initialized = false;
     logger->log(EXTENSION_LOG_INFO, NULL, "CMDLOG BUFFER module destroyed.\n");
 }
 
 ENGINE_ERROR_CODE cmdlog_buf_flush_thread_start(void)
 {
-    assert(log_gl.initialized == true);
+    assert(log_buff_gl.initialized == true);
 
     pthread_t tid;
-    log_gl.log_flusher.running = RUNNING_UNSTARTED;
+    log_buff_gl.log_flusher.running = RUNNING_UNSTARTED;
     /* create log flush thread */
     if (pthread_create(&tid, NULL, log_flush_thread_main, NULL) != 0) {
         logger->log(EXTENSION_LOG_WARNING, NULL,
@@ -1009,7 +493,7 @@ ENGINE_ERROR_CODE cmdlog_buf_flush_thread_start(void)
     }
 
     /* wait until log flush thread starts */
-    while (log_gl.log_flusher.running == RUNNING_UNSTARTED) {
+    while (log_buff_gl.log_flusher.running == RUNNING_UNSTARTED) {
         usleep(5000); /* sleep 5ms */
     }
     logger->log(EXTENSION_LOG_INFO, NULL, "Command log flush thread started.\n");
@@ -1019,7 +503,7 @@ ENGINE_ERROR_CODE cmdlog_buf_flush_thread_start(void)
 
 void cmdlog_buf_flush_thread_stop(void)
 {
-    log_FLUSHER *flusher = &log_gl.log_flusher;
+    log_FLUSHER *flusher = &log_buff_gl.log_flusher;
     if (flusher->running == RUNNING_UNSTARTED) {
         return;
     }

--- a/engines/default/cmdlogbuf.h
+++ b/engines/default/cmdlogbuf.h
@@ -21,22 +21,19 @@
 #include "cmdlogmgr.h"
 #include "cmdlogrec.h"
 
-/* external log functions */
+/* global log flush mutex */
+extern pthread_mutex_t log_flush_lock;
+extern pthread_cond_t  log_flush_cond;
+
+/* external log buffer functions */
 void cmdlog_buff_write(LogRec *logrec, log_waiter_t *waiter, bool dual_write);
 void cmdlog_buff_flush(LogSN *upto_lsn);
-void cmdlog_file_sync(void);
 
 /* FIXME: remove later, if not used */
 //void log_get_write_lsn(LogSN *lsn);
-void cmdlog_get_flush_lsn(LogSN *lsn);
-void cmdlog_get_fsync_lsn(LogSN *lsn);
+void   cmdlog_get_flush_lsn(LogSN *lsn);
+size_t cmdlog_get_file_size(void);
 
-int               cmdlog_file_open(char *path);
-size_t            cmdlog_file_getsize(void);
-void              cmdlog_file_close(bool chkpt_success);
-void              cmdlog_file_init(void);
-void              cmdlog_file_final(void);
-int               cmdlog_file_apply(void);
 void              cmdlog_complete_dual_write(bool success);
 ENGINE_ERROR_CODE cmdlog_buf_init(struct default_engine *engine);
 void              cmdlog_buf_final(void);

--- a/engines/default/cmdlogfile.c
+++ b/engines/default/cmdlogfile.c
@@ -1,0 +1,602 @@
+/* -*- Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ * arcus-memcached - Arcus memory cache server
+ * Copyright 2019 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/time.h>
+
+#include "default_engine.h"
+#ifdef ENABLE_PERSISTENCE
+#include "cmdlogfile.h"
+#include "cmdlogrec.h"
+#include "cmdlogbuf.h"
+
+#define CMDLOG_MAX_FILEPATH_LENGTH 255
+
+#define ENABLE_DEBUG 0
+
+/* log file structure */
+typedef struct _log_file {
+    char      path[CMDLOG_MAX_FILEPATH_LENGTH+1];
+    int       prev_fd;
+    int       fd;
+    int       next_fd;
+    size_t    size;
+    size_t    next_size;
+    bool      close_wait;
+} log_FILE;
+
+/* log file global structure */
+struct log_file_global {
+    log_FILE        log_file;
+    LogSN           nxt_fsync_lsn;
+    pthread_mutex_t log_fsync_lock;
+    pthread_mutex_t fsync_lsn_lock;
+    bool            async_mode;
+    volatile bool   initialized;
+};
+
+/* global data */
+static EXTENSION_LOGGER_DESCRIPTOR* logger = NULL;
+static struct log_file_global log_file_gl;
+
+/*
+ * Static Functions for DIsk IO
+ * FIXME: These can be moved to a separate disk.c file later.
+ */
+/***************/
+
+static int disk_open(const char *fname, int flags, int mode)
+{
+    int fd;
+    while (1) {
+        if ((fd = open(fname, flags, mode)) == -1) {
+            if (errno == EINTR) continue;
+        }
+        break;
+    }
+    return fd;
+}
+
+static off_t disk_lseek(int fd, off_t offset, int whence)
+{
+    off_t ret = lseek(fd, offset, whence);
+    return ret;
+}
+
+static ssize_t disk_read(int fd, void *buf, size_t count)
+{
+    char   *bfptr = (char*)buf;
+    ssize_t nleft = count;
+    ssize_t nread;
+
+    while (nleft > 0) {
+        nread = read(fd, bfptr, nleft);
+        if (nread == 0) break;
+        if (nread <  0) {
+            if (errno == EINTR) continue;
+            return nread;
+        }
+        nleft -= nread;
+        bfptr += nread;
+    }
+    return (count - nleft);
+}
+
+static ssize_t disk_write(int fd, void *buf, size_t count)
+{
+    char   *bfptr = (char*)buf;
+    ssize_t nleft = count;
+    ssize_t nwrite;
+
+    while (nleft > 0) {
+        nwrite = write(fd, bfptr, nleft);
+        if (nwrite == 0) break;
+        if (nwrite <  0) {
+            if (errno == EINTR) continue;
+            return nwrite;
+        }
+        nleft -= nwrite;
+        bfptr += nwrite;
+    }
+    return (count - nleft);
+}
+
+static int disk_fsync(int fd)
+{
+    if (fsync(fd) != 0) {
+        return -1;
+    }
+    return 0;
+}
+
+static int disk_close(int fd)
+{
+    while (1) {
+        if (close(fd) != 0) {
+            if (errno == EINTR) continue;
+            return -1;
+        }
+        break;
+    }
+    return 0;
+}
+/***************/
+
+static void do_log_file_close_waiter_wakeup(void)
+{
+    log_FILE *logfile = &log_file_gl.log_file;
+    /* already locked with log_flush_lock */
+    if (logfile->close_wait) {
+        pthread_cond_signal(&log_flush_cond);
+    }
+}
+
+void cmdlog_file_write(char *log_ptr, uint32_t log_size, bool dual_write)
+{
+    log_FILE *logfile = &log_file_gl.log_file;
+    assert(logfile->fd != -1);
+
+    /* The log data is appended */
+    ssize_t nwrite = disk_write(logfile->fd, log_ptr, log_size);
+    if (nwrite != log_size) {
+        logger->log(EXTENSION_LOG_WARNING, NULL,
+                    "log file(%d) write - write(%ld!=%ld) error=(%d:%s)\n",
+                    logfile->fd, nwrite, (ssize_t)log_size,
+                    errno, strerror(errno));
+    }
+    /* FIXME::need error handling */
+    assert(nwrite == log_size);
+    logfile->size += log_size;
+
+    if (dual_write && logfile->next_fd != -1) {
+        /* next_fd is guaranteed concurrency by log_flush_lock */
+
+        /* The log data is appended */
+        nwrite = disk_write(logfile->next_fd, log_ptr, log_size);
+        if (nwrite != log_size) {
+            logger->log(EXTENSION_LOG_WARNING, NULL,
+                        "log file(%d) write - write(%ld!=%ld) error=(%d:%s)\n",
+                        logfile->next_fd, nwrite, (ssize_t)log_size,
+                        errno, strerror(errno));
+        }
+        /* FIXME::need error handling */
+        assert(nwrite == log_size);
+        logfile->next_size += log_size;
+    }
+}
+
+void cmdlog_file_complete_dual_write(void)
+{
+    log_FILE *logfile = &log_file_gl.log_file;
+
+    if (logfile->next_fd != -1) {
+        logfile->prev_fd   = logfile->fd;
+        logfile->fd        = logfile->next_fd;
+        logfile->size      = logfile->next_size;
+        logfile->next_fd   = -1;
+        logfile->next_size = 0;
+
+        if (log_file_gl.async_mode) {
+            (void)disk_close(logfile->prev_fd);
+            logfile->prev_fd = -1;
+            do_log_file_close_waiter_wakeup();
+        }
+    }
+}
+
+void cmdlog_file_sync(void)
+{
+    LogSN now_flush_lsn;
+    log_FILE *logfile = &log_file_gl.log_file;
+    int fd;
+    int prev_fd = -1;
+    int next_fd = -1;
+    int ret;
+
+    pthread_mutex_lock(&log_file_gl.log_fsync_lock);
+
+    /* get current fd info */
+    pthread_mutex_lock(&log_flush_lock);
+    cmdlog_get_flush_lsn(&now_flush_lsn);
+    if (logfile->prev_fd != -1) {
+        prev_fd = logfile->prev_fd;
+    }
+    fd = logfile->fd;
+    if (logfile->next_fd != -1 && logfile->next_size > 0) {
+        next_fd = logfile->next_fd;
+    }
+    pthread_mutex_unlock(&log_flush_lock);
+
+    if (prev_fd != -1) {
+        /* If prev_fd is set, the prev file access only the log sync thread,
+         * so log_fsync_lock is not needed to close the prev file.
+         */
+        ret = disk_fsync(prev_fd);
+        (void)disk_close(prev_fd);
+
+        pthread_mutex_lock(&log_flush_lock);
+        logfile->prev_fd = -1;
+        do_log_file_close_waiter_wakeup();
+        pthread_mutex_unlock(&log_flush_lock);
+    }
+
+    if (LOGSN_IS_GT(&now_flush_lsn, &log_file_gl.nxt_fsync_lsn)) {
+        do {
+            /* fsync curr fd */
+            ret = disk_fsync(fd);
+            if (ret < 0) {
+                logger->log(EXTENSION_LOG_WARNING, NULL,
+                            "log file fsync error (%d:%s)\n",
+                            errno, strerror(errno));
+                if (log_file_gl.async_mode == false) {
+                    /* [FATAL] untreatable error => abnormal shutdown by assertion */
+                    assert(ret == 0);
+                }
+                break;
+            }
+
+            if (next_fd != -1 && logfile->next_fd != -1) {
+                ret = disk_fsync(next_fd);
+                if (ret < 0) {
+                    logger->log(EXTENSION_LOG_WARNING, NULL,
+                                "log file fsync error (%d:%s)\n",
+                                errno, strerror(errno));
+                    break;
+                }
+            }
+
+            /* update nxt_fsync_lsn */
+            pthread_mutex_lock(&log_file_gl.fsync_lsn_lock);
+            log_file_gl.nxt_fsync_lsn = now_flush_lsn;
+            pthread_mutex_unlock(&log_file_gl.fsync_lsn_lock);
+        } while(0);
+    }
+    pthread_mutex_unlock(&log_file_gl.log_fsync_lock);
+}
+
+int cmdlog_file_open(char *path)
+{
+    log_FILE *logfile = &log_file_gl.log_file;
+    int ret = 0;
+
+    pthread_mutex_lock(&log_flush_lock);
+    /* prepare cmdlog file */
+    do {
+        int fd = disk_open(path, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR | S_IRGRP);
+        if (fd < 0) {
+            logger->log(EXTENSION_LOG_WARNING, NULL,
+                        "Failed to open the cmdlog file. path=%s err=%s\n",
+                        logfile->path, strerror(errno));
+            ret = -1;
+            break;
+        }
+        snprintf(logfile->path, CMDLOG_MAX_FILEPATH_LENGTH, "%s", path);
+        if (logfile->fd == -1) {
+            logfile->fd = fd;
+        } else {
+            /* fd != -1 means that a new cmdlog file is created by checkpoint */
+            logfile->next_fd = fd;
+        }
+    } while(0);
+    pthread_mutex_unlock(&log_flush_lock);
+
+    return ret;
+}
+
+void cmdlog_file_close(bool chkpt_success)
+{
+    log_FILE *logfile = &log_file_gl.log_file;
+    int remove_fd = -1;
+
+    pthread_mutex_lock(&log_flush_lock);
+    if (chkpt_success) {
+        /* wait until the previous file is closed */
+        while (logfile->next_fd != -1 || logfile->prev_fd != -1) {
+            logfile->close_wait = true;
+            pthread_cond_wait(&log_flush_cond, &log_flush_lock);
+            logfile->close_wait = false;
+        }
+    } else {
+        if (logfile->next_fd != -1) {
+            logfile->next_size = 0; /* prevent fsync() */
+            if (log_file_gl.async_mode) {
+                remove_fd = logfile->next_fd;
+                logfile->next_fd = -1;
+            }
+        } else { /* the first checkpoint */
+            assert(logfile->fd != -1);
+            remove_fd = logfile->fd;
+            logfile->fd = -1;
+        }
+    }
+    pthread_mutex_unlock(&log_flush_lock);
+
+    if (logfile->next_fd != -1) {
+        /* only in sync mode and checkpoint failure */
+        pthread_mutex_lock(&log_file_gl.log_fsync_lock);
+        pthread_mutex_lock(&log_flush_lock);
+        remove_fd = logfile->next_fd;
+        logfile->next_fd = -1;
+        pthread_mutex_unlock(&log_flush_lock);
+        pthread_mutex_unlock(&log_file_gl.log_fsync_lock);
+    }
+    if (remove_fd != -1) {
+        (void)disk_close(remove_fd);
+    }
+}
+
+void cmdlog_file_init(struct default_engine* engine)
+{
+    logger = engine->server.log->get_logger();
+
+    /* log file global init */
+    memset(&log_file_gl, 0, sizeof(log_file_gl));
+
+    log_file_gl.async_mode = engine->config.async_logging;
+
+    log_file_gl.nxt_fsync_lsn.filenum = 1;
+    log_file_gl.nxt_fsync_lsn.roffset = 0;
+
+    pthread_mutex_init(&log_file_gl.log_fsync_lock, NULL);
+    pthread_mutex_init(&log_file_gl.fsync_lsn_lock, NULL);
+
+    /* log file init */
+    log_FILE *logfile = &log_file_gl.log_file;
+    logfile->path[0]   = '\0';
+    logfile->prev_fd   = -1;
+    logfile->fd        = -1;
+    logfile->next_fd   = -1;
+    logfile->size      = 0;
+    logfile->next_size = 0;
+    logfile->close_wait = false;
+
+    log_file_gl.initialized = true;
+    logger->log(EXTENSION_LOG_INFO, NULL, "CMDLOG FILE module initialized.\n");
+}
+
+void cmdlog_file_final(void)
+{
+    log_FILE *logfile = &log_file_gl.log_file;
+
+    /* Don't need to hold log_fsync_lock because this function is called
+     * after stopping cmdlog thread. See cmdlog_mgr_final().
+     */
+    if (logfile->fd != -1) {
+        (void)disk_fsync(logfile->fd);
+        (void)disk_close(logfile->fd);
+        logfile->fd = -1;
+    }
+    if (logfile->next_fd != -1) {
+        (void)disk_close(logfile->next_fd);
+        logfile->next_fd = -1;
+    }
+
+    pthread_mutex_destroy(&log_file_gl.log_fsync_lock);
+    pthread_mutex_destroy(&log_file_gl.fsync_lsn_lock);
+
+    log_file_gl.initialized = false;
+    logger->log(EXTENSION_LOG_INFO, NULL, "CMDLOG FILE module destroyed.\n");
+}
+
+static int do_redo_pending_lrec(int fd, int start_offset, int end_offset)
+{
+    char buf[MAX_LOG_RECORD_SIZE];
+    LogRec *logrec = (LogRec*)buf;
+    LogHdr *loghdr = &logrec->header;
+
+    int ret = 0;
+    ssize_t nread = 0;
+    int redo_offset = lseek(fd, (start_offset - end_offset), SEEK_CUR);
+    while (redo_offset < end_offset) {
+        nread = disk_read(fd, loghdr, sizeof(LogHdr));
+        if (nread != sizeof(LogHdr)) {
+            logger->log(EXTENSION_LOG_WARNING, NULL,
+                        "[RECOVERY - CMDLOG] failed : read header data "
+                        "nread(%zd) != header_length(%lu).\n", nread, sizeof(LogHdr));
+            ret = -1; break;
+        }
+        redo_offset += nread;
+        if (loghdr->body_length > 0) {
+            logrec->body = buf + nread;
+            nread = disk_read(fd, logrec->body, loghdr->body_length);
+            if (nread != loghdr->body_length) {
+                logger->log(EXTENSION_LOG_WARNING, NULL,
+                            "[RECOVERY - CMDLOG] failed : read body data "
+                            "nread(%zd) != body_length(%u).\n", nread, loghdr->body_length);
+                ret = -1; break;
+            }
+            redo_offset += nread;
+            ENGINE_ERROR_CODE err = lrec_redo_from_record(logrec);
+            if (err != ENGINE_SUCCESS) {
+                logger->log(EXTENSION_LOG_WARNING, NULL,
+                            "[RECOVERY - CMDLOG] warning : log record redo failed.\n");
+                if (err == ENGINE_ENOMEM) {
+                    logger->log(EXTENSION_LOG_WARNING, NULL,
+                                "[RECOVERY - CMDLOG] failed : out of memory.\n");
+                    ret = -1; break;
+                }
+            }
+        }
+    }
+    return ret;
+}
+
+int cmdlog_file_apply(void)
+{
+    log_FILE *logfile = &log_file_gl.log_file;
+    assert(logfile->fd > 0);
+
+    logger->log(EXTENSION_LOG_INFO, NULL,
+                "[RECOVERY - CMDLOG] applying command log file. path=%s\n", logfile->path);
+
+    struct stat file_stat;
+    fstat(logfile->fd, &file_stat);
+    logfile->size = file_stat.st_size;
+    if (logfile->size == 0) {
+        logger->log(EXTENSION_LOG_INFO, NULL,
+                    "[RECOVERY - CMDLOG] log file is empty.\n");
+        return 0;
+    }
+
+    int  ret = 0;
+    int  seek_offset = 0;
+    int  pending_start_offset = 0;
+    int  pending_end_offset = 0;
+    bool pending = false;
+    char buf[MAX_LOG_RECORD_SIZE];
+    LogRec *logrec = (LogRec*)buf;
+    LogHdr *loghdr = &logrec->header;
+
+    while (log_file_gl.initialized && seek_offset < logfile->size) {
+
+        /* read header */
+        if (logfile->size - seek_offset < sizeof(LogHdr)) {
+            logger->log(EXTENSION_LOG_INFO, NULL,
+                        "[RECOVERY - CMDLOG] header of last log record was not completely written. "
+                        "header_length=%ld\n", sizeof(LogHdr));
+            break;
+        }
+
+        ssize_t nread = disk_read(logfile->fd, loghdr, sizeof(LogHdr));
+        if (nread != sizeof(LogHdr)) {
+            logger->log(EXTENSION_LOG_WARNING, NULL,
+                        "[RECOVERY - CMDLOG] failed : read header data "
+                        "nread(%zd) != header_length(%lu).\n", nread, sizeof(LogHdr));
+            ret = -1; break;
+        }
+        seek_offset += nread;
+
+        if (loghdr->logtype == LOG_OPERATION_BEGIN) {
+            if (pending == true) {
+                logger->log(EXTENSION_LOG_WARNING, NULL,
+                            "[RECOVERY - CMDLOG] failed : LOG_OPERATION_BEGIN recorded "
+                            "before previous kept log record is processed.\n");
+                ret = -1; break;
+            }
+            pending_start_offset = seek_offset;
+            pending = true;
+            continue;
+        }
+
+        if (loghdr->logtype == LOG_OPERATION_END) {
+            if (pending == false) {
+                logger->log(EXTENSION_LOG_WARNING, NULL,
+                            "[RECOVERY - CMDLOG] failed : "
+                            "LOG_OPERATION_END recorded without LOG_OPERATION_BEGIN.\n");
+                ret = -1; break;
+            }
+            /* redo pending normal log records */
+            pending_end_offset = seek_offset;
+            if (do_redo_pending_lrec(logfile->fd, pending_start_offset, pending_end_offset) < 0) {
+                logger->log(EXTENSION_LOG_WARNING, NULL,
+                            "[RECOVERY - CMDLOG] failed : pending log record redo failed\n");
+                ret = -1; break;
+            }
+
+            /* Complete redo of pending log records. cleanup pending info */
+            pending_start_offset = 0;
+            pending_end_offset = 0;
+            pending = false;
+            continue;
+        }
+
+        /* read body */
+        if (loghdr->body_length > 0) {
+            if (logfile->size - seek_offset < loghdr->body_length) {
+                logger->log(EXTENSION_LOG_INFO, NULL,
+                            "[RECOVERY - CMDLOG] body of last log record was not completely written. "
+                            "body_length=%d\n", loghdr->body_length);
+                seek_offset = disk_lseek(logfile->fd, -sizeof(LogHdr), SEEK_CUR);
+                if (seek_offset < 0) {
+                    logger->log(EXTENSION_LOG_WARNING, NULL,
+                                "[RECOVERY - CMDLOG] failed : lseek(SEEK_CUR-%zd). path=%s, error=%s.\n",
+                                sizeof(LogHdr), logfile->path, strerror(errno));
+                    ret = -1;
+                }
+                break;
+            }
+
+            int max_body_length = MAX_LOG_RECORD_SIZE - sizeof(LogHdr);
+            if (max_body_length < loghdr->body_length) {
+                logger->log(EXTENSION_LOG_WARNING, NULL,
+                            "[RECOVERY - CMDLOG] failed : body length is abnormally too big "
+                            "max_body_length(%d) < body_length(%u).\n",
+                            max_body_length, loghdr->body_length);
+                ret = -1; break;
+            }
+            logrec->body = buf + sizeof(LogHdr);
+            nread = disk_read(logfile->fd, logrec->body, loghdr->body_length);
+            if (nread != loghdr->body_length) {
+                logger->log(EXTENSION_LOG_WARNING, NULL,
+                            "[RECOVERY - CMDLOG] failed : read body data "
+                            "nread(%zd) != body_length(%u).\n", nread, loghdr->body_length);
+                ret = -1; break;
+            }
+            seek_offset += loghdr->body_length;
+        }
+
+        if (pending) continue;
+
+        /* redo log record */
+        ENGINE_ERROR_CODE err = lrec_redo_from_record(logrec);
+        if (err != ENGINE_SUCCESS) {
+            /* don't care a log record redo failure. read next log record and redo it. */
+            logger->log(EXTENSION_LOG_WARNING, NULL,
+                        "[RECOVERY - CMDLOG] warning : log record redo failed.\n");
+            if (err == ENGINE_ENOMEM) {
+                logger->log(EXTENSION_LOG_WARNING, NULL,
+                            "[RECOVERY - CMDLOG] failed : out of memory.\n");
+                ret = -1; break;
+            }
+        }
+    }
+    if (ret < 0) {
+        close(logfile->fd);
+    } else {
+        logfile->size = seek_offset;
+        logger->log(EXTENSION_LOG_INFO, NULL, "[RECOVERY - CMDLOG] success.\n");
+    }
+    return ret;
+}
+
+void cmdlog_get_fsync_lsn(LogSN *lsn)
+{
+    pthread_mutex_lock(&log_file_gl.fsync_lsn_lock);
+    *lsn = log_file_gl.nxt_fsync_lsn;
+    pthread_mutex_unlock(&log_file_gl.fsync_lsn_lock);
+}
+
+int cmdlog_get_next_fd(void)
+{
+    log_FILE *logfile = &log_file_gl.log_file;
+
+    return logfile->next_fd;
+}
+
+size_t cmdlog_get_current_file_size(void)
+{
+    log_FILE *logfile = &log_file_gl.log_file;
+
+    /* already locked with log_flush_lock and log_write_lock */
+    return logfile->size;
+}
+#endif

--- a/engines/default/cmdlogfile.h
+++ b/engines/default/cmdlogfile.h
@@ -1,0 +1,38 @@
+/* -*- Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ * arcus-memcached - Arcus memory cache server
+ * Copyright 2019 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef CMDLOGFILE_H
+#define CMDLOGFILE_H
+
+#include "cmdlogmgr.h"
+
+/* external log file functions */
+void cmdlog_file_write(char *log_ptr, uint32_t log_size, bool dual_write);
+void cmdlog_file_complete_dual_write(void);
+void cmdlog_file_sync(void);
+
+int    cmdlog_file_open(char *path);
+void   cmdlog_file_close(bool chkpt_success);
+void   cmdlog_file_init(struct default_engine* engine);
+void   cmdlog_file_final(void);
+int    cmdlog_file_apply(void);
+
+void   cmdlog_get_fsync_lsn(LogSN *lsn);
+int    cmdlog_get_next_fd(void);
+size_t cmdlog_get_current_file_size(void);
+
+#endif

--- a/engines/default/cmdlogmgr.c
+++ b/engines/default/cmdlogmgr.c
@@ -26,6 +26,7 @@
 #ifdef ENABLE_PERSISTENCE
 #include "cmdlogmgr.h"
 #include "cmdlogbuf.h"
+#include "cmdlogfile.h"
 #include "checkpoint.h"
 #include "item_clog.h"
 


### PR DESCRIPTION
#410 관련 PR 입니다.
아래와 같은 부분이 수정되었습니다.

- Log buffer 및 log flusher 모듈을 cmdlogbuf 모듈로 분리
	- cmdlogbuf.c, cmdlogbuf.h
- Log file write/sync 모듈을 cmdlogfile 모듈로 분리
	- cmdlogfile.c, cmdlogfile.h
- Makefile.am에 cmdlogfile 모듈 관련 파일 추가
- cmdlogbuf.c 내 각 함수들의 기존 구현 방식은 유지하였으나, 모듈 분리로 인한 몇가지 수정 사항 아래 작성:
	- 두 모듈이 `log_GLOBAL log_gl`을 공유해, 기존 static한 방식에서 포인터로 접근하도록 수정
	- `cmdlog_buf_init`에서 `malloc` 실패해 `ENGINE_ENOMEM`을 return 해야하는 상황 발생 시, `free(log_gl)` 하도록 추가
	- `cmdlog_buf_final` 시 `free(log_gl)` 추가
	- cmdlogfile 모듈에서 logger 사용을 위해, `cmdlog_file_init` 시 `engine`도 파라미터로 전달
	- cmdlogfile 모듈을 사용하는 checkpoint.c 및 cmdlogmgr.c에 헤더파일 추가

`make test` PASS 확인하였고, [Persistence Guide](https://github.com/naver/arcus-memcached/wiki/Persistence-Guide) 참고해 telnet으로 정상 동작 확인했습니다.
리뷰 요청 드립니다.