### PR TITLE
FIX: -Wformat-security compile error.

### DIFF
--- a/lqdetect.c
+++ b/lqdetect.c
@@ -136,7 +136,7 @@ static void do_lqdetect_write(char client_ip[], char *key,
     if (keylen > 250) { /* long key string */
         keylen = snprintf(keybuf, sizeof(keybuf), "%.*s...%.*s", 124, key, 123, (key+(keylen - 123)));
     } else { /* short key string */
-        keylen = snprintf(keybuf, sizeof(keybuf), key);
+        keylen = snprintf(keybuf, sizeof(keybuf), "%s", key);
     }
 
     gettimeofday(&val, NULL);


### PR DESCRIPTION
Mac OS 에서 컴파일 에러가 발생하여 수정하였습니다.
에러 메세지에 나온 것처럼 3번째 인자는 Literal string 로 주었습니다.

```
lqdetect.c:139:51: error: format string is not a string literal (potentially insecure) [-Werror,-Wformat-security]
        keylen = snprintf(keybuf, sizeof(keybuf), key);
                                                  ^~~
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/secure/_stdio.h:57:62: note: expanded from macro 'snprintf'
  __builtin___snprintf_chk (str, len, 0, __darwin_obsz(str), __VA_ARGS__)
                                                             ^~~~~~~~~~~
lqdetect.c:139:51: note: treat the string as an argument to avoid this
        keylen = snprintf(keybuf, sizeof(keybuf), key);
                                                  ^
                                                  "%s",
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/secure/_stdio.h:57:62: note: expanded from macro 'snprintf'
  __builtin___snprintf_chk (str, len, 0, __darwin_obsz(str), __VA_ARGS__)
                                                             ^
1 error generated.
```