### PR TITLE
FIX: update _run_memcached_solo.sh script

### DIFF
--- a/_run_memcached_solo.sh
+++ b/_run_memcached_solo.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
 
-./memcached -E .libs/default_engine.so -X .libs/syslog_logger.so -X .libs/ascii_scrub.so $@
+CURRENT_DIR_PATH=`pwd`
+
+ ./memcached -E $CURRENT_DIR_PATH/.libs/default_engine.so -X $CURRENT_DIR_PATH/.libs/syslog_logger.so -X $CURRENT_DIR_PATH/.libs/ascii_scrub.so $@


### PR DESCRIPTION
### Issue: daemon으로 실행 시 상대 경로로 입력한 engine library를 찾지 못하는 문제 #503 

- 기존 _run_memcached_solo.sh script에 현재 script가 실행되는 경로를 획득하여 상대 경로를 절대 경로로 실행하도록 변경하였습니다.
