### PR TITLE
FEATURE: add large value set feature

### DIFF
--- a/engines/default/coll_list.h
+++ b/engines/default/coll_list.h
@@ -20,6 +20,21 @@
 
 #include "item_base.h"
 
+#ifdef ENABLE_LARGE_ITEM
+/*
+ * Large item which made of list structure internally.
+ */
+hash_item *list_large_item_alloc(const void* key, const int nkey,
+                                 item_attr *attrp, uint32_t nbytes,
+                                 const void *cookie);
+
+ENGINE_ERROR_CODE list_large_item_attach(hash_item *it, hash_item *new_it,
+                                         ENGINE_STORE_OPERATION operation, bool update,
+                                         const void *cookie);
+
+void list_large_item_free(hash_item *it);
+#endif
+
 /*
  * List Collection
  */

--- a/engines/default/default_engine.h
+++ b/engines/default/default_engine.h
@@ -43,6 +43,10 @@ struct default_engine;
 
 #define MAX_FILEPATH_LENGTH 4096
 #define MAX_FILENAME_LENGTH 256
+#ifdef ENABLE_LARGE_ITEM
+#define MAX_ITEM_VALUE_LENGTH   10 * 1024 * 1024
+#define LARGE_ITEM_VALUE_LENGTH 128 * 1024
+#endif
 
 /**
  * engine configuration

--- a/engines/default/item_base.c
+++ b/engines/default/item_base.c
@@ -137,7 +137,15 @@ static inline size_t ITEM_ntotal(const hash_item *item)
         else if (IS_MAP_ITEM(item)) ntotal += sizeof(map_meta_info);
         else /* BTREE_ITEM */       ntotal += sizeof(btree_meta_info);
     } else {
+#ifdef ENABLE_LARGE_ITEM
+        if (IS_LARGE_ITEM(item->nbytes)) {
+            ntotal += META_OFFSET_IN_ITEM(item->nkey, 2) + sizeof(list_meta_info);
+        } else {
+            ntotal += (item->nkey + item->nbytes);
+        }
+#else
         ntotal += (item->nkey + item->nbytes);
+#endif
     }
     return ntotal;
 }
