### PR TITLE
[persistence] used log_flush_lock as a field of log_buff_gl

### DIFF
--- a/engines/default/cmdlogbuf.h
+++ b/engines/default/cmdlogbuf.h
@@ -21,9 +21,6 @@
 #include "cmdlogmgr.h"
 #include "cmdlogrec.h"
 
-/* global log flush mutex */
-extern pthread_mutex_t log_flush_lock;
-
 /* external log buffer functions */
 void cmdlog_buff_write(LogRec *logrec, log_waiter_t *waiter, bool dual_write);
 void cmdlog_buff_flush(LogSN *upto_lsn);


### PR DESCRIPTION
file_access_lock 이 추가되었으므로 log_flush_lock 은 logbuffer 모듈에서만 사용하도록 변경하였습니다.

- logfile init/final 수행 위치를 cmdlogmgr 모듈로의 변경은 다른 PR 로 하겠습니다.