### PR TITLE
CLEANUP: rotate command log file based on a set file size.

### DIFF
--- a/cmdlog.h
+++ b/cmdlog.h
@@ -20,19 +20,7 @@
 #include "memcached/extension_loggers.h"
 
 #define COMMAND_LOGGING
-#define CMDLOG_FILENAME_LENGTH 256 /* filename plus path's length */
 #define CMDLOG_DIRPATH_LENGTH 128 /* directory path's length */
-
-/* command log stats structure */
-struct cmd_log_stats {
-    int bgndate, bgntime;
-    int enddate, endtime;
-    int file_count;
-    volatile int state;        /* command log module state */
-    uint32_t entered_commands; /* number of entered command */
-    uint32_t skipped_commands; /* number of skipped command */
-    char dirpath[CMDLOG_DIRPATH_LENGTH];
-};
 
 void cmdlog_init(int port, EXTENSION_LOGGER_DESCRIPTOR *logger);
 void cmdlog_final(void);


### PR DESCRIPTION
command log file rotation 은 128MB 단위로 수행하도록 수정하였습니다.
그리고 이전 커밋에서 수정하지 않았던 일부 리팩토링 코드도 포함되어있습니다.