### PR TITLE
FIX: wrong bkey range check in lqdetect_make_bkeystring().

### DIFF
--- a/lqdetect.c
+++ b/lqdetect.c
@@ -411,29 +411,27 @@ static bool lqdetect_save_cmd(char client_ip[], char* key,
 static void lqdetect_make_bkeystring(const unsigned char* from_bkey, const unsigned char* to_bkey,
                                      const int from_nbkey, const int to_nbkey,
                                      const eflag_filter *efilter, char *bufptr) {
-    char *tmpptr = bufptr;
-
     /* bkey */
-    if (from_nbkey > 0) {
-        memcpy(tmpptr, "0x", 2); tmpptr += 2;
-        safe_hexatostr(from_bkey, from_nbkey, tmpptr);
-        tmpptr += strlen(tmpptr);
-        if (to_bkey != NULL) {
-            memcpy(tmpptr, "..0x", 4); tmpptr += 4;
-            safe_hexatostr(to_bkey, to_nbkey, tmpptr);
-            tmpptr += strlen(tmpptr);
+    if (from_nbkey > 0) { /* hexadecimal */
+        memcpy(bufptr, "0x", 2); bufptr += 2;
+        safe_hexatostr(from_bkey, from_nbkey, bufptr);
+        bufptr += strlen(bufptr);
+        if (to_nbkey != BKEY_NULL) { /* range */
+            memcpy(bufptr, "..0x", 4); bufptr += 4;
+            safe_hexatostr(to_bkey, to_nbkey, bufptr);
+            bufptr += strlen(bufptr);
         }
-    } else {
-        sprintf(tmpptr, "%"PRIu64"", *(uint64_t*)from_bkey);
-        tmpptr += strlen(tmpptr);
-        if (to_bkey != NULL) {
-            sprintf(tmpptr, "..%"PRIu64"", *(uint64_t*)to_bkey);
-            tmpptr += strlen(tmpptr);
+    } else { /* 64bit unsigned integer */
+        sprintf(bufptr, "%"PRIu64"", *(uint64_t*)from_bkey);
+        bufptr += strlen(bufptr);
+        if (to_nbkey != BKEY_NULL) { /* range */
+            sprintf(bufptr, "..%"PRIu64"", *(uint64_t*)to_bkey);
+            bufptr += strlen(bufptr);
         }
     }
     /* efilter */
     if (efilter != NULL) {
-        strcpy(tmpptr, " efilter");
+        strcpy(bufptr, " efilter");
     }
 }
 

--- a/t/long_query_detect_issue.t
+++ b/t/long_query_detect_issue.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 use strict;
-use Test::More tests => 106;
+use Test::More tests => 107;
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
@@ -76,6 +76,20 @@ sub do_btree_efilter {
 
     # bop get
     $cmd = "bop get $kstr $bkrange $efilter 0 100";
+    $rst = "VALUE 0 1\n";
+    for ($eidx = 0; $eidx < 1; $eidx += 1) {
+        my $bkstr = "0x" . sprintf "%062d", $eidx;
+        my $eflag = "0x" . sprintf "%062d", $eidx;
+        my $val   = "element_value_$eidx";
+        my $vleng = length($val);
+        $rst .= "$bkstr $eflag $vleng $val\n"
+    }
+    $rst .= "END";
+    mem_cmd_is($sock, $cmd, "", $rst);
+
+    # bop get (single index)
+    my $bkey = "0x" . "0"x62;
+    $cmd = "bop get $kstr $bkey $efilter 0 100";
     $rst = "VALUE 0 1\n";
     for ($eidx = 0; $eidx < 1; $eidx += 1) {
         my $bkstr = "0x" . sprintf "%062d", $eidx;


### PR DESCRIPTION
bkey range check 가 `to_bkey != NULL` 조건으로 잘못되어 있습니다.
to_bkey 는 static array 를 넘겨주기 때문에 NULL 이 아니므로, bkey single index 인 경우에도 항상 참입니다.
이 경우에 to_nbkey 는 BKEY_NULL(255자) 이므로 to_bkey array 의 최대 범위를 넘어서 write 하여 segfault 가 발생합니다.