### PR TITLE
INTERNAL: Fix argument order in keyscan unittest.

### DIFF
--- a/t/keyscan.t
+++ b/t/keyscan.t
@@ -28,7 +28,7 @@ $cmd = "set $key 0 0 $vlen"; $rst = "STORED";
 mem_cmd_is($sock, $cmd, $val, $rst);
 push(@keyarr1, $key);
 $key = "c?\\*aaba";
-$cmd = "set c?\\*aaba 0 0 $vlen"; $rst = "STORED";
+$cmd = "set $key 0 0 $vlen"; $rst = "STORED";
 mem_cmd_is($sock, $cmd, $val, $rst);
 push(@keyarr1, $key);
 push(@keyarr2, $key);
@@ -47,14 +47,14 @@ mem_cmd_is($sock, $cmd, "", $rst);
 push(@keyarr1, $key);
 
 # KEYSCAN
-my @scankeys = keyscan($sock, "0", 2000, "A", "*");
+my @scankeys = keyscan($sock, "0", 2000, "*", "A");
 Test::More::is(scalar(@scankeys), scalar(@keyarr1));
 my %keyset = map { $_ => 1 } @keyarr1;
 foreach $_ ( @scankeys ) {
     Test::More::ok(exists($keyset{$_}));
 }
 
-@scankeys = keyscan($sock, "0", 2000, "K", "?\\?\\\\\\**a");
+@scankeys = keyscan($sock, "0", 2000, "?\\?\\\\\\**a", "K");
 Test::More::is(scalar(@scankeys), scalar(@keyarr2));
 %keyset = map { $_ => 1 } @keyarr2;
 foreach $_ ( @scankeys ) {

--- a/t/lib/MemcachedTest.pm
+++ b/t/lib/MemcachedTest.pm
@@ -1017,7 +1017,7 @@ sub stats_prefix_is {
 
 #KEYSCAN
 sub keyscan {
-    my ($sock_opts, $cursor, $count, $type, $pattern) = @_;
+    my ($sock_opts, $cursor, $count, $pattern, $type) = @_;
     my $opts = ref $sock_opts eq "HASH" ? $sock_opts : {};
     my $sock = ref $sock_opts eq "HASH" ? $opts->{sock} : $sock_opts;
 


### PR DESCRIPTION
keyscan 명령어의 단위 테스트에서 argument 순서가 잘못된 점을 고쳤습니다.