### PR TITLE
FIX: main_zk is not set yet in arcus_zk_client_init()

### DIFF
--- a/arcus_zk.c
+++ b/arcus_zk.c
@@ -396,7 +396,7 @@ arcus_zk_client_init(zk_info_t *zinfo)
     // ZK client ping period is recv_timeout / 3.
     arcus_conf.logger->log(EXTENSION_LOG_INFO, NULL,
             "ZooKeeper client initialized. (ZK session timeout=%d sec)\n",
-            zoo_recv_timeout(main_zk->zh)/1000);
+            zoo_recv_timeout(zinfo->zh)/1000);
     return 0;
 }
 


### PR DESCRIPTION
arcus_zk_client_init() 에서는 main_zk 가 아직 설정되지 않은 상태이므로 zinfo 사용하도록 수정하엿습니다.
```
rc = arcus_zk_client_init(zinfo);
if (rc != 0) {
  arcus_conf.logger->log(EXTENSION_LOG_WARNING, NULL,
   "Failed to initialize zk client\n");
  arcus_exit(NULL, rc);
}
/* setting main zk */
main_zk = zinfo;
```