### PR TITLE
FIX: fixed format-truncation compile error in arcus_zk.c

### DIFF
--- a/arcus_zk.c
+++ b/arcus_zk.c
@@ -630,7 +630,7 @@ arcus_zk_log(zhandle_t *zh, const char *action)
     int     rc;
     char    zpath[200] = "";
     char    rcbuf[200] = "";
-    char    sbuf[200] = "";
+    char    sbuf[128] = "";
 
     struct timeval now;
     struct tm      *ltm;


### PR DESCRIPTION
gcc 상위버전으로 컴파일하면 다음 에러가 발생합니다.
```
arcus_zk.c: In function ‘arcus_create_ephemeral_znode.part.1’:
arcus_zk.c:645:43: error: ‘%s’ directive output may be truncated writing up to 199 bytes into a region of size 182 [-Werror=format-truncation=]
     snprintf(zpath, sizeof(zpath), "%s/%s/%s", zk_root, zk_log_dir, sbuf);
                                           ^~                        ~~~~
arcus_zk.c:645:5: note: ‘snprintf’ output 19 or more bytes (assuming 218) into a destination of size 200
     snprintf(zpath, sizeof(zpath), "%s/%s/%s", zk_root, zk_log_dir, sbuf);
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
arcus_zk.c:659:47: error: ‘%s’ directive output may be truncated writing up to 199 bytes into a region of size 182 [-Werror=format-truncation=]
         snprintf(zpath, sizeof(zpath), "%s/%s/%s/%s-",
                                               ^~
                  zk_root, zk_log_dir, sbuf, arcus_conf.znode_name);
                                       ~~~~
arcus_zk.c:659:9: note: ‘snprintf’ output 21 or more bytes (assuming 220) into a destination of size 200
         snprintf(zpath, sizeof(zpath), "%s/%s/%s/%s-",
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                  zk_root, zk_log_dir, sbuf, arcus_conf.znode_name);
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

zpath 의 버퍼 크기는 200 인데, snprintf 로 입력되는 문자열 크기는 200이 넘을 수 있기 때문에 truncate 될 수 있다는 에러가 발생합니다.
위 에러를 무시하는 컴파일 옵션을 넣어 해결할 수도 있긴 하지만, 안전하게 zpath 크기를 늘리는 것으로 수정하였습니다.
