### PR TITLE
FIX: expand array size of rcbuf to prevent the string from being truncated

### DIFF
--- a/arcus_zk.c
+++ b/arcus_zk.c
@@ -690,7 +690,7 @@ static int arcus_build_znode_name(char *ensemble_list)
     char                *sep1=",";
     char                *sep2=":";
     char                myip[50];
-    char                rcbuf[200];
+    char                rcbuf[512];
 
     // Need to figure out local IP. first create a dummy udp socket
     if ((sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP)) == -1) {


### PR DESCRIPTION
ubuntu 20.04 환경에서 컴파일하면 아래의 빌드 에러가 발생됩니다.
```
arcus_zk.c: In function ‘arcus_zk_init’:
arcus_zk.c:864:41: error: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size 200 [-Werror=format-truncation=]
  864 |         snprintf(rcbuf, sizeof(rcbuf), "%s:%d", hostp, arcus_conf.port);
      |                                         ^~
```

hostname의 최대 사이즈가 255 byte이기 때문에, rcbuf의 사이즈가 hostname을 담을만큼 공간이 충분하지 않아 문자열이 잘릴 것 같습니다. rcbuf 공간을 충분히 늘려 수정하였습니다.