### PR TITLE
INTERNAL: Enhance scan error message.

### DIFF
--- a/doc/ch11-command-administration.md
+++ b/doc/ch11-command-administration.md
@@ -1059,8 +1059,7 @@ keyscan 명령 실패 시에 response string 은 다음과 같다.
 |----------------------------------------|------------------------ |
 | CLIENT_ERROR bad cursor value          | cursor 문자열 길이가 32 이상인 경우
 | CLIENT_ERROR bad count value           | count 가 0 이거나 2000 보다 큰 경우
-| CLIENT_ERROR bad long pattern string   | 패턴 문자열 길이가 65 이상인 경우
-| CLIENT_ERROR bad pattern string        | 패턴 문자열에 * 을 5개 이상 주었거나 '\\' 다음에 패턴 문자('\\', '\*', '\?')가 없는 경우
+| CLIENT_ERROR bad pattern string        | 패턴 문자열 길이가 65 이상이거나 패턴 문자열에 * 을 5개 이상 주었거나 '\\' 다음에 패턴 문자('\\', '\*', '\?')가 없는 경우
 | CLIENT_ERROR bad item type             | type 값을 잘못 준 경우
 | CLIENT_ERROR invalid cursor            | cursor 에 숫자가 아닌 값을 준 경우
 | CLIENT_ERROR bad command line format   | protocol syntax 틀림
@@ -1128,8 +1127,7 @@ prefixscan 명령 실패 시에 response string 은 다음과 같다.
 |----------------------------------------|------------------------ |
 | CLIENT_ERROR bad cursor value          | cursor 문자열 길이가 32 이상인 경우
 | CLIENT_ERROR bad count value           | count 가 0 이거나 2000 보다 큰 경우
-| CLIENT_ERROR bad long pattern string   | 패턴 문자열 길이가 65 이상인 경우
-| CLIENT_ERROR bad pattern string        | 패턴 문자열에 * 을 5개 이상 주었거나 '\\' 다음에 패턴 문자('\\', '\*', '\?')가 없는 경우
+| CLIENT_ERROR bad pattern string        | 패턴 문자열 길이가 65 이상이거나 패턴 문자열에 * 을 5개 이상 주었거나 '\\' 다음에 패턴 문자('\\', '\*', '\?')가 없는 경우
 | CLIENT_ERROR invalid cursor            | cursor 에 숫자가 아닌 값을 준 경우
 | CLIENT_ERROR bad command line format   | protocol syntax 틀림
 

--- a/t/keyscan.t
+++ b/t/keyscan.t
@@ -79,7 +79,7 @@ $cmd = "scan key 0 match \\"; $rst = "CLIENT_ERROR bad pattern string";
 mem_cmd_is($sock, $cmd, "", $rst);
 
 my $key = "a" x 65;
-$cmd = "scan key 0 match $key"; $rst = "CLIENT_ERROR too long pattern string";
+$cmd = "scan key 0 match $key"; $rst = "CLIENT_ERROR bad pattern string";
 mem_cmd_is($sock, $cmd, "", $rst);
 
 # It's difficult to calculate how many tests were run in keyscan()

--- a/t/prefixscan.t
+++ b/t/prefixscan.t
@@ -79,7 +79,7 @@ $cmd = "scan prefix 0 match \\"; $rst = "CLIENT_ERROR bad pattern string";
 mem_cmd_is($sock, $cmd, "", $rst);
 
 my $prefix = "a" x 65;
-$cmd = "scan prefix 0 match $prefix"; $rst = "CLIENT_ERROR too long pattern string";
+$cmd = "scan prefix 0 match $prefix"; $rst = "CLIENT_ERROR bad pattern string";
 mem_cmd_is($sock, $cmd, "", $rst);
 
 # It's difficult to calculate how many tests were run in prefixscan()


### PR DESCRIPTION
keyscan, prefixscan 명령어의 에러 메세지를 보강했습니다.
- count가 숫자가 아닌 값이 들어왔을 경우: CLIENT_ERROR bad count value

keyscan 명령어의 에러 메세지를 보강했습니다.
- type이 1글자가 아닌 값이 들어왔을 경우: CLIENT_ERROR bad item type

기존에는 두 경우 모두 CLIENT_ERROR bad command line format를 반환했습니다.