### PR TITLE
INTERNAL: Add error handling when scan type is not item and not prefix.

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -9599,6 +9599,8 @@ static void process_scan_command(conn *c, token_t *tokens, const size_t ntokens)
         process_prefixscan_command(c, tokens, ntokens);
         return;
     }
+
+    out_string(c, "CLIENT_ERROR bad command line format");
 }
 #endif
 


### PR DESCRIPTION
scan 명령어의 타입이 item도 아니고 prefix도 아닌 경우에 대한 에러 처리가 없던 점을 보완했습니다.