### PR TITLE
INTERNAL: Added memory pool function as example code

### DIFF
--- a/engines/default/mem_pool.c
+++ b/engines/default/mem_pool.c
@@ -1,0 +1,124 @@
+/* -*- Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ * arcus-memcached - Arcus memory cache server
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2015-current JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef ENABLE_LARGE_ITEM
+
+#include "config.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <pthread.h>
+
+#include "mem_pool.h"
+
+static large_pa_pool_t *pool;
+
+/* Large Pointer Array Pool Lock */
+static inline void LOCK_POINTER_ARRAY_POOL(void)
+{
+    pthread_mutex_lock(&pool->large_pa_pool_lock);
+}
+
+static inline void UNLOCK_POINTER_ARRAY_POOL(void)
+{
+    pthread_mutex_unlock(&pool->large_pa_pool_lock);
+}
+
+void pointer_array_pool_init(void)
+{
+    pool = (large_pa_pool_t *)malloc(sizeof(large_pa_pool_t));
+    pool->large_pa_pool = (large_pa *)malloc(sizeof(large_pa) * MAX_LARGE_POINTER_ARRAY_POOL);
+    pool->used_cnt = 0;
+    pool->pool_size = MAX_LARGE_POINTER_ARRAY_POOL;
+
+    for (int i = 0; i < pool->pool_size; i++) {
+        // -1 is unallocated state
+        pool->large_pa_pool[i].pool_id = -1;
+        pool->large_pa_pool[i].addnl = (value_item **)malloc(sizeof(value_item *) * LARGE_POINTER_ARRAY_LENGTH);
+    }
+    pthread_mutex_init(&pool->large_pa_pool_lock, NULL);
+}
+
+void pointer_array_pool_final(void)
+{
+    pthread_mutex_destroy(&pool->large_pa_pool_lock);
+    for (int i = 0; i < pool->pool_size; i++) {
+        free(pool->large_pa_pool[i].addnl);
+    }
+    free(pool->large_pa_pool);
+    free(pool);
+}
+
+/*
+ It's -1 that pool id is not allocated state. When it's 0, new memory allocated state.
+ otherwise if it's positive number are allocated memory from the pool.
+ */
+static void do_pointer_array_pool_alloc(large_pa *pa, uint32_t elem_count)
+{
+    if (elem_count <= LARGE_POINTER_ARRAY_LENGTH &&
+        pool->used_cnt < MAX_LARGE_POINTER_ARRAY_POOL) {
+        for (int i = 0; i < pool->pool_size; i++) {
+            if (pool->large_pa_pool[i].pool_id == -1) {
+                pool->large_pa_pool[i].pool_id = i + 1;
+                pa->pool_id = i + 1;
+                pa->addnl = pool->large_pa_pool[i].addnl;
+                pool->used_cnt++;
+                break;
+            }
+        }
+    } else {
+        pa->pool_id = 0;
+        pa->addnl = (value_item **)malloc(sizeof(value_item *) * elem_count);
+    }
+}
+
+void pointer_array_pool_alloc(large_pa *pa, uint32_t elem_count)
+{
+    assert(pa->addnl == NULL);
+    assert(elem_count > 0);
+    LOCK_POINTER_ARRAY_POOL();
+    do_pointer_array_pool_alloc(pa, elem_count);
+    UNLOCK_POINTER_ARRAY_POOL();
+}
+
+static void do_pointer_array_free(large_pa *pa)
+{
+    assert(pa->pool_id > 0 && pa->pool_id <= LARGE_POINTER_ARRAY_LENGTH);
+    pool->large_pa_pool[pa->pool_id - 1].pool_id = -1;
+    pool->used_cnt--;
+    pa->pool_id = -1;
+    pa->addnl = NULL;
+}
+
+void pointer_array_free(large_pa *pa)
+{
+    assert(pa->addnl != NULL);
+    if (pa->pool_id == 0) {
+        free(pa->addnl);
+        pa->pool_id = -1;
+        pa->addnl = NULL;
+    } else {
+        LOCK_POINTER_ARRAY_POOL();
+        do_pointer_array_free(pa);
+        UNLOCK_POINTER_ARRAY_POOL();
+    }
+}
+
+#endif

--- a/engines/default/mem_pool.h
+++ b/engines/default/mem_pool.h
@@ -1,0 +1,48 @@
+/*
+ * arcus-memcached - Arcus memory cache server
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2015-current JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MEM_POOL_H
+#define MEM_POOL_H
+
+#include <memcached/types.h>
+
+#ifdef ENABLE_LARGE_ITEM
+
+#define LARGE_POINTER_ARRAY_LENGTH      1024 // 16MB
+#define MAX_LARGE_POINTER_ARRAY_POOL    1000
+
+typedef struct {
+    uint32_t     pool_id;
+    value_item **addnl;
+} large_pa;
+
+typedef struct {
+    uint32_t         used_cnt;
+    uint32_t         pool_size;
+    large_pa        *large_pa_pool;
+    pthread_mutex_t  large_pa_pool_lock;
+} large_pa_pool_t;
+
+/* mem pool functions */
+void pointer_array_pool_init(void);
+void pointer_array_pool_final(void);
+void pointer_array_pool_alloc(large_pa *pa, uint32_t elem_count);
+void pointer_array_free(large_pa *pa);
+
+#endif
+
+#endif


### PR DESCRIPTION
Large item 저장 과정에서 필요한 memory pool 코드를 추가하였습니다.

- memory pool 은 한번에 최대 16MB 크기의 large item을 담을 수 있습니다.
- pool 은 한번에 1000개까지 동시에 사용될 수 있습니다.
- pool 의 각 pointer array에 대한 할당 상태 확인은 pool_id 값을 통해 확인합니다.
  - pool_id 가 -1 이면 할당되지 않은 상태, 0 이면 pool 외에 새로 malloc 한 상태, 양수이면 pool 에서 사용중이지 않은 메모리를 할당 받은 상태입니다.
- pool 의 공간이 모두 사용되었거나 pool 에서 제공하는 공간보다 큰(16MB 이상) large item 이 요청되면 새로 malloc을 해서 공간을 할당해줍니다.