### PR TITLE
FEATURE: added config command for changing the persistence setting

### DIFF
--- a/include/memcached/types.h
+++ b/include/memcached/types.h
@@ -31,6 +31,7 @@ struct iovec {
 #include <sys/uio.h>
 #endif
 
+#define PERSISTENCE_CONFIG 1
 #define NESTED_PREFIX
 #define PROXY_SUPPORT
 //#define NEW_PREFIX_STATS_MANAGEMENT


### PR DESCRIPTION
체크포인트 수행 조건과 명령 로깅 모드 설정은 use_persistence 값(on or off)에 따라 달라집니다.   

use_persistence off 이면, 응답은 다음과 같습니다.
```
config chkpt_interval_min_logsize
ERROR not using Persistence
config chkpt_interval_pct_snapshot
ERROR not using Persistence
config async_logging
ERROR not using Persistence
```

use_persistence on 이면, 응답은 다음과 같습니다.
( chkpt_interval_pct_snapshot의 경우 0 < chkpt_interval_pct_snapshot <= 100의 범위를 설정하였습니다.)
```
config chkpt_interval_pct_snapshot
chkpt_interval_pct_snapshot 100
END
config chkpt_interval_pct_snapshot 200
CLIENT_ERROR bad value
config chkpt_interval_pct_snapshot 40
END
config chkpt_interval_pct_snapshot
chkpt_interval_pct_snapshot 40
END
```
stats persistence 명령어를 통해서도 다음과 같이 변경된 값을 조회할 수 있습니다.
```
stats persistence
STAT use_persistence on
STAT data_path /home/hyeong/ARCUS_DB
STAT logs_path /home/hyeong/ARCUS_DB
STAT async_logging false
STAT chkpt_interval_pct_snapshot 40
STAT chkpt_interval_min_logsize 256
STAT recovery_elapsed_time_sec 2
STAT last_chkpt_in_progress false
STAT last_chkpt_failure_count 0
STAT last_chkpt_start_time 0
STAT last_chkpt_elapsed_time_sec 0
STAT last_chkpt_snapshot_filesize_bytes 321600208
STAT current_command_log_filesize_bytes 193422032
END
```