### PR TITLE
CLEANUP: use getnowtime(), getnowdate() as a util function.

### DIFF
--- a/cmdlog.c
+++ b/cmdlog.c
@@ -26,6 +26,7 @@
 #include <unistd.h>
 #include <assert.h>
 #include <errno.h>
+#include <memcached/util.h>
 
 #include "cmdlog.h"
 
@@ -76,38 +77,6 @@ struct cmd_log_global {
 struct cmd_log_global cmdlog;
 
 
-/* command log function */
-static int getnowdate(void)
-{
-    int ldate;
-    time_t clock;
-    struct tm *date;
-
-    clock = time(0);
-    date = localtime(&clock);
-    ldate = date->tm_year * 100000;
-    ldate += (date->tm_mon + 1) * 1000;
-    ldate += date->tm_mday * 10;
-    ldate += date->tm_wday;
-    ldate += 190000000;
-    ldate /= 10;
-    return(ldate);
-}
-
-static int getnowtime(void)
-{
-    int ltime;
-    time_t clock;
-    struct tm *date;
-
-    clock = time(0);
-    date = localtime(&clock);
-    ltime = date->tm_hour * 10000;
-    ltime += date->tm_min * 100;
-    ltime += date->tm_sec;
-    return(ltime);
-}
-
 static void do_cmdlog_flush_sleep()
 {
     struct timeval tv;
@@ -146,8 +115,8 @@ static void do_cmdlog_stop(int cause)
 {
     /* cmdlog lock has already been held */
     cmdlog.stats.state = cause;
-    cmdlog.stats.enddate = getnowdate();
-    cmdlog.stats.endtime = getnowtime();
+    cmdlog.stats.enddate = getnowdate_int();
+    cmdlog.stats.endtime = getnowtime_int();
     cmdlog.on_logging = false;
 }
 
@@ -307,8 +276,8 @@ int cmdlog_start(char *file_path, bool *already_started)
 
         /* prepare comand logging stats */
         memset(&cmdlog.stats, 0, sizeof(struct cmd_log_stats));
-        cmdlog.stats.bgndate = getnowdate();
-        cmdlog.stats.bgntime = getnowtime();
+        cmdlog.stats.bgndate = getnowdate_int();
+        cmdlog.stats.bgntime = getnowtime_int();
 
         sprintf(cmdlog.stats.dirpath, "%s",
                 (file_path != NULL ? file_path : "command_log"));
@@ -375,8 +344,8 @@ char *cmdlog_stats(void)
 
         struct cmd_log_stats *stats = &cmdlog.stats;
         if (cmdlog.on_logging) {
-            stats->enddate = getnowdate();
-            stats->endtime = getnowtime();
+            stats->enddate = getnowdate_int();
+            stats->endtime = getnowtime_int();
         }
 
         snprintf(str, CMDLOG_INPUT_SIZE,

--- a/engines/default/checkpoint.c
+++ b/engines/default/checkpoint.c
@@ -79,18 +79,6 @@ static void chkpt_last_stat_init(void) {
     chkpt_last_stat.last_chkpt_start_time = 0;
     chkpt_last_stat.last_chkpt_elapsed_time_sec = 0;
 }
-static int64_t getnowtime(void)
-{
-    char buf[20] = {0};
-    int64_t ltime;
-    time_t clock = time(0);
-    struct tm *date = localtime(&clock);
-
-    /* year(YYYY) month(01-12) day(01-31) hour(00-23) minute(00-59) second(00-61). */
-    strftime(buf, 20, "%Y%m%d%H%M%S", date);
-    sscanf(buf, "%" SCNd64, &ltime);
-    return ltime;
-}
 
 /* Delete all backup files except last checkpoint file. */
 static bool do_chkpt_sweep_files(chkpt_st *cs)
@@ -245,7 +233,7 @@ static void do_chkpt_thread_wakeup(chkpt_st *cs)
 static int do_checkpoint(chkpt_st *cs)
 {
     logger->log(EXTENSION_LOG_INFO, NULL, "Checkpoint started.\n");
-    int64_t newtime = getnowtime();
+    int64_t newtime = getnowdatetime_int();
     chkpt_last_stat.last_chkpt_in_progress = true;
     chkpt_last_stat.last_chkpt_start_time = newtime;
     time_t start, end;

--- a/include/memcached/util.h
+++ b/include/memcached/util.h
@@ -41,6 +41,10 @@ MEMCACHED_PUBLIC_API bool safe_strtohexa(const char *str, unsigned char *bin, co
 MEMCACHED_PUBLIC_API void safe_hexatostr(const unsigned char *bin, const int size, char *str);
 MEMCACHED_PUBLIC_API bool mc_isvalidname(const char *str, int len);
 
+MEMCACHED_PUBLIC_API int64_t getnowdatetime_int(void);
+MEMCACHED_PUBLIC_API int     getnowdate_int(void);
+MEMCACHED_PUBLIC_API int     getnowtime_int(void);
+
 #ifndef HAVE_HTONLL
 #define htonll mc_htonll
 #define ntohll mc_ntohll

--- a/lqdetect.c
+++ b/lqdetect.c
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <pthread.h>
 #include <sys/time.h>
+#include <memcached/util.h>
 
 #include "lqdetect.h"
 
@@ -38,43 +39,12 @@ struct lq_detect_global {
 struct lq_detect_global lqdetect;
 
 /* lqdetect function */
-static int getnowdate(void)
-{
-    int ldate;
-    time_t clock;
-    struct tm *date;
-
-    clock = time(0);
-    date = localtime(&clock);
-    ldate = date->tm_year * 100000;
-    ldate += (date->tm_mon + 1) * 1000;
-    ldate += date->tm_mday * 10;
-    ldate += date->tm_wday;
-    ldate += 190000000;
-    ldate /= 10;
-    return(ldate);
-}
-
-static int getnowtime(void)
-{
-    int ltime;
-    time_t clock;
-    struct tm *date;
-
-    clock = time(0);
-    date = localtime(&clock);
-    ltime = date->tm_hour * 10000;
-    ltime += date->tm_min * 100;
-    ltime += date->tm_sec;
-    return(ltime);
-}
-
 static void do_lqdetect_stop(int cause)
 {
     /* detect long query lock has already been held */
     lqdetect.stats.stop_cause = cause;
-    lqdetect.stats.enddate = getnowdate();
-    lqdetect.stats.endtime = getnowtime();
+    lqdetect.stats.enddate = getnowdate_int();
+    lqdetect.stats.endtime = getnowtime_int();
     lqdetect.on_detecting = false;
 }
 
@@ -136,8 +106,8 @@ int lqdetect_start(uint32_t lqdetect_standard, bool *already_started)
 
         /* prepare detect long query stats */
         memset(&lqdetect.stats, 0, sizeof(struct lq_detect_stats));
-        lqdetect.stats.bgndate = getnowdate();
-        lqdetect.stats.bgntime = getnowtime();
+        lqdetect.stats.bgndate = getnowdate_int();
+        lqdetect.stats.bgntime = getnowtime_int();
         lqdetect.stats.stop_cause = LONGQ_RUNNING;
         lqdetect.stats.standard = lqdetect_standard;
 

--- a/util.c
+++ b/util.c
@@ -23,6 +23,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <time.h>
 
 #include <memcached/util.h>
 
@@ -225,5 +226,47 @@ uint64_t mc_ntohll(uint64_t val) {
 
 uint64_t mc_htonll(uint64_t val) {
    return mc_swap64(val);
+}
+
+/* integer represents format : YYYYMMDDHHMMSS (ex. 20210806152049) */
+int64_t getnowdatetime_int(void)
+{
+    char buf[24] = {0};
+    int64_t res;
+    time_t clock = time(0);
+    struct tm *lctime = localtime(&clock);
+
+    /* year(YYYY) month(01-12) day(01-31) hour(00-23) minute(00-59) second(00-61). */
+    strftime(buf, 24, "%Y%m%d%H%M%S", lctime);
+    sscanf(buf, "%" SCNd64, &res);
+    return res;
+}
+
+/* integer represents format : YYYYMMDD (ex. 20210806) */
+int getnowdate_int(void)
+{
+    char buf[16] = {0};
+    int res;
+    time_t clock = time(0);
+    struct tm *lctime = localtime(&clock);
+
+    /* year(YYYY) month(01-12) day(01-31). */
+    strftime(buf, 16, "%Y%m%d", lctime);
+    sscanf(buf, "%d", &res);
+    return res;
+}
+
+/* integer represents format : HHMMSS (ex. 152049) */
+int getnowtime_int(void)
+{
+    char buf[8] = {0};
+    int res;
+    time_t clock = time(0);
+    struct tm *lctime = localtime(&clock);
+
+    /* hour(00-23) minute(00-59) second(00-61). */
+    strftime(buf, 8, "%H%M%S", lctime);
+    sscanf(buf, "%d", &res);
+    return res;
 }
 #endif


### PR DESCRIPTION
getnowtime(), getnowdate() 를 lqdetect, cmdlog 모듈에서 중복으로 정의하여 사용하고 있습니다.
향후에 다른 모듈에서도 사용할 가능성이 높은 성격의 함수라서 util.c 에 구현해두고, 이를 사용하도록 리팩토링하였습니다.