### PR TITLE
FIX: free zkconfig buffers when zk is destroyed

### DIFF
--- a/arcus_zk.c
+++ b/arcus_zk.c
@@ -1859,6 +1859,16 @@ void arcus_zk_destroy(void)
         arcus_conf.ch = NULL;
     }
 #endif
+#ifdef ENABLE_ZK_RECONFIG
+    if (arcus_conf.zk_reconfig) {
+        if (sm_info.zkconfig_data_buffer != NULL) {
+            free(sm_info.zkconfig_data_buffer);
+        }
+        if (sm_info.zkconfig_host_buffer != NULL) {
+            free(sm_info.zkconfig_host_buffer);
+        }
+    }
+#endif
     pthread_mutex_unlock(&zk_lock);
 }
 


### PR DESCRIPTION
zkreconfig 기능 추가 commit의 리뷰 과정에서 도입된
zkconfig buffer를 zk destroy 할 때 free 해주도록 추가 했습니다.

@jhpark816 
확인 요청 드립니다.