### PR TITLE
FEATURE: Expand stats prefixes

### DIFF
--- a/engines/default/default_engine.c
+++ b/engines/default/default_engine.c
@@ -1218,6 +1218,19 @@ default_prefix_dump_stats(ENGINE_HANDLE* handle, const void* cookie, int *length
     return stats;
 }
 
+static char *
+ default_prefix_dump_stats_argu(ENGINE_HANDLE* handle, const void* cookie,
+     int *length, token_t *tokens, const size_t ntokens)
+ {
+     struct default_engine* engine = get_handle(handle);
+     char *stats;
+
+     pthread_mutex_lock(&engine->cache_lock);
+     stats = prefix_dump_stats_argu(length, tokens, ntokens);
+     pthread_mutex_unlock(&engine->cache_lock);
+     return stats;
+ }
+
 static ENGINE_ERROR_CODE
 default_prefix_get_stats(ENGINE_HANDLE* handle, const void* cookie,
                          const void* prefix, const int nprefix, ADD_STAT add_stat)
@@ -2024,6 +2037,7 @@ create_instance(uint64_t interface, GET_SERVER_API get_server_api,
          .get_stats        = default_get_stats,
          .reset_stats      = default_reset_stats,
          .prefix_dump_stats = default_prefix_dump_stats,
+         .prefix_dump_stats_argu = default_prefix_dump_stats_argu,
          .prefix_get_stats = default_prefix_get_stats,
          /* Dump API */
          .cachedump        = default_cachedump,

--- a/engines/default/prefix.h
+++ b/engines/default/prefix.h
@@ -81,6 +81,7 @@ void              prefix_bytes_decr(prefix_t *pt, ENGINE_ITEM_TYPE item_type, co
 bool              prefix_isvalid(hash_item *it, rel_time_t current_time);
 uint32_t          prefix_count(void);
 char *            prefix_dump_stats(int *length);
+char *            prefix_dump_stats_argu(int *length, token_t *tokens, const size_t ntokens);
 ENGINE_ERROR_CODE prefix_get_stats(const char *prefix, const int nprefix,
                                    ADD_STAT add_stat, const void *cookie);
 #ifdef SCAN_COMMAND

--- a/include/memcached/engine.h
+++ b/include/memcached/engine.h
@@ -658,6 +658,8 @@ extern "C" {
          * Statistical information for each prefix
          */
         char *(*prefix_dump_stats)(ENGINE_HANDLE* handle, const void* cookie, int *length);
+        char *(*prefix_dump_stats_argu)(ENGINE_HANDLE* handle, const void* cookie,
+                 int *length, token_t *tokens, const size_t ntokens);
 
         ENGINE_ERROR_CODE (*prefix_get_stats)(ENGINE_HANDLE* handle, const void* cookie,
                                               const void* prefix, const int nprefix,

--- a/stats.h
+++ b/stats.h
@@ -55,4 +55,5 @@ void stats_prefix_record_getattr(const char *key, const size_t nkey);
 void stats_prefix_record_setattr(const char *key, const size_t nkey);
 /*@null@*/
 char *stats_prefix_dump(int *length);
+char *stats_prefix_dump_argu(int *length, token_t *tokens, const size_t ntokens);
 void stats_prefix_get(const char *prefix, const size_t nprefix, ADD_STAT add_stat, void *cookie);


### PR DESCRIPTION
`stats prefixes` 명령을 확장합니다.

`stats prefixes item` 명령은 전체 prefixes에 대한 item 관련 stats를 리턴합니다.
`stats prefixes operation` 명령은 전체 prefixes에 대한 operation 관련 stats를 리턴합니다.
`stats prefixes <stats_type> <prefix1> <prefix2> …` 명령은 인자로 받은 prefix에 대한 item 또는 operation stats를 리턴합니다.

#648 