### PR TITLE
FIX: resolve compile error about embedding a directive within macro a…

### DIFF
--- a/engines/default/prefix.c
+++ b/engines/default/prefix.c
@@ -593,11 +593,11 @@ char *prefix_dump_stats(int *length)
                         pt->items_bytes_exclusive[ITEM_TYPE_SET],
                         pt->items_bytes_exclusive[ITEM_TYPE_MAP],
                         pt->items_bytes_exclusive[ITEM_TYPE_BTREE],
-#if 0 // FUTURE
+                        /* FUTURE
                         (uint64_t)pt->child_prefix_items,
                         (uint64_t)0,
                         (uint64_t)0,
-#endif
+                        */
                         t->tm_year+1900, t->tm_mon+1, t->tm_mday,
                         t->tm_hour, t->tm_min, t->tm_sec);
 #else
@@ -642,11 +642,11 @@ char *prefix_dump_stats(int *length)
                                 pt->items_bytes_inclusive[ITEM_TYPE_SET],
                                 pt->items_bytes_inclusive[ITEM_TYPE_MAP],
                                 pt->items_bytes_inclusive[ITEM_TYPE_BTREE],
-#if 0 // FUTURE
+                                /* FUTURE
                                 (uint64_t)pt->child_prefix_items,
                                 pt->total_count_inclusive - pt->total_count_exclusive,
                                 pt->total_bytes_inclusive - pt->total_bytes_exclusive,
-#endif
+                                */
                                 t->tm_year+1900, t->tm_mon+1, t->tm_mday,
                                 t->tm_hour, t->tm_min, t->tm_sec);
             } else {
@@ -663,11 +663,11 @@ char *prefix_dump_stats(int *length)
                                 pt->items_bytes_exclusive[ITEM_TYPE_SET],
                                 pt->items_bytes_exclusive[ITEM_TYPE_MAP],
                                 pt->items_bytes_exclusive[ITEM_TYPE_BTREE],
-#if 0 // FUTURE
+                                /* FUTURE
                                 (uint64_t)pt->child_prefix_items,
                                 (uint64_t)0,
                                 (uint64_t)0,
-#endif
+                                */
                                 t->tm_year+1900, t->tm_mon+1, t->tm_mday,
                                 t->tm_hour, t->tm_min, t->tm_sec);
             }


### PR DESCRIPTION
mac os 에서 컴파일 해보니 아래와 같이 매크로 내에 #if 와 같은 것들은 넣을 수 없다는 컴파일 에러가 발생하였습니다.

```
engines/default/prefix.c:596:2: error: embedding a directive within macro arguments has undefined behavior [-Werror,-Wembedded-directive]
#if 0 // FUTURE
 ^
engines/default/prefix.c:645:2: error: embedding a directive within macro arguments has undefined behavior [-Werror,-Wembedded-directive]
#if 0 // FUTURE
 ^
engines/default/prefix.c:666:2: error: embedding a directive within macro arguments has undefined behavior [-Werror,-Wembedded-directive]
#if 0 // FUTURE
 ^
```

리눅스 환경에서는 컴파일이 잘 되었는데, 구글링 해보니 일부 시스템에서는 sprintf 함수가 macro 로 구현되어 있어 발생한다고 합니다. 
참고 링크 : https://github.com/vim/vim/pull/2946

-----

The error message is:
```
term.c:2877:2: warning: embedding a directive within macro arguments has undefined behavior [-Wembedded-directive]
\#if defined(FEAT_VTP) && defined(FEAT_TERMGUICOLORS)
 ^
1 warning generated.
```
The issue is caused because sprintf() is implemented as a macro on some
systems.

Therefore, this sprintf() call has its parameters conditionally modified
by the preprocessor, and embedding a preprocessor directive within macro
arguments causes undefined behavior.

My proposed fix would be to move the preprocessor check outside the call
to sprintf().

------

위 이슈 관련한 vim 쪽 수정 커밋 : https://github.com/vim/vim/commit/d315cf551f1d15609c4d7cf724e471de55f5cdac
