### PR TITLE
INTERNAL: increased val buffer size in do_snapshot_stats().

### DIFF
--- a/engines/default/chkpt_snapshot.c
+++ b/engines/default/chkpt_snapshot.c
@@ -535,7 +535,7 @@ static void do_snapshot_stop(snapshot_st *ss, bool wait_stop)
 
 static void do_snapshot_stats(snapshot_st *ss, ADD_STAT add_stat, const void *cookie)
 {
-    char val[256];
+    char val[MAX_FILEPATH_LENGTH];
     int  len;
 
     if (ss->running) {


### PR DESCRIPTION
compile시 format-overflow warning 발생시키는 코드를 수정하였습니다.
- do_snapshot_stats() 함수에서 val 버퍼 크기를 256 => 4096으로 증가.

