### PR TITLE
FIX: set item_count to -2 only ENGINE_ENOMEM in item_scan_getnext().

### DIFF
--- a/engines/default/items.c
+++ b/engines/default/items.c
@@ -1047,7 +1047,7 @@ int item_scan_getnext(item_scan *sp, void **item_array, elems_result_t *erst_arr
             /* Found the valid item */
             if (erst_array != NULL && IS_COLL_ITEM(it)) {
                 ret = coll_elem_get_all(it, &erst_array[nfound], false);
-                if (ret  == ENGINE_ENOMEM) break;
+                if (ret == ENGINE_ENOMEM) break;
             }
             ITEM_REFCOUNT_INCR(it);
             if (nfound < i) {
@@ -1057,14 +1057,15 @@ int item_scan_getnext(item_scan *sp, void **item_array, elems_result_t *erst_arr
         }
         item_count = nfound;
     } else {
-        /* item_count == 0: not found element */
+        /* item_count == 0: not found item */
         /* item_count <  0: the end of scan */
     }
     UNLOCK_CACHE();
 
-    if (ret != ENGINE_SUCCESS) {
-        if (item_count > 0)
+    if (ret == ENGINE_ENOMEM) {
+        if (item_count > 0) {
             item_scan_release(sp, item_array, erst_array, item_count);
+        }
         item_count = -2; /* OUT OF MEMORY */
     }
     return item_count;


### PR DESCRIPTION
coll_elem_get_all() 에서 element 가 없는 경우 ENGINE_ELEM_ENOENT 가 리턴될 수 있는데,
`ret != ENGINE_SUCCES ` 로 확인하면  ENGINE_ELEM_ENOENT 도 OUT OF MEMORY 로 처리하는 문제가 잇습니다.
```
 ENGINE_ERROR_CODE coll_elem_get_all(hash_item *it, elems_result_t *eresult, bool lock_hold)
 {
     coll_meta_info *info;
     ENGINE_ERROR_CODE ret = ENGINE_SUCCESS;

     if (lock_hold) LOCK_CACHE();
     do {
         if (!IS_COLL_ITEM(it)) {
             ret = ENGINE_EBADTYPE; break;
         }
         info = (coll_meta_info*)item_get_meta(it);
         if (info->ccnt <= 0) {
             ret = ENGINE_ELEM_ENOENT; break;
         }
         /* init and check result */
         if (eresult->elem_arrsz < info->ccnt) {
             uint32_t new_size = GET_ALIGN_SIZE(info->ccnt, 100);
             if (do_coll_eresult_realloc(eresult, new_size) < 0) {
                 ret = ENGINE_ENOMEM; break;
             }
```