### PR TITLE
 FEATURE: added stats zookeeper command.

### DIFF
--- a/arcus_zk.c
+++ b/arcus_zk.c
@@ -1707,11 +1707,17 @@ bool arcus_zk_get_failstop(void)
 void arcus_zk_get_stats(arcus_zk_stats *stats)
 {
     stats->zk_connected = (main_zk != NULL && main_zk->zh != NULL) ? true : false;
+#ifdef ENABLE_ZK_RECONFIG
+    stats->zk_reconfig_version = sm_info.zkconfig_version;
+#endif
 }
 
 void arcus_zk_get_confs(arcus_zk_confs *confs)
 {
     confs->zk_failstop = arcus_conf.zk_failstop;
+#ifdef ENABLE_ZK_RECONFIG
+    confs->zk_reconfig = arcus_conf.zk_reconfig;
+#endif
     confs->zk_timeout = arcus_conf.zk_timeout;
 }
 

--- a/arcus_zk.h
+++ b/arcus_zk.h
@@ -26,10 +26,16 @@
 
 typedef struct {
     bool     zk_connected;  // ZooKeeper-memcached connection state
+#ifdef ENABLE_ZK_RECONFIG
+    int64_t  zk_reconfig_version; // Zookeeper dynamic reconfiguration version
+#endif
 } arcus_zk_stats;
 
 typedef struct {
     bool     zk_failstop;   // memcached automatic failstop
+#ifdef ENABLE_ZK_RECONFIG
+    bool     zk_reconfig;   // Zookeeper dynamic reconfiguration
+#endif
     uint32_t zk_timeout;    // Zookeeper session timeout (unit: ms)
 } arcus_zk_confs;
 

--- a/memcached.c
+++ b/memcached.c
@@ -8025,6 +8025,12 @@ static void process_stat_zookeeper(ADD_STAT add_stats, void *c)
     APPEND_STAT("zk_connected", "%s", zk_stats.zk_connected ? "true" : "false");
     APPEND_STAT("zk_failstop", "%s", zk_confs.zk_failstop ? "on" : "off");
     APPEND_STAT("zk_timeout", "%u", zk_confs.zk_timeout);
+#ifdef ENABLE_ZK_RECONFIG
+    APPEND_STAT("zk_reconfig", "%s", zk_confs.zk_reconfig ? "on" : "off");
+    if (zk_confs.zk_reconfig) {
+        APPEND_STAT("zk_reconfig_version", "%" PRIx64, zk_stats.zk_reconfig_version);
+    }
+#endif
 }
 #endif
 static void process_stat_settings(ADD_STAT add_stats, void *c)


### PR DESCRIPTION
zookeeper 상태 조회 전용 명령을 추가하였습니다. (issue : https://github.com/jam2in/arcus-works/issues/277#issuecomment-819324187)
해당 명령에서 zk reconfig 상태도 조회할 수 있습니다.
```
stats zookeeper 
STAT zk_connected true
STAT zk_failstop on
STAT zk_timeout 30000
STAT zk_reconfig on
STAT zk_reconfig_version 100000000
```

두 개의 커밋으로 PR 하였습니다. 
첫번째는 zookeeper 상태 조회 전용 명령 추가 두번째는 zk reconfig 상태 조회를 추가하였습니다.