### PR TITLE
FIX: Add usage for -e option

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -14387,6 +14387,8 @@ static void usage(void)
     printf("-I            Override the size of each slab page. Adjusts max item size\n"
            "              (default: 1mb, min: 1k, max: 128m)\n");
     printf("-E <engine>   Engine to load, must be given (for example, -E .libs/default_engine.so)\n");
+    printf("-e <config>   Engine config to load, -e option has higher priority than\n"
+           "              the other options. (for example, -e config_file=</path>\n");
     printf("-q            Disable detailed stats commands\n");
 #ifdef SASL_ENABLED
     printf("-S            Require SASL authentication\n");


### PR DESCRIPTION
`usage(void)` 함수에 구동 시 engine_config 설정을 위한 `-e` 옵션에 대한 내용을 추가했습니다.