### PR TITLE
FIX: wrong parsing delay option in flush_prefix command

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -8634,7 +8634,8 @@ static void process_flush_command(conn *c, token_t *tokens, const size_t ntokens
         delay_flag = (ntokens == (c->noreply ? 5 : 4));
     }
     if (delay_flag) {
-        if (! safe_strtol(tokens[1].value, &exptime) || exptime < 0) {
+        int delay_idx = (flush_all ? 1 : 2);
+        if (! safe_strtol(tokens[delay_idx].value, &exptime) || exptime < 0) {
             print_invalid_command(c, tokens, ntokens);
             out_string(c, "CLIENT_ERROR bad command line format");
             return;

--- a/t/flush-prefix.t
+++ b/t/flush-prefix.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 use strict;
-use Test::More tests => 4001;
+use Test::More tests => 6001;
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
@@ -52,6 +52,13 @@ sub prefix_flush {
   }
 }
 
+sub prefix_flush_delay {
+  for ($size = 0; $size < $prefix_size; $size++) {
+    $cmd = "flush_prefix pname$size 0"; $rst = "OK";
+    mem_cmd_is($sock, $cmd, "", $rst);
+  }
+}
+
 sub item_get_miss {
   for ($size = 0; $size < $prefix_size; $size++) {
     $cmd = "get pname$size:foo";
@@ -82,6 +89,8 @@ item_get_hit();
 prefix_flush();
 count_prefix_empty();
 item_get_miss();
+prefix_insert();
+prefix_flush_delay();
 
 # after test
 release_memcached($engine, $server);


### PR DESCRIPTION
flush_prefix command 에서 delay option 파싱이 잘못되어 있어서 수정하였습니다.