### PR TITLE
FIX: Fix error in centos 7 when format "%llu" with uint64_t.

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -9596,7 +9596,7 @@ static void process_prefixscan_command(conn *c, token_t *tokens, const size_t nt
                     ret = ENGINE_ENOMEM; break;
                 }
                 sprintf(attrptr, " %llu %llu %04d%02d%02d%02d%02d%02d\r\n",
-                        pinfo.total_item_count, pinfo.total_item_bytes,
+                        (unsigned long long)pinfo.total_item_count, (unsigned long long)pinfo.total_item_bytes,
                         pinfo.create_time.tm_year+1900, pinfo.create_time.tm_mon+1, pinfo.create_time.tm_mday,
                         pinfo.create_time.tm_hour, pinfo.create_time.tm_min, pinfo.create_time.tm_sec);
                 if (add_iov(c, pinfo.name, pinfo.name_length) != 0 ||


### PR DESCRIPTION
```c
char buffer[100];
uint64_t num = 10;
sprintf(buffer, "%llu", num);
```

위 코드가 gcc 컴파일러에서는 foramt 워닝을 발생시키고, arcus-memcached에서는 워닝을 에러로 처리하게 되어 있어 컴파일 실패 현상이 일어나고 있습니다. 이를 "%llu" 포맷을 사용하는 다른 부분을 참고하여 다음과 같은 형태로 코드를 수정했습니다.

```c
char buffer[100];
uint64_t num = 10;
sprintf(buffer, "%llu", (unsigned long long)num);
```
