### PR TITLE
FIX: need to clear elems_result in process_bop_mget_single() when ret…

### DIFF
--- a/engines/default/coll_btree.c
+++ b/engines/default/coll_btree.c
@@ -3910,9 +3910,6 @@ ENGINE_ERROR_CODE btree_elem_get(const char *key, const uint32_t nkey,
                                                         : UPD_BT_ELEM_DELETE));
     }
 
-    eresult->elem_array = NULL;
-    eresult->elem_count = 0;
-
     LOCK_CACHE();
     ret = do_btree_item_find(key, nkey, DO_UPDATE, &it);
     if (ret == ENGINE_SUCCESS) {
@@ -4045,9 +4042,6 @@ ENGINE_ERROR_CODE btree_posi_find_with_get(const char *key, const uint32_t nkey,
     int bkrtype = do_btree_bkey_range_type(bkrange);
     assert(bkrtype == BKEY_RANGE_TYPE_SIN);
 
-    eresult->elem_array = NULL;
-    eresult->elem_count = 0;
-
     LOCK_CACHE();
     ret = do_btree_item_find(key, nkey, DO_UPDATE, &it);
     if (ret == ENGINE_SUCCESS) {
@@ -4091,9 +4085,6 @@ ENGINE_ERROR_CODE btree_elem_get_by_posi(const char *key, const uint32_t nkey,
     assert(from_posi >= 0 && to_posi >= 0);
     hash_item *it;
     ENGINE_ERROR_CODE ret;
-
-    eresult->elem_array = NULL;
-    eresult->elem_count = 0;
 
     LOCK_CACHE();
     ret = do_btree_item_find(key, nkey, DO_UPDATE, &it);

--- a/engines/default/coll_list.c
+++ b/engines/default/coll_list.c
@@ -541,9 +541,6 @@ ENGINE_ERROR_CODE list_elem_get(const char *key, const uint32_t nkey,
                                                         : UPD_LIST_ELEM_DELETE));
     }
 
-    eresult->elem_array = NULL;
-    eresult->elem_count = 0;
-
     LOCK_CACHE();
     ret = do_list_item_find(key, nkey, DO_UPDATE, &it);
     if (ret == ENGINE_SUCCESS) {

--- a/engines/default/coll_map.c
+++ b/engines/default/coll_map.c
@@ -887,9 +887,6 @@ ENGINE_ERROR_CODE map_elem_get(const char *key, const uint32_t nkey,
                                                         : UPD_MAP_ELEM_DELETE));
     }
 
-    eresult->elem_array = NULL;
-    eresult->elem_count = 0;
-
     LOCK_CACHE();
     ret = do_map_item_find(key, nkey, DO_UPDATE, &it);
     if (ret == ENGINE_SUCCESS) {

--- a/engines/default/coll_set.c
+++ b/engines/default/coll_set.c
@@ -809,9 +809,6 @@ ENGINE_ERROR_CODE set_elem_get(const char *key, const uint32_t nkey,
                                                         : UPD_SET_ELEM_DELETE));
     }
 