@@ -146,7 +154,11 @@ static inline size_t ITEM_stotal(const hash_item *item)
 {
     size_t ntotal = ITEM_ntotal(item);
     size_t stotal = slabs_space_size(ntotal);
+#ifdef ENABLE_LARGE_ITEM
+    if (IS_COLL_ITEM(item) || IS_LARGE_ITEM(item->nbytes)) {
+#else
     if (IS_COLL_ITEM(item)) {
+#endif
         coll_meta_info *info = (coll_meta_info *)item_get_meta(item);
         stotal += info->stotal;
     }
@@ -967,6 +979,74 @@ hash_item *do_item_alloc(const void *key, const uint32_t nkey,
     return it;
 }
 
+#ifdef ENABLE_LARGE_ITEM
+hash_item *do_large_item_alloc(const void *key, const uint32_t nkey,
+                               const uint32_t flags, const rel_time_t exptime,
+                               const uint32_t nbytes, const void *cookie)
+{
+    assert(nkey > 0);
+    item_attr attrp;
+
+    attrp.flags = flags;
+    attrp.exptime = exptime;
+    attrp.maxcount = 0;
+    attrp.ovflaction = 0;
+    attrp.readable = 1;
+
+    return list_large_item_alloc(key, nkey, &attrp, nbytes, cookie);
+}
+
+ENGINE_ERROR_CODE do_large_item_attach(hash_item *old_it, hash_item *it,
+                                       uint64_t *cas, ENGINE_STORE_OPERATION operation,
+                                       const void *cookie)
+{
+    if (old_it->nbytes + it->nbytes > MAX_ITEM_VALUE_LENGTH) {
+        return ENGINE_E2BIG;
+    }
+    ENGINE_ERROR_CODE ret;
+
+    if (IS_LARGE_ITEM(old_it->nbytes)) {
+        ret = list_large_item_attach(old_it, it, operation, true, cookie);
+        if (ret == ENGINE_SUCCESS) {
+            /* link to the updated old item */
+            do_item_link(old_it);
+            *cas = item_get_cas(old_it);
+        }
+    } else {
+        /* new item allocate due to list_large_item_attach function */
+        hash_item *new_it = do_large_item_alloc(item_get_key(old_it), old_it->nkey, old_it->flags,
+                                                old_it->exptime, old_it->nbytes, cookie);
+        if (new_it == NULL) {
+            return ENGINE_ENOMEM;
+        }
+        /* copy old item to allocated new item */
+        char *data = item_get_data(old_it);
+        uint32_t total = old_it->nbytes;
+        uint32_t nbytes;
+        /* new_it->nbytes can be smaller than MIN_LARGE_ITEM_SIZE */
+        list_meta_info *info = (list_meta_info *)((char *)item_get_key(new_it) + META_OFFSET_IN_ITEM(new_it->nkey, 2));
+        list_elem_item *elem = info->head;
+
+        while (total > 0) {
+            nbytes = (total >= config->max_element_bytes ? config->max_element_bytes : total);
+            assert(elem != NULL);
+            memcpy(elem->value, data, nbytes);
+            data += nbytes;
+            elem = elem->next;
+            total -= nbytes;
+        }
+        assert(total == 0);
+        ret = list_large_item_attach(new_it, it, operation, false, cookie);
+        if (ret == ENGINE_SUCCESS) {
+            do_item_replace(old_it, new_it);
+            *cas = item_get_cas(new_it);
+        }
+    }
+
+    return ret;
+}
+#endif
+
 //static void do_item_free(hash_item *it)
 void do_item_free(hash_item *it)
 {
@@ -982,6 +1062,11 @@ void do_item_free(hash_item *it)
             return;
         }
     }
+#ifdef ENABLE_LARGE_ITEM
+    else if (IS_LARGE_ITEM(it->nbytes)) {
+        list_large_item_free(it);
+    }
+#endif
 
     /* so slab size changer can tell later if item is already free or not */
     DEBUG_REFCNT(it, 'F');
@@ -1019,7 +1104,13 @@ ENGINE_ERROR_CODE do_item_link(hash_item *it)
 
     /* link the item to LRU list */
     item_link_q(it);
+#ifdef ENABLE_LARGE_ITEM
+    if (!IS_LARGE_ITEM(it->nbytes)) {
+        CLOG_ITEM_LINK(it);
+    }
+#else
     CLOG_ITEM_LINK(it);
+#endif
 
     /* update item statistics */
     do_item_stat_link(it, stotal);
@@ -1036,7 +1127,13 @@ void do_item_unlink(hash_item *it, enum item_unlink_cause cause)
     MEMCACHED_ITEM_UNLINK(key, it->nkey, it->nbytes);
 
     if ((it->iflag & ITEM_LINKED) != 0) {
+#ifdef ENABLE_LARGE_ITEM
+        if (!IS_LARGE_ITEM(it->nbytes)) {
+            CLOG_ITEM_UNLINK(it, cause);
+        }
+#else
         CLOG_ITEM_UNLINK(it, cause);
+#endif
 
         /* unlink the item from LRU list */
         item_unlink_q(it);
@@ -1078,7 +1175,13 @@ void do_item_replace(hash_item *old_it, hash_item *new_it)
 
     assert((old_it->iflag & ITEM_LINKED) != 0);
 
+#ifdef ENABLE_LARGE_ITEM
+    if (!IS_LARGE_ITEM(old_it->nbytes)) {
+        CLOG_ITEM_UNLINK(old_it, ITEM_UNLINK_REPLACE);
+    }
+#else
     CLOG_ITEM_UNLINK(old_it, ITEM_UNLINK_REPLACE);
+#endif
 
     /* unlink the item from LRU list */
     item_unlink_q(old_it);
@@ -1127,7 +1230,13 @@ void do_item_replace(hash_item *old_it, hash_item *new_it)
 
     /* link the item to LRU list */
     item_link_q(new_it);
+#ifdef ENABLE_LARGE_ITEM
+    if (!IS_LARGE_ITEM(new_it->nbytes)) {
+        CLOG_ITEM_LINK(new_it);
+    }
+#else
     CLOG_ITEM_LINK(new_it);
+#endif
 }
 
 //static void do_item_update(hash_item *it, bool force)
@@ -1369,9 +1478,15 @@ char* item_get_data(const hash_item* item)
 
 const void* item_get_meta(const hash_item* item)
 {
+#ifdef ENABLE_LARGE_ITEM
+    if (IS_COLL_ITEM(item) || IS_LARGE_ITEM(item->nbytes))
+        return (void*)((char*)item_get_key(item) +
+                       META_OFFSET_IN_ITEM(item->nkey, 2)); /* "\r\n" */
+#else
     if (IS_COLL_ITEM(item))
         return (void*)((char*)item_get_key(item) +
                        META_OFFSET_IN_ITEM(item->nkey, item->nbytes));
+#endif
     else
         return NULL;
 }

--- a/engines/default/item_base.h
+++ b/engines/default/item_base.h
@@ -116,6 +116,9 @@ enum elem_delete_cause {
 #define IS_SET_ITEM(it)   (((it)->iflag & ITEM_IFLAG_COLL) == ITEM_IFLAG_SET)
 #define IS_MAP_ITEM(it)   (((it)->iflag & ITEM_IFLAG_COLL) == ITEM_IFLAG_MAP)
 #define IS_BTREE_ITEM(it) (((it)->iflag & ITEM_IFLAG_COLL) == ITEM_IFLAG_BTREE)
+#ifdef ENABLE_LARGE_ITEM
+#define IS_LARGE_ITEM(nbytes) ((nbytes) >= LARGE_ITEM_VALUE_LENGTH)
+#endif
 #define IS_COLL_ITEM(it)  (((it)->iflag & ITEM_IFLAG_COLL) != 0)
 
 /* collection meta flag */
@@ -376,6 +379,14 @@ void  do_item_mem_free(void *item, size_t ntotal);
 hash_item *do_item_alloc(const void *key, const uint32_t nkey,
                          const uint32_t flags, const rel_time_t exptime,
                          const uint32_t nbytes, const void *cookie);
+#ifdef ENABLE_LARGE_ITEM
+hash_item *do_large_item_alloc(const void *key, const uint32_t nkey,
+                               const uint32_t flags, const rel_time_t exptime,
+                               const uint32_t nbytes, const void *cookie);
+ENGINE_ERROR_CODE do_large_item_attach(hash_item *old_it, hash_item *new_it,
+                                       uint64_t *cas, ENGINE_STORE_OPERATION operation,
+                                       const void *cookie);
+#endif
 void       do_item_free(hash_item *it);
 
 ENGINE_ERROR_CODE do_item_link(hash_item *it);

--- a/memcached.c
+++ b/memcached.c
@@ -3040,6 +3040,12 @@ process_get_single(conn *c, char *key, size_t nkey, bool return_cas)
         /* item_get() has incremented it->refcount for us */
         STATS_HITS(c, get, key, nkey);
         MEMCACHED_COMMAND_GET(c->sfd, key, nkey, c->hinfo.nbytes, c->hinfo.cas);
+#ifdef ENABLE_LARGE_ITEM
+        if (c->hinfo.addnl != NULL) {
+            free(c->hinfo.addnl);
+            c->hinfo.addnl = NULL;
+        }
+#endif
     } else {
         STATS_MISSES(c, get, key, nkey);
         MEMCACHED_COMMAND_GET(c->sfd, key, nkey, -1, 0);
@@ -3282,6 +3288,12 @@ static void complete_update_ascii(conn *c)
     }
     c->store_op = 0;
     c->item = 0;
+#ifdef ENABLE_LARGE_ITEM
+    if (c->hinfo.addnl != NULL) {
+        free(c->hinfo.addnl);
+        c->hinfo.addnl = NULL;
+    }
+#endif
 }
 
 /**


### PR DESCRIPTION
Large value (1MB 이상) 저장 기능을 구현하였습니다.

- kv set 요청에서 1MB 이상의 value 가 요청되었을 때 lop 를 사용하여 데이터를 저장하게 수정하였습니다.
- 기존 단일 list element 로 할당되던 list 요청을 다중 list element 로 할당받을 수 있도록 수정하였습니다.
- 사용자의 입력 값을 ritem 에 read 하던 처리를 large value 로 요청 받았을때 다중 list element 에 연결하기 위한 large_item (read 버퍼 배열) 구조체를 추가하였습니다.
- 위의 large_item 타입의 버퍼에 사용자 데이터를 읽어올수 있도록 수정하였습니다.