### PR TITLE
FEATURE: added default_engine.conf file to set engine settings on file.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,6 +35,10 @@ endif
 noinst_LTLIBRARIES=libmcd_util.la
 
 
+# Engine configuration file.
+engineconfdir=$(prefix)/conf
+dist_engineconf_DATA=
+
 # Test application to test stuff from C
 testapp_SOURCES = testapp.c
 testapp_DEPENDENCIES= libmcd_util.la
@@ -158,6 +162,7 @@ default_engine_la_SOURCES= \
 default_engine_la_DEPENDENCIES= libmcd_util.la
 default_engine_la_LIBADD= libmcd_util.la $(LIBM)
 default_engine_la_LDFLAGS= -avoid-version -shared -module -no-undefined
+dist_engineconf_DATA+= engines/default/default_engine.conf
 
 # The demo storage engine
 demo_engine_la_SOURCES= \

--- a/engines/default/default_engine.conf
+++ b/engines/default/default_engine.conf
@@ -1,0 +1,20 @@
+# This is a default engine config file.
+#
+#
+# Max collection size (default: 50000, min: 10000, max: 1000000).
+# The maximum number of elements that can be stored in each collection item.
+#
+# We recommend setting this value below the default to avoid latency problems.
+# The request for an item that has many elements could cause to delay
+# not only in response to itself but also to other requests.
+max_list_size=50000
+max_set_size=50000
+max_map_size=50000
+max_btree_size=50000
+#
+# Max element bytes (default: 16KB, min: 1KB, max: 32KB)
+max_element_bytes=16KB
+#
+# Scrub count (default: 96, min: 16, max: 320)
+# Count of scrubbing items at each try.
+scrub_count=96


### PR DESCRIPTION
Nushaba 리뷰 받아서 엔진 설정 파일(default_engine.conf) 를 추가하였습니다. (https://github.com/jam2in/arcus-works/issues/252)

- default_engine.conf 경로는 engines/default/default_engine.conf
- make 명령에 따른 default_engine.conf 처리 (tested) :
  - make install : $(prefix)/conf 디렉토리로 복사됨 (conf 디렉토리 없으면 생성). 
  - make uninstall : $(prefix)conf 디렉토리에 있는 only default_engine.conf 삭제. 
  - make dist : tar 파일에 default_engine.conf 가 기존 경로 그대로 포함되어 있음.

- Makefile.am 수정 사항 설명
```
engineconfdir=$(prefix)/conf
dist_engineconf_DATA=
```
**engineconfdir** 은 make install/uninstall 시에 생성/제거할 engineconf 파일의 directory path입니다.
**dist_engineconf_DATA** 는 `${prefix}_XX_${primary}` 와 같은 형태로, XX는 파일이 설치될 경로(lookup XXdir)를 의미하고 prefix 와 primary 아래와 같은 역할을 하는 symbol입니다.
- primary : primary 는  _PROGRAMS, _SCRIPTS, _DATA, _LIBRARIES 등으로 명시할 수 있고 파일 성격에 따라 선택. 일반적으로 컴파일된 바이너리가 대상일 때는 _PROGRAMS 를(_SOURCES를 필요로함.), _SCRIPTS 는 script를, _DATA 는 실행 불가능한 보통 파일에 쓰임. primary 별로 각 make 명령 target 이 다른데, make install, make uninstall 은 모두 target 이 되지만, make dist 의 경우 _DATA 는 제외됨.  
- prefix : specific make 명령의 target 이 될 수 있도록 설정할 수 있음. 현재 prefix 가 dist 로 되어 있는데, 이는 make dist 명령의 대상이 되기 위함임.