### PR TITLE
FEATURE: supported large value set feature

### DIFF
--- a/engines/default/coll_list.h
+++ b/engines/default/coll_list.h
@@ -20,6 +20,21 @@
 
 #include "item_base.h"
 
+#ifdef ENABLE_LARGE_ITEM
+/*
+ * Large item created with a list structure internally
+ */
+hash_item *list_large_item_alloc(const void* key, const int nkey,
+                                 item_attr *attrp, uint32_t nbytes,
+                                 const void *cookie);
+
+ENGINE_ERROR_CODE list_large_item_attach(hash_item *it, hash_item *new_it,
+                                         ENGINE_STORE_OPERATION operation, bool update,
+                                         const void *cookie);
+
+uint32_t large_elem_delete_with_count(list_meta_info *info, const uint32_t count);
+#endif
+
 /*
  * List Collection
  */

--- a/engines/default/default_engine.c
+++ b/engines/default/default_engine.c
@@ -317,11 +317,17 @@ default_item_allocate(ENGINE_HANDLE* handle, const void* cookie,
                       const int flags, const rel_time_t exptime,
                       const uint64_t cas)
 {
+#ifdef ENABLE_LARGE_ITEM
+    if (nbytes > MAX_ITEM_VALUE_LENGTH) {
+        return ENGINE_E2BIG;
+    }
+#else
     uint32_t ntotal = item_kv_size(nkey, nbytes);
     unsigned int id = slabs_clsid(ntotal);
     if (id == 0) {
         return ENGINE_E2BIG;
     }
+#endif
 
     hash_item *it;
     ENGINE_ERROR_CODE ret = ENGINE_EINVAL;
@@ -1660,6 +1666,45 @@ default_scrub_stale(ENGINE_HANDLE* handle)
 
 /* Item/Elem Info */
 
+#ifdef ENABLE_LARGE_ITEM
+static bool
+get_large_item_info(hash_item *it, item_info *item_info)
+{
+    int count = 0;
+    list_meta_info *info = (list_meta_info *)item_get_meta(it);
+    list_elem_item *elem = info->head;
+
+    item_info->naddnl = info->ccnt + 1;
+    item_info->nvalue = 0;
+
+    if (item_info->addnl == NULL) {
+        item_info->addnl = (value_item **)malloc(sizeof(value_item *) * item_info->naddnl);
+        if (item_info->addnl == NULL) {
+            return false;
+        }
+    } else {
+        free(item_info->addnl);
+        item_info->addnl = (value_item **)malloc(sizeof(value_item *) * item_info->naddnl);
+        if (item_info->addnl == NULL) {
+            return false;
+        }
+    }
+
+    while (elem != NULL) {
+        item_info->addnl[count] = (value_item *)((char *)elem + offsetof(list_elem_item, nbytes));
+        item_info->addnl[count]->len = elem->nbytes;
+        count++;
+        elem = elem->next;
+    }
+    item_info->addnl[count] = (value_item *)((char *)item_get_key(it)
+                            + META_OFFSET_IN_ITEM(it->nkey, 2) + sizeof(list_meta_info));
+    count++;
+    assert(count == item_info->naddnl);
+
+    return true;
+}
+#endif
+
 static bool
 get_item_info(ENGINE_HANDLE *handle, const void *cookie,
               const item* item, item_info *item_info)
@@ -1676,7 +1721,15 @@ get_item_info(ENGINE_HANDLE *handle, const void *cookie,
     item_info->naddnl = 0;
     item_info->key = item_get_key(it);
     item_info->value = item_get_data(it);
+#ifdef ENABLE_LARGE_ITEM
+    if (IS_LARGE_SIZE(it->nbytes)) {
+        return get_large_item_info(it, item_info);
+    } else {
+        item_info->addnl = NULL;
+    }
+#else
     item_info->addnl = NULL;
+#endif
     return true;
 }
 

--- a/engines/default/default_engine.h
+++ b/engines/default/default_engine.h
@@ -43,6 +43,10 @@ struct default_engine;
 
 #define MAX_FILEPATH_LENGTH 4096
 #define MAX_FILENAME_LENGTH 256
+#ifdef ENABLE_LARGE_ITEM
+#define MAX_ITEM_VALUE_LENGTH   60 * 1024 * 1024
+#define LARGE_ITEM_VALUE_LENGTH 64 * 1024
+#endif
 
 /**
  * engine configuration

--- a/engines/default/item_base.h
+++ b/engines/default/item_base.h
@@ -116,6 +116,9 @@ enum elem_delete_cause {
 #define IS_SET_ITEM(it)   (((it)->iflag & ITEM_IFLAG_COLL) == ITEM_IFLAG_SET)
 #define IS_MAP_ITEM(it)   (((it)->iflag & ITEM_IFLAG_COLL) == ITEM_IFLAG_MAP)
 #define IS_BTREE_ITEM(it) (((it)->iflag & ITEM_IFLAG_COLL) == ITEM_IFLAG_BTREE)
+#ifdef ENABLE_LARGE_ITEM
+#define IS_LARGE_SIZE(nbytes) ((nbytes) >= LARGE_ITEM_VALUE_LENGTH)
+#endif
 #define IS_COLL_ITEM(it)  (((it)->iflag & ITEM_IFLAG_COLL) != 0)
 
 /* collection meta flag */
@@ -377,6 +380,16 @@ hash_item *do_item_alloc(const void *key, const uint32_t nkey,
                          const uint32_t flags, const rel_time_t exptime,
                          const uint32_t nbytes, const void *cookie);
 void       do_item_free(hash_item *it);
+
+#ifdef ENABLE_LARGE_ITEM
+/* large item functions */
+hash_item *do_large_item_alloc(const void *key, const uint32_t nkey,
+                               const uint32_t flags, const rel_time_t exptime,
+                               const uint32_t nbytes, const void *cookie);
+ENGINE_ERROR_CODE do_large_item_attach(hash_item *old_it, hash_item *new_it,
+                                       uint64_t *cas, ENGINE_STORE_OPERATION operation,
+                                       const void *cookie);
+#endif
 
 ENGINE_ERROR_CODE do_item_link(hash_item *it);
 void              do_item_unlink(hash_item *it, enum item_unlink_cause cause);

--- a/engines/default/items.c
+++ b/engines/default/items.c
@@ -191,6 +191,11 @@ static ENGINE_ERROR_CODE do_item_store_attach(hash_item *it, uint64_t *cas,
                item_get_cas(it) != item_get_cas(old_it)) {
         // CAS much be equal
         stored = ENGINE_KEY_EEXISTS;
+#ifdef ENABLE_LARGE_ITEM
+    } else if (IS_LARGE_SIZE(it->nbytes) || IS_LARGE_SIZE(old_it->nbytes) ||
+               IS_LARGE_SIZE(it->nbytes + old_it->nbytes)) {
+        stored = do_large_item_attach(old_it, it, cas, operation, cookie);
+#endif
     } else {
         /* we have it and old_it here - alloc memory to hold both */
         hash_item *new_it = do_item_alloc(item_get_key(it), it->nkey,
@@ -284,7 +289,15 @@ hash_item *item_alloc(const void *key, const uint32_t nkey,
     hash_item *it;
     LOCK_CACHE();
     /* key can be NULL */
+#ifdef ENABLE_LARGE_ITEM
+    if (IS_LARGE_SIZE(nbytes)) {
+        it = do_large_item_alloc(key, nkey, flags, exptime, nbytes, cookie);
+    } else {
+        it = do_item_alloc(key, nkey, flags, exptime, nbytes, cookie);
+    }
+#else
     it = do_item_alloc(key, nkey, flags, exptime, nbytes, cookie);
+#endif
     UNLOCK_CACHE();
     return it;
 }


### PR DESCRIPTION
Large value item 저장 기능을 추가하였습니다.

- large value 요청으로 최소 64KB 이상, 최대 64MB 이하 크기의 item 까지 지원하도록 설계하였습니다.
- large value를 저장할 때 내부 구현체는 list를 활용하였기 때문에 기존 list 함수들을 응용할 수 있도록 수정하였습니다.
기존 key value item에 대한 기능(set, get, delete, add, relace, attach, cas)들을 지원하도록 구현하였습니다.
- large item의 element에 대한 삭제 요청은 일반 collection item과 동일하게 collection_delete_thread()에서 처리하도록 구현하였습니다.
- large item의 hash item은 기존 list의 hash item 구조에서 CRLF 정보(value_item 타입)를 추가한 구조로 설계하였습니다.
large item의 저장 구조입니다.
![image](https://user-images.githubusercontent.com/22315365/127263308-62c354d3-e85f-4aaa-a87a-181e2130f35e.png)

관련 추가 기능에 대한 진행은 아래와 같습니다.

- CLOG 관련 동작은 다른 pr에서 요청할 예정입니다. 현재 large item일 때는 CLOG 동작 수행하지 않도록 구현하였습니다.
- large value 의 값을 임시 저장할 버퍼에 대한 pointer array pool 관련 코드는 다른 pr에서 요청할 예정입니다. 현재 임시로 구동할 수 있게 구현하였습니다.