### PR TITLE
INTERNAL: Generalize keyscan command.

### DIFF
--- a/doc/ch11-command-administration.md
+++ b/doc/ch11-command-administration.md
@@ -1002,7 +1002,7 @@ iteration 방식으로 전체 아이템을 스캔한다.
 keyscan 명령 요청 syntax는 아래와 같다.
 
 ```
-keyscan <cursor> [count <count>] [type <type>] [match <pattern>]\r\n
+scan key <cursor> [count <count>] [match <pattern>] [type <type>]\r\n
 ```
 
 - \<cursor\> - 스캔 시작 위치.  
@@ -1014,11 +1014,11 @@ count 보다 적은 경우는 조건과 불일치한 아이템이 존재하거�
 count 보다 많은 경우는 스캔 동작이 해시테이블의 버켓 단위로 수행하기 때문에 하나의 버켓에 대해 스캔을 시작하면 마지막 지점까지 스캔을 완료하므로 count 보다 많은 수의 아이템을 스캔할 수 있다.  
 이렇게 설계한 이유는 버켓 중간에서 스캔을 중지할 경우 다음 스캔 요청이 들어올 때까지 그 버켓의 상태가 변경되지 않게 유지해야 하는
 복잡성을 제거하여 stateless한 keyscan api를 제공하기 위함이다.
-- \<type\> - 아이템 타입. 각 타입별 지정 값은 다음과 같다. 지정하지 않을 시 'A' 로 설정된다.  
-All type : 'A', KV : 'K', List : 'L', Set : 'S', Map : 'M', Btree : 'B'
 - \<pattern\> - 키 문자열 패턴. 최대 문자열 길이: 64, 최대 '\*' 입력 개수: 4 . 지정하지 않을 시 모든 키 문자열을 조회한다.  
 glob style 패턴 문자열을 지정하여 해당 패턴과 일치하는 키 문자열을 갖는 아이템들을 찾는다. glob 문자는 '\*', '\?', '\\' 을 지원한다.
 문자열 비교 알고리즘의 worst case 수행 시간이 오래 걸리는 것을 방지하기 위해 패턴 문자열에 길이와 '\*' 입력 개수에 제약을 두었다.
+- \<type\> - 아이템 타입. 각 타입별 지정 값은 다음과 같다. 지정하지 않을 시 'A' 로 설정된다.  
+All type : 'A', KV : 'K', List : 'L', Set : 'S', Map : 'M', Btree : 'B'
 
 keyscan 명령 응답 syntax는 아래와 같다.
 
@@ -1038,7 +1038,7 @@ key3\r\n
 keyscan 사용 예시이다.  
 1000개의 아이템을 스캔하여 그 중 KV 타입이고, \*key1\* 패턴과 일치하는 키 목록을 조회한다.
 ```
-keyscan 0 count 1000 type K match *key1*
+scan key 0 count 1000 match *key1* type K
 ```
 
 5개의 키가 조회되었고, 다음 스캔 지점 cursor 값은 8000이다.  

--- a/include/memcached/types.h
+++ b/include/memcached/types.h
@@ -32,6 +32,9 @@ struct iovec {
 #endif
 
 #define SCAN_COMMAND
+#ifdef SCAN_COMMAND
+#define SCAN_COMMAND_GENERALIZE
+#endif
 #define NESTED_PREFIX
 #define PROXY_SUPPORT
 //#define NEW_PREFIX_STATS_MANAGEMENT

--- a/memcached.c
+++ b/memcached.c
@@ -9399,7 +9399,11 @@ static void process_extension_command(conn *c, token_t *tokens, size_t ntokens)
 }
 
 #ifdef SCAN_COMMAND
+#ifdef SCAN_COMMAND_GENERALIZE
+/* scan command limits */
+#else
 /* keyscan command limits */
+#endif
 #define SCAN_COUNT_MAX           2000
 #define SCAN_CURSOR_MAX_LENGTH   31
 /* pattern constraints is necessary to prevent string_pattern_match()
@@ -9409,7 +9413,11 @@ static void process_extension_command(conn *c, token_t *tokens, size_t ntokens)
 #define SCAN_PATTERN_MAX_LENGTH  64
 static void process_keyscan_command(conn *c, token_t *tokens, const size_t ntokens)
 {
+#ifdef SCAN_COMMAND_GENERALIZE
+    /* keyscan command format : scan key <cursor> [count <count>] [match <pattern>] [type <type>] */
+#else
     /* keyscan command format : keyscan <cursor> [count <count>] [match <pattern>] [type <type>] */
+#endif
     char     cursor[SCAN_CURSOR_MAX_LENGTH+1];
     uint32_t count   = 20;
     char    *pattern = NULL;
