### PR TITLE
FEATURE: Expand stats prefixes command

### DIFF
--- a/engines/default/default_engine.c
+++ b/engines/default/default_engine.c
@@ -1208,13 +1208,14 @@ default_reset_stats(ENGINE_HANDLE* handle, const void *cookie)
 }
 
 static char *
-default_prefix_dump_stats(ENGINE_HANDLE* handle, const void* cookie, int *length)
+default_prefix_dump_stats(ENGINE_HANDLE* handle, const void* cookie,
+    token_t *tokens, const size_t ntokens, int *length)
 {
     struct default_engine* engine = get_handle(handle);
     char *stats;
 
     pthread_mutex_lock(&engine->cache_lock);
-    stats = prefix_dump_stats(length);
+    stats = prefix_dump_stats(tokens, ntokens, length);
     pthread_mutex_unlock(&engine->cache_lock);
     return stats;
 }

--- a/engines/default/prefix.h
+++ b/engines/default/prefix.h
@@ -80,7 +80,7 @@ void              prefix_bytes_incr(prefix_t *pt, ENGINE_ITEM_TYPE item_type, co
 void              prefix_bytes_decr(prefix_t *pt, ENGINE_ITEM_TYPE item_type, const uint32_t bytes);
 bool              prefix_isvalid(hash_item *it, rel_time_t current_time);
 uint32_t          prefix_count(void);
-char *            prefix_dump_stats(int *length);
+char *            prefix_dump_stats(token_t *tokenes, const size_t ntokens, int *length);
 ENGINE_ERROR_CODE prefix_get_stats(const char *prefix, const int nprefix,
                                    ADD_STAT add_stat, const void *cookie);
 #ifdef SCAN_COMMAND

--- a/engines/demo/demo_engine.c
+++ b/engines/demo/demo_engine.c
@@ -712,7 +712,8 @@ Demo_reset_stats(ENGINE_HANDLE* handle, const void *cookie)
 }
 
 static char *
-Demo_prefix_dump_stats(ENGINE_HANDLE* handle, const void* cookie, int *length)
+Demo_prefix_dump_stats(ENGINE_HANDLE* handle, const void* cookie,
+    token_t *tokens, const size_t ntokens, int *length)
 {
     *length = -1; /* It means ENGINE_ENOTSUP */
     return NULL;

--- a/include/memcached/engine.h
+++ b/include/memcached/engine.h
@@ -657,7 +657,8 @@ extern "C" {
         /**
          * Statistical information for each prefix
          */
-        char *(*prefix_dump_stats)(ENGINE_HANDLE* handle, const void* cookie, int *length);
+        char *(*prefix_dump_stats)(ENGINE_HANDLE* handle, const void* cookie,
+            token_t *tokenes, const size_t ntokens, int *length);
 
         ENGINE_ERROR_CODE (*prefix_get_stats)(ENGINE_HANDLE* handle, const void* cookie,
                                               const void* prefix, const int nprefix,

--- a/stats.h
+++ b/stats.h
@@ -54,5 +54,5 @@ void stats_prefix_record_bop_gbp(const char *key, const size_t nkey, const bool 
 void stats_prefix_record_getattr(const char *key, const size_t nkey);
 void stats_prefix_record_setattr(const char *key, const size_t nkey);
 /*@null@*/
-char *stats_prefix_dump(int *length);
+char *stats_prefix_dump(token_t *tokens, const size_t ntokens, int *length);
 void stats_prefix_get(const char *prefix, const size_t nprefix, ADD_STAT add_stat, void *cookie);


### PR DESCRIPTION
기존의 prefix_dump_stats 함수와 stats_prefix_dump 함수에 인자를 추가합니다.
- `char *prefix_dump_stats(int *length)`
  - `char *prefix_dump_stats(int *length, token_t *prefix_tokenes, const size_t nprefix_tokens)`
- `char *stats_prefix_dump(int *length)`
  - `char *stats_prefix_dump(int *length, token_t *prefix_tokens, const size_t nprefix_tokens)`

해당 인자에는 입력받은 token을 넘겨 해당 prefix에 대한 정보를 리턴합니다. 해당 인자가 NULL인 경우 기존과 같이 전체 prefixes에 대한 결과를 리턴합니다.

확장된 명령어는 다음과 같이 사용할 수 있습니다.
- `stats prefixes` (기존과 동일. 전체 prefixes의 item 관련 stats 리턴)
- `stats prefixes item` (`stats prefixes`와 동일. 전체 prefixes의 item 관련 stats 리턴)
- `stats prefixes operation` (`stats detail dump`와 유사. 전체 prefixes의 operation 관련 stats 리턴)
- `stats prefixes <item/operation> <prefix1> <prefix2> ...` (주어진 prefixes의 item 또는 operation 관련 stats 리턴)

이전 버전에서 확장된 명령어를 입력으로 받는 경우 에러 메시지가 아닌 `stats prefixes`의 수행 결과를 응답으로 보내기 때문에 주의가 필요합니다.

#648