### PR TITLE
INTERNAL: Not to use already used port.

### DIFF
--- a/t/lib/MemcachedTest.pm
+++ b/t/lib/MemcachedTest.pm
@@ -1047,12 +1047,16 @@ sub free_port {
     my $type = shift || "tcp";
     my $sock;
     my $port;
+    my $netstat;
     while (!$sock) {
         $port = int(rand(20000)) + 30000;
-        $sock = IO::Socket::INET->new(LocalAddr => '127.0.0.1',
-                                      LocalPort => $port,
-                                      Proto     => $type,
-                                      ReuseAddr => 1);
+        $netstat = `netstat -tnau | grep $port`;
+        if ($netstat eq "") {
+            $sock = IO::Socket::INET->new(LocalAddr => '127.0.0.1',
+                                          LocalPort => $port,
+                                          Proto     => $type,
+                                          ReuseAddr => 1);
+        }
     }
     return $port;
 }


### PR DESCRIPTION
단위 테스트 수행 중 이미 사용 중인 포트를 사용하면 테스트가 실패하는 현상이 있어 이미 사용 중인 포트를 사용하지 않도록 수정했습니다.