-    eresult->elem_array = NULL;
-    eresult->elem_count = 0;
-
     LOCK_CACHE();
     ret = do_set_item_find(key, nkey, DO_UPDATE, &it);
     if (ret == ENGINE_SUCCESS) {

--- a/engines/default/default_engine.c
+++ b/engines/default/default_engine.c
@@ -533,6 +533,9 @@ default_list_elem_get(ENGINE_HANDLE* handle, const void* cookie,
     ENGINE_ERROR_CODE ret;
     VBUCKET_GUARD(engine, vbucket);
 
+    eresult->elem_array = NULL;
+    eresult->elem_count = 0;
+
     if (delete) ACTION_BEFORE_WRITE(cookie, key, nkey);
     else        ACTION_BEFORE_READ(cookie, key, nkey);
     ret = list_elem_get(key, nkey, from_index, to_index, delete, drop_if_empty,
@@ -653,6 +656,9 @@ default_set_elem_get(ENGINE_HANDLE* handle, const void* cookie,
     ENGINE_ERROR_CODE ret;
     VBUCKET_GUARD(engine, vbucket);
 
+    eresult->elem_array = NULL;
+    eresult->elem_count = 0;
+
     if (delete) ACTION_BEFORE_WRITE(cookie, key, nkey);
     else        ACTION_BEFORE_READ(cookie, key, nkey);
     ret = set_elem_get(key, nkey, count, delete, drop_if_empty,
@@ -771,6 +777,9 @@ default_map_elem_get(ENGINE_HANDLE* handle, const void* cookie,
     struct default_engine *engine = get_handle(handle);
     ENGINE_ERROR_CODE ret;
     VBUCKET_GUARD(engine, vbucket);
+
+    eresult->elem_array = NULL;
+    eresult->elem_count = 0;
 
     if (delete) ACTION_BEFORE_WRITE(cookie, key, nkey);
     else        ACTION_BEFORE_READ(cookie, key, nkey);
@@ -932,6 +941,9 @@ default_btree_elem_get(ENGINE_HANDLE* handle, const void* cookie,
     ENGINE_ERROR_CODE ret;
     VBUCKET_GUARD(engine, vbucket);
 
+    eresult->elem_array = NULL;
+    eresult->elem_count = 0;
+
     if (delete) ACTION_BEFORE_WRITE(cookie, key, nkey);
     else        ACTION_BEFORE_READ(cookie, key, nkey);
     ret = btree_elem_get(key, nkey, bkrange, efilter, offset, req_count,
@@ -984,6 +996,9 @@ default_btree_posi_find_with_get(ENGINE_HANDLE* handle, const void* cookie,
     ENGINE_ERROR_CODE ret;
     VBUCKET_GUARD(engine, vbucket);
 
+    eresult->elem_array = NULL;
+    eresult->elem_count = 0;
+
     ACTION_BEFORE_READ(cookie, key, nkey);
     ret = btree_posi_find_with_get(key, nkey, bkrange, order, count,
                                    position, eresult);
@@ -999,6 +1014,9 @@ default_btree_elem_get_by_posi(ENGINE_HANDLE* handle, const void* cookie,
     struct default_engine *engine = get_handle(handle);
     ENGINE_ERROR_CODE ret;
     VBUCKET_GUARD(engine, vbucket);
+
+    eresult->elem_array = NULL;
+    eresult->elem_count = 0;
 
     ACTION_BEFORE_READ(cookie, key, nkey);
     ret = btree_elem_get_by_posi(key, nkey, order, from_posi, to_posi, eresult);


### PR DESCRIPTION
enterprise 의 경우 ACTION_BEFORE_XX 에서 btree_elem_get() 을 호출하기 전에 리턴될 수 있습니다. 그럴 경우에 btree_elem_get() 에서 수행하는 eresult 초기화 (eresult->elem_array = NULL; eresult->elem_count = 0; ) 를 수행하지 못합니다.

```
 static ENGINE_ERROR_CODE
 default_btree_elem_get(ENGINE_HANDLE* handle, const void* cookie,
                        const void* key, const int nkey,
                        const bkey_range *bkrange, const eflag_filter *efilter,
                        const uint32_t offset, const uint32_t req_count,
                        const bool delete, const bool drop_if_empty,
                        struct elems_result *eresult, uint16_t vbucket)
 {
     struct default_engine *engine = get_handle(handle);
     ENGINE_ERROR_CODE ret;
     VBUCKET_GUARD(engine, vbucket);

     if (strncmp(key, "b0", 2) == 0) {
         return ENGINE_NOT_MY_KEY;
     }
     if (delete) ACTION_BEFORE_WRITE(cookie, key, nkey);
     else        ACTION_BEFORE_READ(cookie, key, nkey);
     ret = btree_elem_get(key, nkey, bkrange, efilter, offset, req_count,
                          delete, drop_if_empty, eresult, cookie);
     if (delete) ACTION_AFTER_WRITE(cookie, engine, ret);
     return ret;
 }
```

eresult 초기화를 하지 못한다면 아래 함수에서 elem_array 에 접근하게 되어 malloc 하지 않았는데 free 하는 등 undefined behavior 하는 문제가 있습니다.
```
static void conn_coll_eitem_free(conn *c)
 {
     switch (c->coll_op) {
...

 #ifdef SUPPORT_BOP_MGET
       case OPERATION_BOP_MGET:
         for (int k = 0; k < c->coll_numkeys; k++) {
             struct elems_result *eresptr = &((struct elems_result*)c->coll_eitem)[k];
             if (eresptr->elem_array != NULL) {
                 mc_engine.v1->btree_elem_release(mc_engine.v0, c,
                                                  eresptr->elem_array, eresptr->elem_count);
                 free(eresptr->elem_array);
                 eresptr->elem_array = NULL;
             }
         }
         free(c->coll_eitem);
         break;
 #endif
```

실제로 ACTION_BEFORE_XXX 에서 리턴되게끔 코드를 임의로 수정하여 테스트하여 문제 재현도 확인하였습니다.