### PR TITLE
FIX: handled memory allocation failure for connection object.

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -607,6 +607,12 @@ void dispatch_conn_new(int sfd, STATE_FUNC init_state, int event_flags,
                        int read_buffer_size, enum network_transport transport)
 {
     CQ_ITEM *item = cqi_new();
+    if (item == NULL) {
+        close(sfd);
+        mc_logger->log(EXTENSION_LOG_WARNING, NULL,
+                       "Failed to allocate memory for connection object.\n");
+        return;
+    }
     int tid = (last_thread + 1) % settings.num_threads;
 
     LIBEVENT_THREAD *thread = threads + tid;


### PR DESCRIPTION
cqi_new() 에서 malloc 실패하면 item 은 NULL 이 됩니다.
이후 수행하는 item access 시에 segfault 발생할 수 있는 문제가 있습니다.

참고) memcached.c open source code :
- thread.c : https://github.com/memcached/memcached/blob/master/thread.c#L670
