### PR TITLE
[persistence] init/final cmdlogfile in cmdlogmgr module

### DIFF
--- a/engines/default/cmdlogbuf.c
+++ b/engines/default/cmdlogbuf.c
@@ -396,9 +396,6 @@ ENGINE_ERROR_CODE cmdlog_buf_init(struct default_engine* engine)
     pthread_mutex_init(&log_buff_gl.log_flush_lock, NULL);
     pthread_mutex_init(&log_buff_gl.flush_lsn_lock, NULL);
 
-    /* log file init */
-    cmdlog_file_init(engine);
-
     /* log buffer init */
     log_BUFFER *logbuff = &log_buff_gl.log_buffer;
 
@@ -455,9 +452,6 @@ void cmdlog_buf_final(void)
         free((void*)logbuff->fque);
         logbuff->fque = NULL;
     }
-
-    /* log file final */
-    cmdlog_file_final();
 
     /* log buff global final */
     pthread_mutex_destroy(&log_buff_gl.log_write_lock);

--- a/engines/default/cmdlogmgr.c
+++ b/engines/default/cmdlogmgr.c
@@ -451,6 +451,7 @@ ENGINE_ERROR_CODE cmdlog_mgr_init(struct default_engine* engine_ptr)
     if (ret != ENGINE_SUCCESS) {
         return ret;
     }
+    (void)cmdlog_file_init(engine);
     ret = cmdlog_buf_init(engine);
     if (ret != ENGINE_SUCCESS) {
         return ret;
@@ -494,6 +495,7 @@ void cmdlog_mgr_final(void)
     /* CONSIDER: do last checkpoint before shutdown engine. */
     chkpt_final();
     cmdlog_buf_final();
+    cmdlog_file_final();
     cmdlog_waiter_final();
 
     if (logmgr_gl.initialized == true) {


### PR DESCRIPTION
logfile 은 logbuffer 모듈과 decoupling 되었으므로 logfile init/final 을 cmdlogmgr 에서 수행합니다.