### PR TITLE
DOC: amended compilation_faq.md.

### DIFF
--- a/doc/compilation_faq.md
+++ b/doc/compilation_faq.md
@@ -3,7 +3,7 @@
   - Install tools
 
     ```
-    (CentOS) sudo yum install gcc gcc-c++ autoconf automake libtool pkgconfig cppunit-devel
+    (CentOS) sudo yum install gcc gcc-c++ make autoconf automake libtool pkgconfig cppunit-devel perl-Test-Harness perl-Test-Simple
     (Ubuntu) sudo apt-get install build-essential autoconf automake libtool libcppunit-dev
     (OSX)    brew install autoconf automake libtool pkg-config cppunit
     ```
@@ -13,7 +13,8 @@
     $ wget https://github.com/downloads/libevent/libevent/libevent-2.0.21-stable.tar.gz
     $ tar xfz libevent-2.0.21-stable.tar.gz
     $ pushd libevent-2.0.21-stable
-    $ ./configure
+    $ ./autogen.sh
+    $ ./configure --prefix=/path/to/arcus-directory
     $ make
     $ sudo make install
     $ popd


### PR DESCRIPTION
Install tools 항목 수정은 CentOS 8 환경에서는 하위 버전과 다르게 기본적으로 설치가 되지 않는 지 사용자가 직접 설치가 필요하여 추가하였습니다.
- perl-Test-Harness : `make test` 시 `sh: prove: command not found` 해결에 필요한 모듈
- perl-Test-Simple : `make test` 시 `Can't locate Test/More.pm in @INC (you may need to install the Test::More module)` 해결에 필요한 모듈

libevent 2.x 부터 autogen.sh 가 추가되어 실행이 필요한데 빠져있어서 추가하였습니다.