### PR TITLE
FEATURE: add redistribution logs

### DIFF
--- a/engines/default/assoc.h
+++ b/engines/default/assoc.h
@@ -31,6 +31,7 @@ struct assoc {
     uint32_t hashmask;  /* hash bucket mask */
     uint32_t rootpower; /* how many hash tables we use ? (power of 2) */
     uint32_t rootsize;
+    uint32_t redistributed_bucket_cnt;
 
     /* cache item hash table : an array of hash tables */
     struct table {


### PR DESCRIPTION
#546 관련 PR입니다. 

해쉬 테이블 확장/재분배 시 다음과 같이 로그를 남깁니다.

1. 재분배를 위해 assoc_expand를 실행했을 때 (전/후 rootsize 기록)
2. 재분배가 50% 진행되었을 때
3. 재분배가 종료되었을 때 

확장의 진행 정도와 종료 여부를 알 수 있으려면 재분배된 버켓이 몇 개인지 셀 필요가 있으므로 관련 변수를 추가 했습니다.(assocp->redistributed_bucket_cnt) 