### PR TITLE
ENHANCE: Add some stats to default stats command

### DIFF
--- a/engines/default/default_engine.c
+++ b/engines/default/default_engine.c
@@ -1170,6 +1170,7 @@ default_get_stats(ENGINE_HANDLE* handle, const void* cookie,
 
     if (stat_key == NULL) {
         item_stats_global(add_stat, cookie);
+        slabs_stats_basic(add_stat, cookie);
     }
     else if (strncmp(stat_key, "items", 5) == 0) {
         item_stats(add_stat, cookie);

--- a/engines/default/slabs.c
+++ b/engines/default/slabs.c
@@ -1501,6 +1501,12 @@ static void do_slabs_stats(ADD_STAT add_stats, const void *cookie)
     add_statistics(cookie, add_stats, NULL, -1, "total_malloced", "%llu", (unsigned long long)slabsp->mem_malloced);
 }
 
+/*@null@*/
+static void do_slabs_stats_basic(ADD_STAT add_stats, const void *cookie)
+{
+    add_statistics(cookie, add_stats, NULL, -1, "engine_malloced", "%llu", (unsigned long long)slabsp->mem_malloced);
+}
+
 static ENGINE_ERROR_CODE do_slabs_set_memlimit(size_t memlimit)
 {
     if (slabsp->mem_base != NULL) {
@@ -1556,6 +1562,13 @@ void slabs_stats(ADD_STAT add_stats, const void *c)
 {
     pthread_mutex_lock(&slabsp->lock);
     do_slabs_stats(add_stats, c);
+    pthread_mutex_unlock(&slabsp->lock);
+}
+
+void slabs_stats_basic(ADD_STAT add_stats, const void *c)
+{
+    pthread_mutex_lock(&slabsp->lock);
+    do_slabs_stats_basic(add_stats, c);
     pthread_mutex_unlock(&slabsp->lock);
 }
 

--- a/engines/default/slabs.h
+++ b/engines/default/slabs.h
@@ -99,6 +99,9 @@ void  slabs_free(void *ptr, size_t size, unsigned int id);
 /** Fill buffer with stats */ /*@null@*/
 void  slabs_stats(ADD_STAT add_stats, const void *c);
 
+/** Fill buffer with stats */ /*@null@*/
+void  slabs_stats_basic(ADD_STAT add_stats, const void *c);
+
 /** Adjust the stats for memory requested */
 void  slabs_adjust_mem_requested(unsigned int id, size_t old, size_t ntotal);
 

--- a/memcached.c
+++ b/memcached.c
@@ -8010,6 +8010,7 @@ static void server_stats(ADD_STAT add_stats, conn *c, bool aggregate)
     APPEND_STAT("bytes_read", "%"PRIu64, thread_stats.bytes_read);
     APPEND_STAT("bytes_written", "%"PRIu64, thread_stats.bytes_written);
     APPEND_STAT("limit_maxbytes", "%"PRIu64, settings.maxbytes);
+    APPEND_STAT("limit_maxconns", "%d", settings.maxconns);
     APPEND_STAT("threads", "%d", settings.num_threads);
     APPEND_STAT("conn_yields", "%"PRIu64, thread_stats.conn_yields);
     UNLOCK_STATS();


### PR DESCRIPTION
hubble-v3의 grafana에서 수집하는 stat을 기본 stats 명령의 결과에 포함되도록 변경합니다.
추가되는 stats는 다음과 같습니다.
- `stats settings` 결과 중 `maxconns`
- `stats slabs` 결과 중 `total_malloced`

기존 `stats settings`, `stats slabs` 명령의 결과는 그대로 유지하며, 기본 명령의 결과만 변경됩니다.

### 변경사항
- server_stats() 함수에 `limit_maxconns`가 추가됩니다.
- slabs_stats_basic() 함수가 추가됩니다.
  - `engine_malloced`를 결과에 포함합니다.

jam2in/arcus-hubble-v3#216