### PR TITLE
FEATURE: added keyscan command

### DIFF
--- a/engines/default/assoc.h
+++ b/engines/default/assoc.h
@@ -75,6 +75,9 @@ void              assoc_delete(const char *key, const uint32_t nkey, uint32_t ha
 void              assoc_scan_init(struct assoc_scan *scan);
 int               assoc_scan_next(struct assoc_scan *scan, hash_item **item_array,
                                   int array_size, int elem_limit);
+#ifdef SCAN_COMMAND
+int               assoc_scan_direct(const char *cursor, int req_count, hash_item **item_array, int array_size);
+#endif
 bool              assoc_scan_in_visited_area(struct assoc_scan *scan, hash_item *it);
 void              assoc_scan_final(struct assoc_scan *scan);
 

--- a/engines/default/default_engine.c
+++ b/engines/default/default_engine.c
@@ -26,6 +26,7 @@
 #include <unistd.h>
 #include <stddef.h>
 #include <inttypes.h>
+#include <sys/time.h>
 
 #include "default_engine.h"
 #include "memcached/util.h"
@@ -1227,6 +1228,66 @@ default_dump(ENGINE_HANDLE* handle, const void* cookie,
     }
 }
 
+#ifdef SCAN_COMMAND
+/*
+ * Keyscan API
+ */
+#define SCAN_ITER_COUNT 200
+static ENGINE_ERROR_CODE
+default_keyscan(const char cursor[], const uint32_t count, const char *pattern,
+                ENGINE_ITEM_TYPE type, item **item_array, int item_arrsz, int *item_count)
+{
+    assert(count+100 <= item_arrsz); /* may scan more than count. */
+    hash_item **scan_array = (hash_item**)item_array;
+    int iter_count;
+    int scan_count = 0;
+    int scan_cost = 0;
+    int get_count = 0;
+    int max_elapsed = 5000; /* 5 msec */
+    struct timeval begin, end, diff;
+
+    gettimeofday(&begin, NULL);
+    while (scan_cost < count) {
+        iter_count = (count-scan_cost) < SCAN_ITER_COUNT
+                   ? (count-scan_cost) : SCAN_ITER_COUNT;
+        scan_count = item_scan_direct(cursor, type, iter_count, (void**)scan_array, item_arrsz);
+        if (scan_count < 0) { /* reached to the end or invalid cursor */
+            break;
+        }
+        if (pattern) {
+            for (int i = 0; i < scan_count; i++) {
+                hash_item *it = (hash_item*)scan_array[i];
+                if (string_pattern_match(item_get_key(it), it->nkey, pattern, strlen(pattern))) { /* match */
+                    item_array[get_count++] = it;
+                } else { /* no match */
+                    item_release(it);
+                    scan_count -= 1;
+                }
+            }
+        } else {
+            get_count += scan_count;
+        }
+        if (strncmp(cursor, "0", 1) == 0) break; /* reached to the end */
+        gettimeofday(&end, NULL);
+        timersub(&end, &begin, &diff);
+        if (diff.tv_usec >= max_elapsed) break; /* too long scan */
+
+        scan_cost += iter_count;
+        scan_array += scan_count;
+        item_arrsz -= scan_count;
+    }
+    if (scan_count == -2) { /* invalid cursor */
+        for (int i = 0; i < get_count; i++) {
+            item_release(item_array[i]);
+        }
+        return ENGINE_EINVAL;
+    }
+
+    *item_count = get_count;
+    return ENGINE_SUCCESS;
+}
+#endif
+
 /*
  * Config API
  */