@@ -9417,19 +9425,36 @@ static void process_keyscan_command(conn *c, token_t *tokens, const size_t ntoke
     ENGINE_ERROR_CODE ret = ENGINE_SUCCESS;
 
     /* read <cursor> */
+#ifdef SCAN_COMMAND_GENERALIZE
+    if (tokens[2].length > SCAN_CURSOR_MAX_LENGTH) {
+#else
     if (tokens[1].length > SCAN_CURSOR_MAX_LENGTH) {
+#endif
         print_invalid_command(c, tokens, ntokens);
         out_string(c, "CLIENT_ERROR bad cursor value");
         return;
     }
+#ifdef SCAN_COMMAND_GENERALIZE
+    strcpy(cursor, tokens[2].value);
+#else
     strcpy(cursor, tokens[1].value);
+#endif
 
     /* read optional fields (<count>, <pattern>, <type>) */
     int i = 0;
+#ifdef SCAN_COMMAND_GENERALIZE
+    int optcnt = ntokens - 4; /* except (scan, key, <cursor>, CRLF) */
+#else
     int optcnt = ntokens - 3; /* except (scan, <cursor>, CRLF) */
+#endif
     while (optcnt >= 2) {
+#ifdef SCAN_COMMAND_GENERALIZE
+        char *optk = tokens[3+i].value;
+        char *optv = tokens[4+i].value;
+#else
         char *optk = tokens[2+i].value;
         char *optv = tokens[3+i].value;
+#endif
         if (strcmp(optk, "count") == 0) {
             if (!safe_strtoul(optv, &count)) {
                 ret = ENGINE_EINVAL; break;
@@ -9579,6 +9604,29 @@ static void process_keyscan_command(conn *c, token_t *tokens, const size_t ntoke
             break;
     }
 }
+
+#ifdef SCAN_COMMAND_GENERALIZE
+static void process_prefixscan_command(conn *c, token_t *tokens, const size_t ntokens)
+{
+    /* prefixscan command format : scan prefix <cursor> [count <count>] [match <pattern>] */
+    return; // TODO: scan prefixes
+}
+
+static void process_scan_command(conn *c, token_t *tokens, const size_t ntokens)
+{
+    /* keyscan command format : scan key <cursor> [count <count>] [match <pattern>] [type <type>] */
+    if (strcmp(tokens[1].value, "key") == 0) {
+        process_keyscan_command(c, tokens, ntokens);
+        return;
+    }
+
+    /* prefixscan command format : scan prefix <cursor> [count <count>] [match <pattern>] */
+    if (strcmp(tokens[1].value, "prefix") == 0) {
+        process_prefixscan_command(c, tokens, ntokens);
+        return;
+    }
+}
+#endif
 #endif
 #ifdef COMMAND_LOGGING
 static void process_logging_command(conn *c, token_t *tokens, const size_t ntokens)
@@ -12876,9 +12924,15 @@ static void process_command(conn *c, char *command, int cmdlen)
         process_help_command(c, tokens, ntokens);
     }
 #ifdef SCAN_COMMAND
+#ifdef SCAN_COMMAND_GENERALIZE
+    else if ((ntokens >= 4) && (strcmp(tokens[COMMAND_TOKEN].value, "scan") == 0))
+    {
+        process_scan_command(c, tokens, ntokens);
+#else
     else if ((ntokens >= 3) && (strcmp(tokens[COMMAND_TOKEN].value, "keyscan") == 0))
     {
         process_keyscan_command(c, tokens, ntokens);
+#endif
     }
 #endif
 #ifdef COMMAND_LOGGING

--- a/t/keyscan.t
+++ b/t/keyscan.t
@@ -63,23 +63,23 @@ foreach $_ ( @scankeys ) {
 }
 
 # FAIL CASES
-$cmd = "keyscan a"; $rst = "CLIENT_ERROR invalid cursor.";
+$cmd = "scan key a"; $rst = "CLIENT_ERROR invalid cursor.";
 mem_cmd_is($sock, $cmd, "", $rst);
 
-$cmd = "keyscan 0 count 2001"; $rst = "CLIENT_ERROR bad count value";
+$cmd = "scan key 0 count 2001"; $rst = "CLIENT_ERROR bad count value";
 mem_cmd_is($sock, $cmd, "", $rst);
 
-$cmd = "keyscan 0 type V"; $rst = "CLIENT_ERROR bad item type";
+$cmd = "scan key 0 type V"; $rst = "CLIENT_ERROR bad item type";
 mem_cmd_is($sock, $cmd, "", $rst);
 
-$cmd = "keyscan 0 match ***asdds\\***"; $rst = "CLIENT_ERROR bad pattern string";
+$cmd = "scan key 0 match ***asdds\\***"; $rst = "CLIENT_ERROR bad pattern string";
 mem_cmd_is($sock, $cmd, "", $rst);
 
-$cmd = "keyscan 0 match \\"; $rst = "CLIENT_ERROR bad pattern string";
+$cmd = "scan key 0 match \\"; $rst = "CLIENT_ERROR bad pattern string";
 mem_cmd_is($sock, $cmd, "", $rst);
 
 my $key = "a" x 65;
-$cmd = "keyscan 0 match $key"; $rst = "CLIENT_ERROR too long pattern string";
+$cmd = "scan key 0 match $key"; $rst = "CLIENT_ERROR too long pattern string";
 mem_cmd_is($sock, $cmd, "", $rst);
 
 # It's difficult to calculate how many tests were run in keyscan()

--- a/t/lib/MemcachedTest.pm
+++ b/t/lib/MemcachedTest.pm
@@ -1024,7 +1024,7 @@ sub keyscan {
     my $response;
     my @get_keys;
     while (1) {
-        print $sock "keyscan $cursor count $count type $type match $pattern\r\n";
+        print $sock "scan key $cursor count $count match $pattern type $type\r\n";
         $response = <$sock>;
         Test::More::like($response, qr/^KEYS/);
         $response =~ /KEYS (\d+) (\d+)/;


### PR DESCRIPTION
`keyscan <cursor> [count <count>] [match <pattern>] [type <type>]` 명령어를
`scan key [type <type>] <cursor> [count <count>] [match <pattern>]` 명령어로 수정했습니다.