### PR TITLE
FIX: Return human readable expire time in scan key command.

### DIFF
--- a/engines/default/items.c
+++ b/engines/default/items.c
@@ -759,22 +759,7 @@ do_item_getattr(hash_item *it, ENGINE_ITEM_ATTR *attr_ids, const uint32_t attr_c
 {
     /* item flags */
     attr_data->flags = it->flags;
-
-    /* human readable expiretime */
-    if (it->exptime == 0) {
-        attr_data->exptime = it->exptime;
-#ifdef ENABLE_STICKY_ITEM
-    } else if (it->exptime == (rel_time_t)-1) {
-        attr_data->exptime = it->exptime;
-#endif
-    } else {
-        rel_time_t current_time = svcore->get_current_time();
-        if (it->exptime <= current_time) {
-            attr_data->exptime = (rel_time_t)-2;
-        } else {
-            attr_data->exptime = it->exptime - current_time;
-        }
-    }
+    attr_data->exptime = it->exptime;
 
     if (IS_COLL_ITEM(it)) {
         attr_data->type = GET_ITEM_TYPE(it);

--- a/t/keyscan.t
+++ b/t/keyscan.t
@@ -20,29 +20,29 @@ my @keyarr2 = ();
 
 # SET ITEMS
 $key = "aa\\*aaa";
-$cmd = "set $key 0 0 $vlen"; $rst = "STORED";
+$cmd = "set $key 0 1000 $vlen"; $rst = "STORED";
 mem_cmd_is($sock, $cmd, $val, $rst);
 push(@keyarr1, $key);
 $key = "bb\\*aab";
-$cmd = "set $key 0 0 $vlen"; $rst = "STORED";
+$cmd = "set $key 0 1000 $vlen"; $rst = "STORED";
 mem_cmd_is($sock, $cmd, $val, $rst);
 push(@keyarr1, $key);
 $key = "c?\\*aaba";
-$cmd = "set $key 0 0 $vlen"; $rst = "STORED";
+$cmd = "set $key 0 1000 $vlen"; $rst = "STORED";
 mem_cmd_is($sock, $cmd, $val, $rst);
 push(@keyarr1, $key);
 push(@keyarr2, $key);
 $key = "d?\\*abba";
-$cmd = "set $key 0 0 $vlen"; $rst = "STORED";
+$cmd = "set $key 0 1000 $vlen"; $rst = "STORED";
 mem_cmd_is($sock, $cmd, $val, $rst);
 push(@keyarr1, $key);
 push(@keyarr2, $key);
 $key = "a?\\*aaaaa";
-$cmd = "bop create $key 0 0 3"; $rst = "CREATED";
+$cmd = "bop create $key 0 1000 3"; $rst = "CREATED";
 mem_cmd_is($sock, $cmd, "", $rst);
 push(@keyarr1, $key);
 $key = "a?\\*aaaa";
-$cmd = "sop create $key 0 0 3"; $rst = "CREATED";
+$cmd = "sop create $key 0 1000 3"; $rst = "CREATED";
 mem_cmd_is($sock, $cmd, "", $rst);
 push(@keyarr1, $key);
 


### PR DESCRIPTION
scan key 명령어에서 item의 expire time이 raw 값을 그대로 반환하는 점을 수정했습니다.