### PR TITLE
FIX: fix a persistence code bug in config command.

### DIFF
--- a/engines/default/default_engine.c
+++ b/engines/default/default_engine.c
@@ -1351,7 +1351,7 @@ default_set_config(ENGINE_HANDLE* handle, const void* cookie,
         pthread_mutex_unlock(&engine->cache_lock);
     }
 #ifdef ENABLE_PERSISTENCE
-    if (engine->config.use_persistence) {
+    else if (engine->config.use_persistence) {
         if (strcmp(config_key, "chkpt_interval_pct_snapshot") == 0) {
             size_t new_chkpt_interval_pct_snapshot = *(size_t*)config_value;
             pthread_mutex_lock(&engine->cache_lock);
@@ -1442,7 +1442,7 @@ default_get_config(ENGINE_HANDLE* handle, const void* cookie,
         pthread_mutex_unlock(&engine->cache_lock);
     }
 #ifdef ENABLE_PERSISTENCE
-    if (engine->config.use_persistence) {
+    else if (engine->config.use_persistence) {
         if (strcmp(config_key, "chkpt_interval_pct_snapshot") == 0) {
             pthread_mutex_lock(&engine->cache_lock);
             *(size_t*)config_value = engine->config.chkpt_interval_pct_snapshot;


### PR DESCRIPTION
persistence enable compile 하고, engine->config.use_persistence == false 인 경우에 config 명령을 수행하면
ENOTSUP 에러 코드를 반환하는 버그를 수정하였습니다.