### PR TITLE
FIX: Fix compile warning - a function declaration without a prototype is deprecated in all versions of C

### DIFF
--- a/engine_testapp.c
+++ b/engine_testapp.c
@@ -527,7 +527,7 @@ static ENGINE_HANDLE_V1 *start_your_engines(const char *engine, const char* cfg,
     return &mock_engine.me;
 }
 
-static void destroy_engine() {
+static void destroy_engine(void) {
     if (handle_v1) {
         handle_v1->destroy(handle);
         handle_v1 = NULL;

--- a/memcached.c
+++ b/memcached.c
@@ -66,22 +66,22 @@
 static pthread_mutex_t stats_lock = PTHREAD_MUTEX_INITIALIZER;
 
 
-void LOCK_STATS() {
+void LOCK_STATS(void) {
     pthread_mutex_lock(&stats_lock);
 }
 
-void UNLOCK_STATS() {
+void UNLOCK_STATS(void) {
     pthread_mutex_unlock(&stats_lock);
 }
 
 /* Lock for global settings */
 static pthread_mutex_t setting_lock = PTHREAD_MUTEX_INITIALIZER;
 
-void LOCK_SETTING() {
+void LOCK_SETTING(void) {
     pthread_mutex_lock(&setting_lock);
 }
 
-void UNLOCK_SETTING() {
+void UNLOCK_SETTING(void) {
     pthread_mutex_unlock(&setting_lock);
 }
 

--- a/mock_server.c
+++ b/mock_server.c
@@ -58,7 +58,7 @@ static int mock_get_socket_fd(const void *cookie) {
     return c->sfd;
 }
 
-static const char *mock_get_server_version() {
+static const char *mock_get_server_version(void) {
     return "mock server";
 }
 

--- a/stats.c
+++ b/stats.c
@@ -134,7 +134,7 @@ void stats_prefix_init(char delimiter, void (*cb_when_prefix_overflow)(void))
  * Cleans up all our previously collected stats. NOTE: the stats lock is
  * assumed to be held when this is called.
  */
-void stats_prefix_clear()
+void stats_prefix_clear(void)
 {
     PREFIX_STATS *curr, *next;
 
@@ -150,7 +150,7 @@ void stats_prefix_clear()
     total_prefix_size = 0;
 }
 
-int stats_prefix_count()
+int stats_prefix_count(void)
 {
     return num_prefixes;
 }
@@ -1584,8 +1584,8 @@ static void run_test(char *what, void (*func)(void))
 }
 
 /* In case we're compiled in thread mode */
-void mt_stats_lock() { }
-void mt_stats_unlock() { }
+void mt_stats_lock(void) { }
+void mt_stats_unlock(void) { }
 
 main(int argc, char **argv)
 {


### PR DESCRIPTION
인자가 없는 함수에 인자로 void 키워드를 넣어야 제거되는 컴파일 워닝입니다.
MacOS 업데이트 이후 발견되어 수정합니다.