### PR TITLE
FIX: Add default prefix "<null>" when scan prefix.

### DIFF
--- a/engines/default/default_engine.c
+++ b/engines/default/default_engine.c
@@ -1838,8 +1838,13 @@ get_prefix_info(ENGINE_HANDLE *handle, const void *cookie,
 {
     prefix_t *it = (prefix_t*)item;
 
-    prefix_info->name = (const char*)prefix_get_name(it);
-    prefix_info->name_length = it->nprefix;
+    if (it->nprefix > 0) {
+        prefix_info->name = (const char*)prefix_get_name(it);
+        prefix_info->name_length = it->nprefix;
+    } else {
+        prefix_info->name = "<null>";
+        prefix_info->name_length = 6;
+    }
 #ifdef NESTED_PREFIX
     if (it->child_prefix_items > 0) {
         prefix_info->total_item_count = it->total_count_inclusive;

--- a/t/prefixscan.t
+++ b/t/prefixscan.t
@@ -20,6 +20,10 @@ my @prefixarr2 = ();
 
 # SET ITEMS
 $prefix = "aaaaaab";
+$cmd = "set $prefix 0 0 $vlen"; $rst = "STORED";
+mem_cmd_is($sock, $cmd, $val, $rst);
+push(@prefixarr1, "<null>");
+$prefix = "aaaaaab";
 $cmd = "set $prefix:$prefix 0 0 $vlen"; $rst = "STORED";
 mem_cmd_is($sock, $cmd, $val, $rst);
 push(@prefixarr1, $prefix);
@@ -47,7 +51,7 @@ mem_cmd_is($sock, $cmd, "", $rst);
 push(@prefixarr1, $prefix);
 
 # PREFIXSCAN
-my @scanprefixes = prefixscan($sock, "0", 2000, "*");
+my @scanprefixes = prefixscan($sock, "0", 1, "*");
 Test::More::is(scalar(@scanprefixes), scalar(@prefixarr1));
 my %prefixset = map { $_ => 1 } @prefixarr1;
 foreach $_ ( @scanprefixes ) {
@@ -56,7 +60,7 @@ foreach $_ ( @scanprefixes ) {
     Test::More::ok(exists($prefixset{$key}));
 }
 
-@scanprefixes = prefixscan($sock, "0", 2000, "*a");
+@scanprefixes = prefixscan($sock, "0", 1, "*a");
 Test::More::is(scalar(@scanprefixes), scalar(@prefixarr2));
 %prefixset = map { $_ => 1 } @prefixarr2;
 foreach $_ ( @scanprefixes ) {


### PR DESCRIPTION
scan prefix 명령에서 default prefix `"<null>"`이 빠진 점을 수정했습니다.