### PR TITLE
FIX: Remove reading extra request message when client want to know collection attributes using binary protocol

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -6868,8 +6868,8 @@ static void dispatch_bin_command(conn *c)
         }
         break;
     case PROTOCOL_BINARY_CMD_GETATTR:
-        if (keylen > 0 && extlen == (sizeof(bkey_t)+24) && bodylen == (keylen + extlen)) {
-            bin_read_key(c, bin_reading_getattr, (sizeof(bkey_t)+24));
+        if (keylen > 0 && extlen == 0 && bodylen == (keylen + extlen)) {
+            bin_read_key(c, bin_reading_getattr, extlen);
         } else {
             protocol_error = 1;
         }


### PR DESCRIPTION
- binary protocol로 getattr operation이 들어왔을 때 response message의 크기를 request message에서 읽으려고 하여 정상적으로 동작하지 않던 문제를 수정했습니다.
- https://github.com/naver/arcus-c-client/pull/241 PR과 함께 리뷰해주시기 바랍니다.