### PR TITLE
FIX: libarcuszk.a sets memcached_DEPENDENCIES for compile ahead.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -123,6 +123,7 @@ memcached_SOURCES += $(demo_engine_la_SOURCES)
 endif
 
 if BUILD_ZK_INTEGRATION
+memcached_DEPENDENCIES += libarcuszk.a
 memcached_SOURCES += arcus_zk.h arcus_hb.h
 memcached_LDADD += libarcuszk.a -lzookeeper_mt
 noinst_LIBRARIES = libarcuszk.a


### PR DESCRIPTION
CentOS8 환경에서 make 시 libarcuszk.a : No such file or directory 에러 https://github.com/jam2in/arcus-works/issues/296

상위 빌드 툴에서는 PROGRAMS가 LIBRARIES 보다 먼저 compile 되므로 
```
all-am: Makefile $(PROGRAMS) $(LIBRARIES) $(LTLIBRARIES) $(DATA) \
                $(HEADERS) config.h
```
libarcuszk.a 를 DEPENDENCIES 에 추가하여 먼저 컴파일 되도록 하였습니다.

참고로, CentOS7에서는 아래 순서로 만들어집니다.
```
all-am: Makefile $(LIBRARIES) $(LTLIBRARIES) $(PROGRAMS) $(DATA) \
        $(HEADERS) config.h
```