### PR TITLE
[persistence] checked checkpoint success at chkpt_recovery_redo()

### DIFF
--- a/engines/default/checkpoint.c
+++ b/engines/default/checkpoint.c
@@ -423,7 +423,7 @@ int chkpt_recovery_redo(void)
         logger->log(EXTENSION_LOG_INFO, NULL,
                     "There are no files needed for recovery. "
                     "Do checkpoint to create checkpoint file set.\n");
-        if (do_checkpoint(cs) == CHKPT_ERROR) {
+        if (do_checkpoint(cs) != CHKPT_SUCCESS) {
             logger->log(EXTENSION_LOG_WARNING, NULL,
                         "Checkpoint failed in chkpt_recovery_redo().\n");
             return -1;


### PR DESCRIPTION
백업 파일이 없는 상태에서 엔진을 구동시킨 경우 redo 단계에서 수행하는 checkpoint 성공이 보장되어야 합니다. 
현재 조건 체크로는 CHKPT_ERROR_FILE_REMOVE 에러를 확인할 수 없습니다.

```
 /* FIXME : Error handling(Disk I/O etc) */
 static int do_checkpoint(chkpt_st *cs)
 {
     int ret;
     int64_t newtime = getnowtime();

     do {
         if ((ret = do_chkpt_create_files(cs, newtime)) != 0) {
             break;
         }

         if ((ret = cmdlog_file_open(cs->cmdlog_path)) != 0) {
             if (do_chkpt_remove_files(cs, newtime) < 0) {
                 ret = CHKPT_ERROR_FILE_REMOVE;
             }
             break;
         }

         if (mc_snapshot_direct(MC_SNAPSHOT_MODE_CHKPT, NULL, -1,
                                cs->snapshot_path, &cs->lastsize) == ENGINE_SUCCESS) {
             cs->prevtime = cs->lasttime;
             cs->lasttime = newtime;
             ret = CHKPT_SUCCESS;
         } else {
             ret = CHKPT_ERROR;
         }
```