### PR TITLE
FEATURE: changed the unit of chkpt_interval_min_logsize. 

### DIFF
--- a/engines/default/checkpoint.c
+++ b/engines/default/checkpoint.c
@@ -494,7 +494,7 @@ void chkpt_persistence_stats(struct default_engine *engine, ADD_STAT add_stat, c
          add_statistics(cookie, add_stat, NULL, -1, "logs_path", "%s", conf->logs_path);
          add_statistics(cookie, add_stat, NULL, -1, "async_logging", "%s", conf->async_logging? "true" : "false");
          add_statistics(cookie, add_stat, NULL, -1, "chkpt_interval_pct_snapshot", "%u", conf->chkpt_interval_pct_snapshot);
-         add_statistics(cookie, add_stat, NULL, -1, "chkpt_interval_min_logsize", "%u", conf->chkpt_interval_min_logsize);
+         add_statistics(cookie, add_stat, NULL, -1, "chkpt_interval_min_logsize", "%u", conf->chkpt_interval_min_logsize/1024/1024);
          add_statistics(cookie, add_stat, NULL, -1, "recovery_elapsed_time_sec", "%ld", (long)chkpt_last_stat.recovery_elapsed_time_sec);
          add_statistics(cookie, add_stat, NULL, -1, "last_chkpt_in_progress", "%s",
                         chkpt_last_stat.last_chkpt_in_progress? "true" : "false");


### PR DESCRIPTION
stats persistence 명령의 수행 결과 중 STAT chkpt_interval_min_logsize와 관련하여 
unit: B에서 unit:MB로 출력되도록 변환하였습니다.

STAT use_persistence on
STAT data_path /home/hyeong/ARCUS_DB
STAT logs_path /home/hyeong/ARCUS_DB
STAT async_logging false
STAT chkpt_interval_pct_snapshot 100
STAT chkpt_interval_min_logsize 256
STAT recovery_elapsed_time_sec 0.000047
STAT last_chkpt_in_progress false
STAT last_chkpt_failure_count 0
STAT last_chkpt_start_time 0
STAT last_chkpt_elapsed_time_sec 0.000000
STAT last_chkpt_snapshot_filesize_bytes 321600208
STAT current_command_log_filesize_bytes 0