### PR TITLE
INTERNAL: Add zk_version to stats

### DIFF
--- a/arcus_zk.c
+++ b/arcus_zk.c
@@ -1825,6 +1825,7 @@ bool arcus_zk_get_failstop(void)
 
 void arcus_zk_get_confs(arcus_zk_confs *confs)
 {
+    confs->zk_libversion = zoo_version_str();
     confs->zk_timeout = arcus_conf.zk_timeout;
     confs->zk_failstop = arcus_conf.zk_failstop;
 }

--- a/arcus_zk.h
+++ b/arcus_zk.h
@@ -25,8 +25,9 @@
 #ifdef ENABLE_ZK_INTEGRATION
 
 typedef struct {
-    uint32_t zk_timeout;  // Zookeeper session timeout (unit: ms)
-    bool     zk_failstop; // memcached automatic failstop
+    const char  *zk_libversion; // Zookeeper client version
+    uint32_t    zk_timeout;     // Zookeeper session timeout (unit: ms)
+    bool        zk_failstop;    // memcached automatic failstop
 } arcus_zk_confs;
 
 typedef struct {

--- a/memcached.c
+++ b/memcached.c
@@ -8086,6 +8086,7 @@ static void process_stats_zookeeper(ADD_STAT add_stats, void *c)
     arcus_zk_get_confs(&zk_confs);
     arcus_zk_get_stats(&zk_stats);
 
+    APPEND_STAT("zk_libversion", "%s", zk_confs.zk_libversion);
     APPEND_STAT("zk_timeout", "%u", zk_confs.zk_timeout);
     APPEND_STAT("zk_failstop", "%s", zk_confs.zk_failstop ? "on" : "off");
     APPEND_STAT("zk_connected", "%s", zk_stats.zk_connected ? "true" : "false");


### PR DESCRIPTION
zookeeper 함수명 변경 내용에 맞추어 stats 명령시
zk_libversion을 출력하게 설정되었습니다.