### PR TITLE
INTERNAL: replaced event_init() to event_base_new().

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -15352,7 +15352,7 @@ int main (int argc, char **argv)
     }
 
     /* initialize main thread libevent instance */
-    main_base = event_init();
+    main_base = event_base_new();
 
     /* initialize other stuff */
     stats_init();
@@ -15572,6 +15572,7 @@ int main (int argc, char **argv)
         free(settings.inter);
     }
 
+    event_base_free(main_base);
     mc_logger->log(EXTENSION_LOG_INFO, NULL, "Arcus memcached terminated.\n");
     return EXIT_SUCCESS;
 }

--- a/thread.c
+++ b/thread.c
@@ -218,7 +218,7 @@ static void create_worker(void *(*func)(void *), void *arg, pthread_t *id)
 static void setup_thread(LIBEVENT_THREAD *me)
 {
     me->type = GENERAL;
-    me->base = event_init();
+    me->base = event_base_new();
     if (! me->base) {
         mc_logger->log(EXTENSION_LOG_WARNING, NULL,
                        "Can't allocate event base\n");
@@ -308,6 +308,7 @@ static void *worker_libevent(void *arg)
     }
     token_buff_destroy(&me->token_buff);
     mblck_pool_destroy(&me->mblck_pool);
+    event_base_free(me->base);
     return NULL;
 }
 


### PR DESCRIPTION
event_init()은 deprecated 될 API 이므로, event_base_new() 로 변경하였습니다.

```
 /**
   Initialize the event API.

   The event API needs to be initialized with event_init() before it can be
   used.  Sets the global current base that gets used for events that have no
   base associated with them.

   @deprecated This function is deprecated because it replaces the "current"
     event_base, and is totally unsafe for multithreaded use.  The replacement
     is event_base_new().

   @see event_base_set(), event_base_new()
  */
 EVENT2_EXPORT_SYMBOL
 struct event_base *event_init(void);
```

동작 테스트 확인하였습니다.