### PR TITLE
FIX: Remove unnecessary files from MacOS and Visual Studio Code.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,9 @@ Makefile.in
 TAGS
 cscope.out
 tags
+
+# MacOS
+.DS_Store
+
+# Visual Stuido Code
+.vscode


### PR DESCRIPTION
MacOS에서 Visual Studio Code로 작업 시 생성되는 불필요한 파일들을 gitignore에 추가했습니다.