### PR TITLE
FIX: in async mode, log records may remain in flush size.

### DIFF
--- a/engines/default/cmdlogbuf.c
+++ b/engines/default/cmdlogbuf.c
@@ -473,6 +473,9 @@ void cmdlog_buf_final(void)
         return;
     }
 
+    /* In async mode, log records may remain in CMDLOG_FLUSH_AUTO_SIZE. */
+    (void)do_log_buff_flush(true);
+
     /* log buffer final */
     log_BUFFER *logbuff = &log_buff_gl.log_buffer;
 


### PR DESCRIPTION
async mode 에서는 32KB 단위로 log records flush 를 수행하기 때문에 이 단위만큼 채워지지 않은 경우 일부 log records 가 디스크에 쓰여지지 않은 채로 서버가 종료될 수 있는 문제를 수정하였습니다.