### PR TITLE
FEATURE: added stats persistence command.

### DIFF
--- a/engines/default/checkpoint.h
+++ b/engines/default/checkpoint.h
@@ -32,6 +32,9 @@ void chkpt_thread_stop(void);
 void chkpt_final(void);
 
 int64_t chkpt_get_lasttime(void);
+
+void chkpt_persistence_stats(struct default_engine *engine, ADD_STAT add_stat, const void *cookie);
+
 #endif
 
 #endif

--- a/engines/default/default_engine.c
+++ b/engines/default/default_engine.c
@@ -1138,6 +1138,11 @@ default_get_stats(ENGINE_HANDLE* handle, const void* cookie,
     else if (strncmp(stat_key, "dump", 4) == 0) {
         item_dump_stats(engine, add_stat, cookie);
     }
+#ifdef ENABLE_PERSISTENCE
+    else if (strncmp(stat_key, "persistence", 11) == 0) {
+        chkpt_persistence_stats(engine, add_stat, cookie);
+    }
+#endif
     else {
         ret = ENGINE_KEY_ENOENT;
     }

--- a/memcached.c
+++ b/memcached.c
@@ -9220,6 +9220,9 @@ static void process_help_command(conn *c, token_t *tokens, const size_t ntokens)
         "\t" "stats dump\\r\\n" "\n"
         "\t" "stats cachedump <slab_clsid> <limit> [forward|backward [sticky]]\\r\\n" "\n"
         "\t" "stats reset\\r\\n" "\n"
+#ifdef ENABLE_PERSISTENCE
+        "\t" "stats persistence\\r\\n" "\n"
+#endif
 #ifdef COMMAND_LOGGING
         "\n"
         "\t" "cmdlog start [<file_path>]\\r\\n" "\n"


### PR DESCRIPTION
ARCUS의 default 엔진에는 엔진 동작에 관한 설정들을 가지는 default_engine.conf 파일이 있으며, 그 파일에서 아래와 같은 Persistence 관련 설정을 할 수 있습니다.
```
# Persistence configuration
#
# use persistence (true or false, default: false)
use_persistence=true
#
# The path of the snapshot file (default: ARCUS-DB)
data_path=/home/hyeong/arcus/ARCUS_DB
#
# The path of the command log file (default: ARCUS-DB)
logs_path=/home/hyeong/arcus/ARCUS_DB
#
# asynchronous logging
async_logging=false
#
# checkpoint interval (unit: percentage, default: 100)
# The ratio of the command log file size to the snapshot file size.
# 100 means checkpoint if snapshot file size is 10GB, command log file size is 20GB or more
chkpt_interval_pct_snapshot=100
#
# checkpoint interval minimum file size (unit: MB, default: 256)
chkpt_interval_min_logsize=256
```
   

stats persistence 명령의 수행 결과는 use_persistence 값(on or off)에 따라 달라집니다.
use_persistence on 이면, 응답은 다음과 같습니다.
( STAT chkpt_interval_min_logsize (unit: B))
```
STAT use_persistence on
STAT data_path /home/hyeong/ARCUS_DB
STAT logs_path /home/hyeong/ARCUS_DB
STAT async_logging false
STAT chkpt_interval_pct_snapshot 100
STAT chkpt_interval_min_logsize 268435456
STAT recovery_elapsed_time_sec 0.000047
STAT last_chkpt_in_progress false
STAT last_chkpt_failure_count 0
STAT last_chkpt_start_time 0
STAT last_chkpt_elapsed_time_sec 0.000000
STAT last_chkpt_snapshot_filesize_bytes 321600208
STAT current_command_log_filesize_bytes 0
```

Memtier_benchmark 이용해 ARCUS 명령 대량 수행을 진행해 checkpoint를 수행시킨 결과입니다.
```
STAT use_persistence on
STAT data_path /home/hyeong/ARCUS_DB
STAT logs_path /home/hyeong/ARCUS_DB
STAT async_logging false
STAT chkpt_interval_pct_snapshot 100
STAT chkpt_interval_min_logsize 268435456
STAT recovery_elapsed_time_sec 0.000047
STAT last_chkpt_in_progress false
STAT last_chkpt_failure_count 0
STAT last_chkpt_start_time 20201230105550
STAT last_chkpt_elapsed_time_sec 0.458821
STAT last_chkpt_snapshot_filesize_bytes 321600208
STAT current_command_log_filesize_bytes 335645344
END
```



use_persistence off 이면, 응답은 다음과 같습니다.
```
STAT use_persistence off
END
```