### PR TITLE
[persistence] added file_access_lock to guarantee logfile concurrency

### DIFF
--- a/engines/default/cmdlogbuf.c
+++ b/engines/default/cmdlogbuf.c
@@ -365,24 +365,20 @@ size_t cmdlog_get_file_size(void)
 {
     size_t file_size = 0;
 
-    pthread_mutex_lock(&log_flush_lock);
     pthread_mutex_lock(&log_buff_gl.log_write_lock);
     if (log_buff_gl.log_buffer.dw_end == -1) {
         file_size = cmdlog_get_current_file_size();
     }
     pthread_mutex_unlock(&log_buff_gl.log_write_lock);
-    pthread_mutex_unlock(&log_flush_lock);
 
     return file_size;
 }
 
 void cmdlog_complete_dual_write(bool success)
 {
-    pthread_mutex_lock(&log_flush_lock);
     if (cmdlog_get_next_fd() != -1) {
         do_log_buff_complete_dual_write(success);
     }
-    pthread_mutex_unlock(&log_flush_lock);
 }
 
 ENGINE_ERROR_CODE cmdlog_buf_init(struct default_engine* engine)


### PR DESCRIPTION
파일 접근 동시성 보장 시 flush_lock 대신 별도 lock 사용 (https://github.com/naver/arcus-memcached/issues/515) PR 입니다.

파일 접근 동시성 보장을 log_flush_lock 대신 file_access_lock 을 사용하도록 변경하였습니다. 
- 파일 접근 동시성을 주의해야 하는 모듈은
    - fsync 모듈의 cmdlog_file_sync()
    - flush 모듈에서 dw_end 까지 flush 완료하고 fd를 변경하는 cmdlog_file_complete_dual_write()
    - checkpoint 모듈에서 snapshot 실패 시 호출하는 cmdlog_file_close() 인데,
- file_access_lock 으로 변경해도 함수 호출 시점과 fd 변경 시점을 따져봤을 때 문제 없다고 판단했습니다.

cmdlogbuf 모듈에서의 log_flush_lock 사용 코드 변경은 현재 커밋 검토가 끝난 후 변경하겠습니다.
- log_flush_lock 정의 위치를 log_buffer 구조체로 
- extern 제거
