### PR TITLE
INTERNAL: consider maximum key length has increased in do_lqdetect_wr…

### DIFF
--- a/lqdetect.c
+++ b/lqdetect.c
@@ -130,8 +130,14 @@ static void do_lqdetect_write(char client_ip[], char *key,
     uint32_t offset = buffer->offset;
     uint32_t nsaved = buffer->nsaved;
     char     *bufptr = buffer->data + buffer->offset;
-    uint32_t nwrite;
-    uint32_t length;
+    uint32_t nwrite, length, keylen = strlen(key);
+    char keybuf[251];
+
+    if (keylen > 250) { /* long key string */
+        keylen = snprintf(keybuf, sizeof(keybuf), "%.*s...%.*s", 124, key, 123, (key+(keylen - 123)));
+    } else { /* short key string */
+        keylen = snprintf(keybuf, sizeof(keybuf), key);
+    }
 
     gettimeofday(&val, NULL);
     ptm = localtime(&val.tv_sec);
@@ -143,11 +149,11 @@ static void do_lqdetect_write(char client_ip[], char *key,
 
     nwrite = strlen(bufptr);
     buffer->keypos[nsaved] = offset + nwrite;
-    buffer->keylen[nsaved] = strlen(key);
+    buffer->keylen[nsaved] = keylen;
     length -= nwrite;
     bufptr += nwrite;
 
-    snprintf(bufptr, length, "%s %s\n", key, arg->query);
+    snprintf(bufptr, length, "%s %s\n", keybuf, arg->query);
     nwrite += strlen(bufptr);
     buffer->offset += nwrite;
     lqdetect.arg[cmd][nsaved] = *arg;


### PR DESCRIPTION
lq command write 시에 키 문자열은 최대 250자까지 축약해서 기록하도록 수정하였습니다.
전체 키 문자열을 기록하지 않으므로 mop delete, mop get 와 같은 경우 duplication check 를 정확히 할 수가 없습니다.
query 필드에 명령 옵션 값 count 를 기록하지 않고 실제 조회한 개수인 elem_count 를 기록하면
query 비교를 통해 duplication check 할 수 있습니다.