### PR TITLE
[persistence] removed logfile close wait in checkpoint

### DIFF
--- a/engines/default/cmdlogbuf.c
+++ b/engines/default/cmdlogbuf.c
@@ -83,7 +83,6 @@ struct log_buff_global {
 static EXTENSION_LOGGER_DESCRIPTOR* logger = NULL;
 static struct log_buff_global log_buff_gl;
 pthread_mutex_t log_flush_lock;
-pthread_cond_t  log_flush_cond;
 
 static void do_log_flusher_wakeup(log_FLUSHER *flusher)
 {
@@ -402,7 +401,6 @@ ENGINE_ERROR_CODE cmdlog_buf_init(struct default_engine* engine)
 
     /* log global init */
     pthread_mutex_init(&log_flush_lock, NULL);
-    pthread_cond_init(&log_flush_cond, NULL);
 
     /* log file init */
     cmdlog_file_init(engine);
@@ -469,7 +467,6 @@ void cmdlog_buf_final(void)
 
     /* log global final */
     pthread_mutex_destroy(&log_flush_lock);
-    pthread_cond_destroy(&log_flush_cond);
 
     /* log buff global final */
     pthread_mutex_destroy(&log_buff_gl.log_write_lock);

--- a/engines/default/cmdlogbuf.h
+++ b/engines/default/cmdlogbuf.h
@@ -23,7 +23,6 @@
 
 /* global log flush mutex */
 extern pthread_mutex_t log_flush_lock;
-extern pthread_cond_t  log_flush_cond;
 
 /* external log buffer functions */
 void cmdlog_buff_write(LogRec *logrec, log_waiter_t *waiter, bool dual_write);

--- a/engines/default/cmdlogfile.h
+++ b/engines/default/cmdlogfile.h
@@ -23,10 +23,11 @@
 /* external log file functions */
 void cmdlog_file_write(char *log_ptr, uint32_t log_size, bool dual_write);
 void cmdlog_file_complete_dual_write(void);
+bool cmdlog_file_dual_write_finished(void);
 void cmdlog_file_sync(void);
 
 int    cmdlog_file_open(char *path);
-void   cmdlog_file_close(bool chkpt_success);
+void   cmdlog_file_close(void);
 void   cmdlog_file_init(struct default_engine* engine);
 void   cmdlog_file_final(void);
 int    cmdlog_file_apply(void);


### PR DESCRIPTION
checkpoint thread가 log file close 시에 대기하는 기능 제거 https://github.com/naver/arcus-memcached/issues/514 PR 입니다.

변경된 사항은 다음과 같습니다.
- cmdlog_file_close() 에서 chkpt_success 시 file_close wait 로직 제거
- next checkpoint 는 prev checkpoint 의 logfile close 이후 수행
  - logfile close 확인 함수 정의 : cmdlog_file_dual_write_finished() (prev_fd == -1 && next_fd == -1)
  - checkpoint main thread logic 에서 이를 확인
- do_checkpoint()에서 cmdlog_file_close() 이후 수행하는 remove_chkpt_files 조건 변경
  - 스냅샷 실패 시에만 수행. 
  - 스냅샷 성공한 경우는 prev_time(previous checkpoint time) 만 설정. 이 필드 사용 목적은 previous log file close 이후에 remove_chkpt_files 를 수행하기 위함임. checkpoint 주기에서 prev_time != -1 인 경우 cmdlog_file_dual_write_finished=true 인 경우 remove_chkpt_files(prev_time) 수행 