@@ -1833,6 +1894,10 @@ create_instance(uint64_t interface, GET_SERVER_API get_server_api,
          /* Dump API */
          .cachedump        = default_cachedump,
          .dump             = default_dump,
+#ifdef SCAN_COMMAND
+         /* Keyscan API */
+         .keyscan          = default_keyscan,
+#endif
          /* Config API */
          .set_config       = default_set_config,
          .get_config       = default_get_config,

--- a/engines/default/items.h
+++ b/engines/default/items.h
@@ -207,6 +207,10 @@ typedef void (*CB_SCAN_CLOSE)(bool success);
 /* item scan functions */
 void item_scan_open(item_scan *sp, const char *prefix, const int nprefix, CB_SCAN_OPEN cb_scan_open);
 int  item_scan_getnext(item_scan *sp, void **item_array, elems_result_t *erst_array, int item_arrsz);
+#ifdef SCAN_COMMAND
+int  item_scan_direct(const char *cursor, ENGINE_ITEM_TYPE type, int req_count,
+                      void **item_array, int item_arrsz);
+#endif
 void item_scan_release(item_scan *sp, void **item_array, elems_result_t *erst_array, int item_count);
 void item_scan_close(item_scan *sp, CB_SCAN_CLOSE cb_scan_close, bool success);
 

--- a/include/memcached/engine.h
+++ b/include/memcached/engine.h
@@ -699,6 +699,22 @@ extern "C" {
                                   const char *prefix, const int nprefix,
                                   const char *filepath);
 
+#ifdef SCAN_COMMAND
+        /**
+         * Scan a certain number of items that meet the given conditions.
+         *
+         * @param cursor     scan start point
+         * @param count      the number of items to scan
+         * @param pattern    key string glob pattern
+         * @param type       item's type
+         * @param item_array where to store item
+         * @param item_arrsz the size of item_array
+         * @param item_count the number of matched items
+         */
+        ENGINE_ERROR_CODE (*keyscan)(const char cursor[], const uint32_t count, const char *pattern,
+                                     ENGINE_ITEM_TYPE type, item **item_array, int item_arrsz, int *item_count);
+
+#endif
         /**
          * Any unknown command will be considered engine specific.
          *

--- a/include/memcached/types.h
+++ b/include/memcached/types.h
@@ -31,6 +31,7 @@ struct iovec {
 #include <sys/uio.h>
 #endif
 
+#define SCAN_COMMAND
 #define NESTED_PREFIX
 #define PROXY_SUPPORT
 //#define NEW_PREFIX_STATS_MANAGEMENT

--- a/include/memcached/util.h
+++ b/include/memcached/util.h
@@ -40,6 +40,8 @@ MEMCACHED_PUBLIC_API bool safe_strtof(const char *str, float *out);
 MEMCACHED_PUBLIC_API bool safe_strtohexa(const char *str, unsigned char *bin, const int size);
 MEMCACHED_PUBLIC_API void safe_hexatostr(const unsigned char *bin, const int size, char *str);
 MEMCACHED_PUBLIC_API bool mc_isvalidname(const char *str, int len);
+MEMCACHED_PUBLIC_API bool string_pattern_match(const char *text, int text_len,
+                                               const char *pattern, int pattern_len);
 
 MEMCACHED_PUBLIC_API int64_t getnowdatetime_int(void);
 MEMCACHED_PUBLIC_API int     getnowdate_int(void);


### PR DESCRIPTION
keyscan 명령을 개발하였습니다.

keyscan command protocol (request) :
`keyscan <cursor> [count <count>] [match <pattern>] [type <type>]`
- cursor :  default engine - 32비트 정수 :상위16비트(tabidx)/하위16비트(bucket)
- count : 1~2000 설정, 생략 시 20개.
- match : 패턴은 '\\', '*', '?' 지원, 지정하지 않을 시 모든 아이템 스캔. 패턴 매칭 비교 수행시간이 오래 걸릴 수 있으므로 아래 제약을 둠.
  - 최대 패턴문자열 길이는 64자
  - '*' 지정 최대 개수는 4개 
- type : 아이템 타입 지정, 지정하지 않을 시 'A' 로 설정되며 이는 모든 아이템 타입을 의미함.

keyscan command protocol (response) :
`KEYS <key count> <cursor>\r\n<line separated keys>END\r\n`
- key count
  - physical bucket 단위로 스캔을 하기 때문에 주어진 count 보다 조금 클 수 있음.
  - 패턴 지정 시 아이템 스캔 수행시간이 10msec 넘어가면 스캔 종료하므로 count 보다 작을 수 있음.
- cursor : 스캔 끝난 위치. 0을 응답하면 전체 해시테이블을 스캔했음을 의미함.

internal :
- 버켓 참조카운트는 하나의 명령 처리가 끝나면 반드시 해제되어 있어야 한다. 엔진 내부에서 수행하는 풀스캔과 달리 스캔 요청이 더 오지 않을 수 있다.
- 비트를 상위 비트부터 증가시켜 스캔하고, 해시테이블 확장 중인 경우 확장 중인 버켓을 스캔하므로 아이템 중복 반환하지 않음.
- 캐시 락 hold 시간은 크지 않도록 내부적으로 200개씩 해시 테이블 스캔.
- 패턴 매칭에 경우 아이템 스캔 시간을 측정하여 10msec 이상이면 더 이상 스캔하지 않고, 현재까지 스캔한 아이템을 반환.
