### PR TITLE
FIX: Fix compile warning - a function declaration without a prototype is deprecated in all versions of C

### DIFF
--- a/arcus_zk.c
+++ b/arcus_zk.c
@@ -1721,7 +1721,7 @@ int arcus_zk_get_ensemble(char *buf, int size)
     return ret;
 }
 
-int arcus_zk_rejoin_ensemble()
+int arcus_zk_rejoin_ensemble(void)
 {
     int ret = 0;
 

--- a/cmdlog.c
+++ b/cmdlog.c
@@ -134,7 +134,7 @@ static void do_cmdlog_stop(int cause)
     cmdlog.on_logging = false;
 }
 
-static void *cmdlog_flush_thread()
+static void *cmdlog_flush_thread(void *arg)
 {
     struct cmd_log_buffer *buffer = &cmdlog.buffer;
     char fname[CMDLOG_FILENAME_LENGTH];

--- a/engines/default/cmdlogmgr.c
+++ b/engines/default/cmdlogmgr.c
@@ -89,7 +89,7 @@ static struct cmdlog_global logmgr_gl;
 static __thread log_waiter_t *tls_waiter = NULL;
 
 /* Recovery Function */
-static ENGINE_ERROR_CODE cmdlog_mgr_recovery()
+static ENGINE_ERROR_CODE cmdlog_mgr_recovery(void)
 {
     /* find and set the last completed snapshot info. */
     int ret = chkpt_recovery_analysis();

--- a/lqdetect.c
+++ b/lqdetect.c
@@ -256,7 +256,7 @@ int lqdetect_init(EXTENSION_LOGGER_DESCRIPTOR *logger)
     return 0;
 }
 
-void lqdetect_final()
+void lqdetect_final(void)
 {
     for (int ii = 0; ii < LQ_CMD_NUM; ii++) {
         free(lqdetect.buffer[ii].data);

--- a/rfc1321/md5c.c
+++ b/rfc1321/md5c.c
@@ -97,8 +97,7 @@ static unsigned char PADDING[64] = {
 
 /* MD5 initialization. Begins an MD5 operation, writing a new context.
 */
-void MD5Init (context)
-        MD5_CTX *context;                                        /* context */
+void MD5Init (MD5_CTX *context)
 {
     context->count[0] = context->count[1] = 0;
     /* Load magic initialization constants.
@@ -113,10 +112,7 @@ void MD5Init (context)
    operation, processing another message block, and updating the
    context.
    */
-void MD5Update (context, input, inputLen)
-        MD5_CTX *context;                                        /* context */
-        unsigned char *input;                                /* input block */
-        unsigned int inputLen;                     /* length of input block */
+void MD5Update (MD5_CTX *context, unsigned char *input, unsigned int inputLen)
 {
     unsigned int i, index, partLen;
 
@@ -155,9 +151,7 @@ void MD5Update (context, input, inputLen)
 /* MD5 finalization. Ends an MD5 message-digest operation, writing the
    the message digest and zeroizing the context.
    */
-void MD5Final (digest, context)
-        unsigned char digest[16];                        /* message digest */
-        MD5_CTX *context;                                       /* context */
+void MD5Final (unsigned char digest[16], MD5_CTX *context)
 {
     unsigned char bits[8];
     unsigned int index, padLen;
@@ -184,9 +178,7 @@ void MD5Final (digest, context)
 
 /* MD5 basic transformation. Transforms state based on block.
 */
-static void MD5Transform (state, block)
-        UINT4 state[4];
-        unsigned char block[64];
+static void MD5Transform (UINT4 state[4], unsigned char block[64])
 {
     UINT4 a = state[0], b = state[1], c = state[2], d = state[3], x[16];
 
@@ -277,10 +269,7 @@ static void MD5Transform (state, block)
 /* Encodes input (UINT4) into output (unsigned char). Assumes len is
    a multiple of 4.
    */
-static void Encode (output, input, len)
-        unsigned char *output;
-        UINT4 *input;
-        unsigned int len;
+static void Encode (unsigned char *output, UINT4 *input, unsigned int len)
 {
     unsigned int i, j;
 
@@ -295,10 +284,7 @@ static void Encode (output, input, len)
 /* Decodes input (unsigned char) into output (UINT4). Assumes len is
    a multiple of 4.
    */
-static void Decode (output, input, len)
-        UINT4 *output;
-        unsigned char *input;
-        unsigned int len;
+static void Decode (UINT4 *output, unsigned char *input, unsigned int len)
 {
     unsigned int i, j;
 
@@ -310,10 +296,7 @@ static void Decode (output, input, len)
 /* Note: Replace "for loop" with standard memcpy if possible.
 */
 
-static void MD5_memcpy (output, input, len)
-        POINTER output;
-        POINTER input;
-        unsigned int len;
+static void MD5_memcpy (POINTER output, POINTER input, unsigned int len)
 {
     unsigned int i;
 
@@ -323,10 +306,7 @@ static void MD5_memcpy (output, input, len)
 
 /* Note: Replace "for loop" with standard memset if possible.
 */
-static void MD5_memset (output, value, len)
-        POINTER output;
-        int value;
-        unsigned int len;
+static void MD5_memset (POINTER output, int value, unsigned int len)
 {
     unsigned int i;
 

--- a/stats.c
+++ b/stats.c
@@ -1450,7 +1450,7 @@ static void test_equals_ull(char *what, uint64_t a, uint64_t b) { test_count++; 
 static void test_notequals_ptr(char *what, void *a, void *b) { test_count++; if (a == b) fail(what); }
 static void test_notnull_ptr(char *what, void *a) { test_count++; if (a == NULL) fail(what); }
 
-static void test_prefix_find()
+static void test_prefix_find(void)
 {
     PREFIX_STATS *pfs1, *pfs2;
 
@@ -1470,7 +1470,7 @@ static void test_prefix_find()
     test_notequals_ptr("find of shorter prefix", pfs1, pfs2);
 }
 
-static void test_prefix_record_get()
+static void test_prefix_record_get(void)
 {
     PREFIX_STATS *pfs;
 
@@ -1489,7 +1489,7 @@ static void test_prefix_record_get()
     test_equals_ull("hit count after get #4", 1, pfs->num_hits);
 }
 
-static void test_prefix_record_delete()
+static void test_prefix_record_delete(void)
 {
     PREFIX_STATS *pfs;
 
@@ -1503,7 +1503,7 @@ static void test_prefix_record_delete()
     test_equals_ull("delete count after delete #2", 1, pfs->num_deletes);
 }
 
-static void test_prefix_record_set()
+static void test_prefix_record_set(void)
 {
     PREFIX_STATS *pfs;
 
@@ -1517,7 +1517,7 @@ static void test_prefix_record_set()
     test_equals_ull("set count after set #2", 1, pfs->num_sets);
 }
 
-static void test_prefix_dump()
+static void test_prefix_dump(void)
 {
     int hashval = mc_hash("abc", 3, 0) % PREFIX_HASH_SIZE;
     char tmp[500];

--- a/thread.c
+++ b/thread.c
@@ -638,7 +638,7 @@ void dispatch_conn_new(int sfd, STATE_FUNC init_state, int event_flags,
 /*
  * Returns true if this is the thread that listens for new TCP connections.
  */
-int is_listen_thread()
+int is_listen_thread(void)
 {
 #ifdef __WIN32__
     pthread_t tid = pthread_self();


### PR DESCRIPTION
https://github.com/naver/arcus-memcached/pull/669

후속 PR 입니다. 이전 PR에서 놓친 부분을 모두 찾아 컴파일 워닝을 제거했습니다.
cmdlog_flush_thread() 함수의 경우 사용처에서 void* 타입의 인자를 요구하기 때문에 해당 타입의 인자를 추가했습니다.