### PR TITLE
FIX: Increase the refcount when allocate a hash_item

### DIFF
--- a/engines/default/coll_list.c
+++ b/engines/default/coll_list.c
@@ -369,9 +369,7 @@ ENGINE_ERROR_CODE list_struct_create(const char *key, const uint32_t nkey,
             ret = ENGINE_ENOMEM;
         } else {
             ret = do_item_link(it);
-            if (ret != ENGINE_SUCCESS) {
-                do_item_free(it);
-            }
+            do_item_release(it);
         }
     }
     UNLOCK_CACHE();
@@ -432,20 +430,17 @@ ENGINE_ERROR_CODE list_elem_insert(const char *key, const uint32_t nkey,
             ret = do_item_link(it);
             if (ret == ENGINE_SUCCESS) {
                 *created = true;
-            } else {
-                do_item_free(it);
             }
         }
     }
     if (ret == ENGINE_SUCCESS) {
         ret = do_list_elem_insert(it, index, elem, cookie);
-        if (*created) {
-            if (ret != ENGINE_SUCCESS) {
-                do_item_unlink(it, ITEM_UNLINK_NORMAL);
-            }
-        } else {
-            do_item_release(it);
+        if (ret != ENGINE_SUCCESS && *created) {
+            do_item_unlink(it, ITEM_UNLINK_NORMAL);
         }
+    }
+    if (it) {
+        do_item_release(it);
     }
     UNLOCK_CACHE();
 
@@ -693,9 +688,7 @@ ENGINE_ERROR_CODE list_apply_item_link(void *engine, const char *key, const uint
     if (new_it) {
         /* Link the new item into the hash table */
         ret = do_item_link(new_it);
-        if (ret != ENGINE_SUCCESS) {
-            do_item_free(new_it);
-        }
+        do_item_release(new_it);
     } else {
         ret = ENGINE_ENOMEM;
     }

--- a/engines/default/coll_map.c
+++ b/engines/default/coll_map.c
@@ -735,9 +735,7 @@ ENGINE_ERROR_CODE map_struct_create(const char *key, const uint32_t nkey,
             ret = ENGINE_ENOMEM;
         } else {
             ret = do_item_link(it);
-            if (ret != ENGINE_SUCCESS) {
-                do_item_free(it);
-            }
+            do_item_release(it);
         }
     }
     UNLOCK_CACHE();
@@ -797,20 +795,17 @@ ENGINE_ERROR_CODE map_elem_insert(const char *key, const uint32_t nkey,
             ret = do_item_link(it);
             if (ret == ENGINE_SUCCESS) {
                 *created = true;
-            } else {
-                do_item_free(it);
             }
         }
     }
     if (ret == ENGINE_SUCCESS) {
         ret = do_map_elem_insert(it, elem, false /* replace_if_exist */, cookie);
-        if (*created) {
-            if (ret != ENGINE_SUCCESS) {
-                do_item_unlink(it, ITEM_UNLINK_NORMAL);
-            }
-        } else {
-            do_item_release(it);
+        if (ret != ENGINE_SUCCESS && *created) {
+            do_item_unlink(it, ITEM_UNLINK_NORMAL);
         }
+    }
+    if (it) {
+        do_item_release(it);
     }
     UNLOCK_CACHE();
 
@@ -1091,9 +1086,7 @@ ENGINE_ERROR_CODE map_apply_item_link(void *engine, const char *key, const uint3
     if (new_it) {
         /* Link the new item into the hash table */
         ret = do_item_link(new_it);
-        if (ret != ENGINE_SUCCESS) {
-            do_item_free(new_it);
-        }
+        do_item_release(new_it);
     } else {
         ret = ENGINE_ENOMEM;
     }

--- a/engines/default/coll_set.c
+++ b/engines/default/coll_set.c
@@ -655,9 +655,7 @@ ENGINE_ERROR_CODE set_struct_create(const char *key, const uint32_t nkey,
             ret = ENGINE_ENOMEM;
         } else {
             ret = do_item_link(it);
-            if (ret != ENGINE_SUCCESS) {
-                do_item_free(it);
-            }
+            do_item_release(it);
         }
     }
     UNLOCK_CACHE();
@@ -717,20 +715,17 @@ ENGINE_ERROR_CODE set_elem_insert(const char *key, const uint32_t nkey,
             ret = do_item_link(it);
             if (ret == ENGINE_SUCCESS) {
                 *created = true;
-            } else {
-                do_item_free(it);
             }
         }
     }
     if (ret == ENGINE_SUCCESS) {
         ret = do_set_elem_insert(it, elem, cookie);
-        if (*created) {
-            if (ret != ENGINE_SUCCESS) {
-                do_item_unlink(it, ITEM_UNLINK_NORMAL);
-            }
-        } else {
-            do_item_release(it);
+        if (ret != ENGINE_SUCCESS && *created) {
+            do_item_unlink(it, ITEM_UNLINK_NORMAL);
         }
+    }
+    if (it) {
+        do_item_release(it);
     }
     UNLOCK_CACHE();
 
@@ -1008,9 +1003,7 @@ ENGINE_ERROR_CODE set_apply_item_link(void *engine, const char *key, const uint3
     if (new_it) {
         /* Link the new item into the hash table */
         ret = do_item_link(new_it);
-        if (ret != ENGINE_SUCCESS) {
-            do_item_free(new_it);
-        }
+        do_item_release(new_it);
     } else {
         ret = ENGINE_ENOMEM;
     }

--- a/engines/default/default_engine.c
+++ b/engines/default/default_engine.c
@@ -358,12 +358,6 @@ default_item_allocate(ENGINE_HANDLE* handle, const void* cookie,
     return ret;
 }
 
-static void
-default_item_free(ENGINE_HANDLE* handle, const void *cookie, item* item)
-{
-    item_free(get_real_item(item));
-}
-
 static ENGINE_ERROR_CODE
 default_item_delete(ENGINE_HANDLE* handle, const void* cookie,
                     const void* key, const size_t nkey,
@@ -1966,7 +1960,6 @@ create_instance(uint64_t interface, GET_SERVER_API get_server_api,
 #endif
          /* Item API */
          .allocate          = default_item_allocate,
-         .free              = default_item_free,
          .remove            = default_item_delete,
          .release           = default_item_release,
          .get               = default_get,

--- a/engines/default/item_base.c
+++ b/engines/default/item_base.c
@@ -952,7 +952,7 @@ hash_item *do_item_alloc(const void *key, const uint32_t nkey,
 
     it->next = it->prev = it; /* special meaning: unlinked from LRU */
     it->h_next = 0;
-    it->refcount = 0;
+    it->refcount = 1;     /* the caller will have a reference */
     it->refchunk = 0;
     DEBUG_REFCNT(it, '*');
     it->iflag = config->use_cas ? ITEM_WITH_CAS : 0;

--- a/engines/default/items.h
+++ b/engines/default/items.h
@@ -43,12 +43,6 @@ hash_item *item_alloc(const void *key, const uint32_t nkey,
                       const uint32_t nbytes, const void *cookie);
 
 /**
- * Frees and adds an item to the freelist
- * @param it the item to free
- */
-void item_free(hash_item *it);
-
-/**
  * Get an item from the cache
  *
  * @param key the key for the item to get

--- a/engines/demo/demo_engine.c
+++ b/engines/demo/demo_engine.c
@@ -205,12 +205,6 @@ Demo_item_allocate(ENGINE_HANDLE* handle, const void* cookie,
     return ret;
 }
 
-static void
-Demo_item_free(ENGINE_HANDLE* handle, const void *cookie, item* item)
-{
-    dm_item_free(get_handle(handle), get_real_item(item));
-}
-
 static ENGINE_ERROR_CODE
 Demo_item_delete(ENGINE_HANDLE* handle, const void* cookie,
                     const void* key, const size_t nkey,
@@ -806,7 +800,6 @@ create_instance(uint64_t interface, GET_SERVER_API get_server_api,
          .destroy           = Demo_destroy,
          /* Item API */
          .allocate          = Demo_item_allocate,
-         .free              = Demo_item_free,
          .remove            = Demo_item_delete,
          .release           = Demo_item_release,
          .get               = Demo_get,

--- a/engines/demo/dm_items.c
+++ b/engines/demo/dm_items.c
@@ -431,6 +431,7 @@ static ENGINE_ERROR_CODE do_item_store_attach(struct demo_engine *engine,
             do_item_replace(engine, old_it, new_it);
             stored = ENGINE_SUCCESS;
             *cas = dm_item_get_cas(new_it);
+            do_item_release(engine, new_it);
         } else {
             /* SERVER_ERROR out of memory */
             stored = ENGINE_NOT_STORED;
@@ -474,16 +475,6 @@ hash_item *dm_item_alloc(struct demo_engine *engine,
     it = do_item_alloc(engine, key, nkey, flags, exptime, nbytes, cookie);
     pthread_mutex_unlock(&engine->cache_lock);
     return it;
-}
-
-/*
- * Frees an item.
- */
-void dm_item_free(struct demo_engine *engine, hash_item *item)
-{
-    pthread_mutex_lock(&engine->cache_lock);
-    do_item_free(engine, item);
-    pthread_mutex_unlock(&engine->cache_lock);
 }
 
 /*

--- a/engines/demo/dm_items.h
+++ b/engines/demo/dm_items.h
@@ -64,14 +64,6 @@ hash_item *dm_item_alloc(struct demo_engine *engine,
                       rel_time_t exptime, int nbytes, const void *cookie);
 
 /**
- * Frees an item
- *
- * @param engine handle to the storage engine
- * @param it the item to release
- */
-void dm_item_free(struct demo_engine *engine, hash_item *it);
-
-/**
  * Get an item from the cache
  *
  * @param engine handle to the storage engine

--- a/include/memcached/engine.h
+++ b/include/memcached/engine.h
@@ -252,15 +252,6 @@ extern "C" {
                                       const uint64_t cas);
 
         /**
-         * Frees and adds an item to the freelist.
-         *
-         * @param handle the engine handle
-         * @param cookie The cookie provided by the frontend
-         * @param item the item to be freed
-         */
-        void (*free)(ENGINE_HANDLE* handle, const void *cookie, item* item);
-
-        /**
          * Remove an item.
          *
          * @param handle the engine handle


### PR DESCRIPTION
- jam2in/arcus-works#357 
### 변경사항
- hash item allocation에서 refcount를 1로 초기화합니다.
  - 이에 따라 free 대신 release를 사용하도록 변경됩니다.
- `engine->free` api가 사용되는 곳이 없으므로 제거합니다.