### PR TITLE
FIX: Use the second ip when it is 127.0.0.1

### DIFF
--- a/arcus_zk.c
+++ b/arcus_zk.c
@@ -1188,8 +1188,7 @@ static int get_zk_client_ipport(char *startp, char *endp, char *buf) {
     clientp++;
 
     colonp = memchr(clientp, ':', endp - clientp);
-    if (colonp && strncmp(clientp, "0.0.0.0", colonp - clientp) != 0
-               && strncmp(clientp, "127.0.0.1", colonp - clientp) != 0) {
+    if (colonp && strncmp(clientp, "0.0.0.0", colonp - clientp) != 0) {
         memcpy(buf, clientp, endp - clientp);
         return endp - clientp;
     }


### PR DESCRIPTION
- jam2in/arcus-works#355
- #653 

zk config string에서 두 번째 ip가 `127.0.0.1`인 경우 이를 그대로 사용합니다.