### PR TITLE
FIX: add header

### DIFF
--- a/engines/default/item_base.c
+++ b/engines/default/item_base.c
@@ -29,6 +29,7 @@
 #endif
 #include <assert.h>
 #include <sys/time.h> /* gettimeofday() */
+#include <string.h>
 #include "default_engine.h"
 #include "item_base.h"
 #include "item_clog.h"


### PR DESCRIPTION
macOS mojave(10.14.5), LLVM 10.0.1 환경에서 develop 브랜치를 컴파일 했을 때 implicit-function-declaration warning이 발생합니다.

```
engines/default/item_base.c:307:5: error: implicitly declaring library function 'memset' with type 'void *(void *, int, unsigned long)' [-Werror,-Wimplicit-function-declaration]
    memset(itemsp->itemstats, 0, sizeof(itemsp->itemstats));
    ^
engines/default/item_base.c:307:5: note: include the header <string.h> or explicitly provide a declaration for 'memset'
engines/default/item_base.c:956:9: error: implicitly declaring library function 'memcpy' with type 'void *(void *, const void *, unsigned long)' [-Werror,-Wimplicit-function-declaration]
        memcpy((void*)item_get_key(it), key, nkey);
        ^
engines/default/item_base.c:956:9: note: include the header <string.h> or explicitly provide a declaration for 'memcpy'
engines/default/item_base.c:1420:50: error: implicitly declaring library function 'strerror' with type 'char *(int)' [-Werror,-Wimplicit-function-declaration]
                    "Can't create thread: %s\n", strerror(ret));
                                                 ^
engines/default/item_base.c:1420:50: note: include the header <string.h> or explicitly provide a declaration for 'strerror'
```

warning 제거를 위해 string.h 헤더를 include했습니다.