### PR TITLE
INTERNAL: Add zk_version to stats

### DIFF
--- a/arcus_zk.c
+++ b/arcus_zk.c
@@ -100,6 +100,17 @@
 #define MAX_SERVICECODE_LENGTH  128
 #define MAX_HOSTNAME_LENGTH     128
 
+#define STR_INNER(x) #x
+#define STR(x) STR_INNER(x)
+
+#ifndef ZOO_VERSION
+#ifdef ZOO_INHOUSE_VERSION
+#define ZOO_VERSION STR(ZOO_MAJOR_VERSION) "." STR(ZOO_MINOR_VERSION) "." STR(ZOO_PATCH_VERSION) "-p" STR(ZOO_INHOUSE_VERSION)
+#else
+#define ZOO_VERSION STR(ZOO_MAJOR_VERSION) "." STR(ZOO_MINOR_VERSION) "." STR(ZOO_PATCH_VERSION)
+#endif
+#endif
+
 #ifdef ENABLE_ZK_RECONFIG
 /* The maximum config data size per ZK server is 600.
  * Therefore, config data of about 26 ZK servers can be stored.
@@ -145,6 +156,7 @@ typedef struct {
     char    *mc_hostnameport;   // this memcached hostname:port string
     char    *hostip;            // localhost server IP
     int     port;               // memcached port number
+    char    *zk_version;
     bool    zk_failstop;        // memcached automatic failstop on/off
     int     zk_timeout;         // Zookeeper session timeout
     bool    auto_scrub;         // automactic scrub_stale
@@ -176,6 +188,7 @@ arcus_zk_config arcus_conf = {
     .hostip         = NULL,
     .zk_failstop    = true,
     .zk_timeout     = DEFAULT_ZK_TO,
+    .zk_version     = ZOO_VERSION,
     .auto_scrub     = true,
     .znode_name     = NULL,
     .znode_ver      = -1,
@@ -1825,6 +1838,7 @@ bool arcus_zk_get_failstop(void)
 
 void arcus_zk_get_confs(arcus_zk_confs *confs)
 {
+    confs->zk_version = arcus_conf.zk_version;
     confs->zk_timeout = arcus_conf.zk_timeout;
     confs->zk_failstop = arcus_conf.zk_failstop;
 }

--- a/arcus_zk.h
+++ b/arcus_zk.h
@@ -25,6 +25,7 @@
 #ifdef ENABLE_ZK_INTEGRATION
 
 typedef struct {
+    char     *zk_version; // Zookeeper client version
     uint32_t zk_timeout;  // Zookeeper session timeout (unit: ms)
     bool     zk_failstop; // memcached automatic failstop
 } arcus_zk_confs;

--- a/memcached.c
+++ b/memcached.c
@@ -8086,6 +8086,7 @@ static void process_stats_zookeeper(ADD_STAT add_stats, void *c)
     arcus_zk_get_confs(&zk_confs);
     arcus_zk_get_stats(&zk_stats);
 
+    APPEND_STAT("zk_version", "%s", zk_confs.zk_version);
     APPEND_STAT("zk_timeout", "%u", zk_confs.zk_timeout);
     APPEND_STAT("zk_failstop", "%s", zk_confs.zk_failstop ? "on" : "off");
     APPEND_STAT("zk_connected", "%s", zk_stats.zk_connected ? "true" : "false");


### PR DESCRIPTION
- jam2in/arcus-works#364

memcached에서 stats 명령을 통해 zookeeper version 정보를 조회할 수 있게 추가했습니다.

version 정보 조회 코드는 아래와 같습니다.

#define STR_INNER(x) #x
#define STR(x) STR_INNER(x)

#ifndef ZOO_VERSION
#ifdef ZOO_INHOUSE_VERSION
#define ZOO_VERSION STR(ZOO_MAJOR_VERSION) "." STR(ZOO_MINOR_VERSION) "." STR(ZOO_PATCH_VERSION) "-p" STR(ZOO_INHOUSE_VERSION)
#else
#define ZOO_VERSION STR(ZOO_MAJOR_VERSION) "." STR(ZOO_MINOR_VERSION) "." STR(ZOO_PATCH_VERSION)
#endif
#endif

Arcus 및 apache 오픈소스 zookeeper 헤더 파일에서
매크로를 통해 버전 정보를 string 형태로 변환하여 가져옵니다.

버전 string 정보가 담긴 ZOO_VERSION(현재 apache zookeeper 사용 방식)가 정의 되지 않은 경우
구버전에 정의된 ZOO_MAJOR_VERSION, ZOO_MINOR_VERSION, ZOO_PATCH_VERSION 정보,
그리고 ZOO_PATCH_VERSION(현재 arcus zookeeper에서 추가한 패치 정보)를 조합하여 
ZOO_VERSION을 정의합니다.