### PR TITLE
[persistence] set chkpt_scanp when checkpoint lasttime is set

### DIFF
--- a/engines/default/checkpoint.c
+++ b/engines/default/checkpoint.c
@@ -499,4 +499,9 @@ void chkpt_final(void)
     chkpt_anch.initialized = false;
     logger->log(EXTENSION_LOG_INFO, NULL, "CHECKPOINT module destroyed.\n");
 }
+
+int64_t chkpt_get_lasttime(void)
+{
+    return chkpt_anch.lasttime;
+}
 #endif

--- a/engines/default/checkpoint.h
+++ b/engines/default/checkpoint.h
@@ -28,4 +28,6 @@ ENGINE_ERROR_CODE chkpt_thread_start(void);
 void chkpt_thread_stop(void);
 void chkpt_final(void);
 
+int64_t chkpt_get_lasttime(void);
+
 #endif

--- a/engines/default/cmdlogbuf.c
+++ b/engines/default/cmdlogbuf.c
@@ -344,6 +344,11 @@ void cmdlog_buff_flush(LogSN *upto_lsn)
     } while (nflush > 0);
 }
 
+void cmdlog_buff_complete_dual_write(bool success)
+{
+    do_log_buff_complete_dual_write(success);
+}
+
 void cmdlog_get_write_lsn(LogSN *lsn)
 {
     pthread_mutex_lock(&log_buff_gl.log_write_lock);
@@ -356,13 +361,6 @@ void cmdlog_get_flush_lsn(LogSN *lsn)
     pthread_mutex_lock(&log_buff_gl.flush_lsn_lock);
     *lsn = log_buff_gl.nxt_flush_lsn;
     pthread_mutex_unlock(&log_buff_gl.flush_lsn_lock);
-}
-
-void cmdlog_complete_dual_write(bool success)
-{
-    if (cmdlog_get_next_fd() != -1) {
-        do_log_buff_complete_dual_write(success);
-    }
 }
 
 ENGINE_ERROR_CODE cmdlog_buf_init(struct default_engine* engine)

--- a/engines/default/cmdlogbuf.h
+++ b/engines/default/cmdlogbuf.h
@@ -24,11 +24,11 @@
 /* external log buffer functions */
 void cmdlog_buff_write(LogRec *logrec, log_waiter_t *waiter, bool dual_write);
 void cmdlog_buff_flush(LogSN *upto_lsn);
+void cmdlog_buff_complete_dual_write(bool success);
 
 void cmdlog_get_write_lsn(LogSN *lsn);
 void cmdlog_get_flush_lsn(LogSN *lsn);
 
-void              cmdlog_complete_dual_write(bool success);
 ENGINE_ERROR_CODE cmdlog_buf_init(struct default_engine *engine);
 void              cmdlog_buf_final(void);
 ENGINE_ERROR_CODE cmdlog_buf_flush_thread_start(void);

--- a/engines/default/cmdlogfile.c
+++ b/engines/default/cmdlogfile.c
@@ -590,15 +590,4 @@ void cmdlog_get_fsync_lsn(LogSN *lsn)
     *lsn = log_file_gl.nxt_fsync_lsn;
     pthread_mutex_unlock(&log_file_gl.fsync_lsn_lock);
 }
-
-int cmdlog_get_next_fd(void)
-{
-    log_FILE *logfile = &log_file_gl.log_file;
-    int next_fd = -1;
-    pthread_mutex_lock(&log_file_gl.file_access_lock);
-    next_fd = logfile->next_fd;
-    pthread_mutex_unlock(&log_file_gl.file_access_lock);
-
-    return next_fd;
-}
 #endif

--- a/engines/default/cmdlogfile.h
+++ b/engines/default/cmdlogfile.h
@@ -34,5 +34,4 @@ int    cmdlog_file_apply(void);
 size_t cmdlog_file_getsize(void);
 
 void   cmdlog_get_fsync_lsn(LogSN *lsn);
-int    cmdlog_get_next_fd(void);
 #endif

--- a/engines/default/cmdlogmgr.c
+++ b/engines/default/cmdlogmgr.c
@@ -691,7 +691,10 @@ void cmdlog_set_chkpt_scan(void *scanp)
 {
     /* Cache locked */
     assert(chkpt_scanp == NULL);
-    chkpt_scanp = scanp;
+    if (chkpt_get_lasttime() != -1) {
+        /* normal checkpoint by checkpoint thread */
+        chkpt_scanp = scanp;
+    }
 }
 
 void cmdlog_reset_chkpt_scan(bool chkpt_success)
@@ -699,7 +702,7 @@ void cmdlog_reset_chkpt_scan(bool chkpt_success)
     /* Cache locked */
     if (chkpt_scanp != NULL) {
         chkpt_scanp = NULL;
-        cmdlog_complete_dual_write(chkpt_success);
+        cmdlog_buff_complete_dual_write(chkpt_success);
     }
 }
 #endif


### PR DESCRIPTION
cmdlog_complete_dual_write() 함수 재검토.https://github.com/naver/arcus-memcached/issues/521 PR 입니다.

complete_dual_write 는 checkpoint 스레드에 의한 checkpoint 일 때만 수행하도록 다음과 같이 변경하였습니다.
- checkpoint lasttime 값을 확인하여 -1 이 아닐 때 chkpt_scanp 를 set.
- chkpt_scanp 가 set 되지 않았다면, chkpt_scanp_close() 호출되지 않으므로 complete_dual_write() 수행하지 않음.
