### PR TITLE
[persistence] removed cmdlog_get_file_size()

### DIFF
--- a/engines/default/checkpoint.c
+++ b/engines/default/checkpoint.c
@@ -27,7 +27,6 @@
 #ifdef ENABLE_PERSISTENCE
 #include "checkpoint.h"
 #include "mc_snapshot.h"
-#include "cmdlogbuf.h"
 #include "cmdlogfile.h"
 
 #define CHKPT_MAX_FILENAME_LENGTH  255
@@ -276,7 +275,7 @@ static bool do_checkpoint_needed(chkpt_st *cs)
 {
     struct engine_config *config = cs->config;
     size_t snapshot_file_size = cs->lastsize;
-    size_t cmdlog_file_size   = cmdlog_get_file_size();
+    size_t cmdlog_file_size   = cmdlog_file_getsize();
     size_t min_logsize        = config->chkpt_interval_min_logsize;
     int    pct_snapshot       = config->chkpt_interval_pct_snapshot;
 

--- a/engines/default/cmdlogbuf.c
+++ b/engines/default/cmdlogbuf.c
@@ -361,19 +361,6 @@ void cmdlog_get_flush_lsn(LogSN *lsn)
     pthread_mutex_unlock(&log_buff_gl.flush_lsn_lock);
 }
 
-size_t cmdlog_get_file_size(void)
-{
-    size_t file_size = 0;
-
-    pthread_mutex_lock(&log_buff_gl.log_write_lock);
-    if (log_buff_gl.log_buffer.dw_end == -1) {
-        file_size = cmdlog_get_current_file_size();
-    }
-    pthread_mutex_unlock(&log_buff_gl.log_write_lock);
-
-    return file_size;
-}
-
 void cmdlog_complete_dual_write(bool success)
 {
     if (cmdlog_get_next_fd() != -1) {

--- a/engines/default/cmdlogbuf.h
+++ b/engines/default/cmdlogbuf.h
@@ -28,7 +28,6 @@ void cmdlog_buff_flush(LogSN *upto_lsn);
 /* FIXME: remove later, if not used */
 //void log_get_write_lsn(LogSN *lsn);
 void   cmdlog_get_flush_lsn(LogSN *lsn);
-size_t cmdlog_get_file_size(void);
 
 void              cmdlog_complete_dual_write(bool success);
 ENGINE_ERROR_CODE cmdlog_buf_init(struct default_engine *engine);

--- a/engines/default/cmdlogfile.c
+++ b/engines/default/cmdlogfile.c
@@ -573,6 +573,17 @@ int cmdlog_file_apply(void)
     return ret;
 }
 
+size_t cmdlog_file_getsize(void)
+{
+    log_FILE *logfile = &log_file_gl.log_file;
+    size_t size;
+    pthread_mutex_lock(&log_file_gl.file_access_lock);
+    size = logfile->size;
+    pthread_mutex_unlock(&log_file_gl.file_access_lock);
+
+    return size;
+}
+
 void cmdlog_get_fsync_lsn(LogSN *lsn)
 {
     pthread_mutex_lock(&log_file_gl.fsync_lsn_lock);
@@ -589,16 +600,5 @@ int cmdlog_get_next_fd(void)
     pthread_mutex_unlock(&log_file_gl.file_access_lock);
 
     return next_fd;
-}
-
-size_t cmdlog_get_current_file_size(void)
-{
-    log_FILE *logfile = &log_file_gl.log_file;
-    int size = 0;
-    pthread_mutex_lock(&log_file_gl.file_access_lock);
-    size = logfile->size;
-    pthread_mutex_unlock(&log_file_gl.file_access_lock);
-
-    return size;
 }
 #endif

--- a/engines/default/cmdlogfile.h
+++ b/engines/default/cmdlogfile.h
@@ -31,9 +31,8 @@ void   cmdlog_file_close(void);
 void   cmdlog_file_init(struct default_engine* engine);
 void   cmdlog_file_final(void);
 int    cmdlog_file_apply(void);
+size_t cmdlog_file_getsize(void);
 
 void   cmdlog_get_fsync_lsn(LogSN *lsn);
 int    cmdlog_get_next_fd(void);
-size_t cmdlog_get_current_file_size(void);
-
 #endif


### PR DESCRIPTION
cmdlog_get_file_size() 함수 재검토 (issue: https://github.com/naver/arcus-memcached/issues/522) PR 입니다.

- logbuffer 모듈의 cmdlog_get_file_size() 함수를 제거하였습니다.
  - cmdlog_file_dual_write_finished()==true 이후에 해당 함수가 호출되므로, dw_end == -1 인 상태이어서 해당 값을 확인할 필요가 없음.
- logfile 모듈의 cmdlog_get_current_file_size() 함수명을 cmdlog_file_getsize() 로 변경하였습니다.
  - 이전 함수 명이 낫다면 roll back 하겠습니다. 