### PR TITLE
CLEANUP: fix realtime function

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -196,9 +196,12 @@ static rel_time_t get_current_time(void)
 static rel_time_t realtime(const time_t exptime)
 {
     if (exptime == 0) return 0; /* 0 means never expire */
+    if (exptime < 0) {
 #ifdef ENABLE_STICKY_ITEM
-    if (exptime == -1) return (rel_time_t)(-1);
+        if (exptime == -1) return (rel_time_t)(-1);
 #endif
+        return (rel_time_t)1;
+    }
     /* no. of seconds in 30 days - largest possible delta exptime */
     if (exptime > REALTIME_MAXDELTA) {
         /* if item expiration is at/before the server started, give it an


### PR DESCRIPTION
### Issue: Invalid exptime(과거 시점의 exptime)을 주는 경우 set, setattr 동작의 재검토  #376 

- 기존 exptime 값을 처리하는 realtime 함수에서 exptime 값이 -1 보다 더 작은 음수 값에 대한 예외 처리를 추가하였습니다.