### PR TITLE
INTERNAL: Do not use UNKNOWN version

### DIFF
--- a/config/version.pl
+++ b/config/version.pl
@@ -11,10 +11,15 @@ chomp $version;
 #my $version = '1.4.2-30-gf966dba';
 #my $version = '1.4.3-rc1';
 #my $version = '1.4.3';
-unless ($version =~ m/^\d+\.\d+\.\d+/) {
-    write_file('m4/version.m4', "m4_define([VERSION_NUMBER], [UNKNOWN])\n");
-    exit;
-}
+
+#unless ($version =~ m/^\d+\.\d+\.\d+/) {
+#    write_file('m4/version.m4', "m4_define([VERSION_NUMBER], [UNKNOWN])\n");
+#    exit;
+#}
+my $unknown_version_message = "Can't find recent tag from current commit.
+If you forked the repository, the tag might not be included.
+You need to fetch tags from upstream repository.";
+$version =~ m/^\d+\.\d+\.\d+/ or die $unknown_version_message;
 
 my @version_tokens = split /-/, $version;
 if (scalar @version_tokens > 2) {


### PR DESCRIPTION
`git describe`를 통해 태그로부터 버전 정보를 가져올 수 없는 경우, 버전을 `UNKNOWN`으로 설정하는 대신 스크립트 실행을 중단합니다.

https://github.com/naver/arcus-memcached/blob/79571d8bd48c4f6b5256407d57f6fe6e6b1f1cb6/config/autorun.sh#L3
https://github.com/naver/arcus-memcached/blob/79571d8bd48c4f6b5256407d57f6fe6e6b1f1cb6/config/autorun.sh#L43-L46

참고할 사항으로는, arcus-c-client와는 달리 `autorun.sh`가 `die` 함수를 포함하고 있어 수정 없이도 정상 동작하고 있습니다.
필요하다면 arcus-c-client의 `autorun.sh`에 `die()`를 추가하여 기존과 동일한 구현을 유지할 수 있습니다.

- arcus-memcached와 arcus-c-client가 유사한 구조를 가질 수 있음
- arcus-memcached의 `die()`는 여러 번 사용되지만, arcus-c-client에서 `die()`를 호출하는 경우는 한 번 뿐이므로
함수를 분리하는 것에 큰 이점은 없음