### PR TITLE
FIX: missing to set logger in lqdetect.

### DIFF
--- a/lqdetect.c
+++ b/lqdetect.c
@@ -78,8 +78,9 @@ static void do_lqdetect_stop(int cause)
     lqdetect.on_detecting = false;
 }
 
-int lqdetect_init()
+int lqdetect_init(EXTENSION_LOGGER_DESCRIPTOR *logger)
 {
+    mc_logger = logger;
     int ii, jj;
     pthread_mutex_init(&lqdetect.lock, NULL);
     lqdetect.on_detecting = false;

--- a/lqdetect.h
+++ b/lqdetect.h
@@ -47,7 +47,7 @@ struct lq_detect_stats {
     uint32_t standard;
 };
 
-int lqdetect_init(void);
+int lqdetect_init(EXTENSION_LOGGER_DESCRIPTOR *logger);
 void lqdetect_final(void);
 char *lqdetect_buffer_get(int cmd, uint32_t *length, uint32_t *cmdcnt);
 void lqdetect_buffer_release(int bufcnt);

--- a/memcached.c
+++ b/memcached.c
@@ -15405,7 +15405,7 @@ int main (int argc, char **argv)
 
 #ifdef DETECT_LONG_QUERY
     /* initialize long query detection */
-    if (lqdetect_init() == -1) {
+    if (lqdetect_init(mc_logger) == -1) {
         mc_logger->log(EXTENSION_LOG_WARNING, NULL,
                 "Can't allocate long query detection buffer\n");
         exit(EXIT_FAILURE);


### PR DESCRIPTION
lqdetect 모듈에서 mc_logger 설정하지 않고 사용하는 문제가 있습니다.