### PR TITLE
FIX: use uninitialized opcost variable when lqdetect bop count.

### DIFF
--- a/engines/default/coll_btree.c
+++ b/engines/default/coll_btree.c
@@ -2483,9 +2483,11 @@ static uint32_t do_btree_elem_count(btree_meta_info *info,
     uint32_t tot_found = 0; /* total found count */
     uint32_t tot_access = 0; /* total access count */
 
+    if (opcost) {
+        *opcost = 0;
+    }
+
     if (info->root == NULL) {
-        if (opcost)
-            *opcost = 0;
         return 0;
     }
 


### PR DESCRIPTION
do_btree_elem_count() 에서 BOP_COUNT_OPTIMIZE 로직을 수행하는 경우 opcost 변수에 값 설정을 하지 않음.
이로 인해 short query 가 long query 로 분류되는 문제가 있어 처음에 0으로 초기화하여 사용하도록 수정