### PR TITLE
INTERNAL: Remove dependencies of write method in command protocol

### DIFF
--- a/memcached.h
+++ b/memcached.h
@@ -435,6 +435,9 @@ struct conn {
 
     ENGINE_ERROR_CODE aiostat;
     bool ewouldblock;
+
+    const void *terse;      /* Used for containing single message of command */
+    STATE_FUNC next_state;  /* Used for containing next state */
 #ifdef MULTI_NOTIFY_IO_COMPLETE
     /* ewouldblock=true is set when the command returns EWOULDBLOCK.
      * The worker thread is going to remove the connection from the


### PR DESCRIPTION
- jam2in/arcus-works#442
ASCII / Binary 프로토콜 모듈화에 대한 첫번째 PR입니다.

이후 이루어질 파일 분리를 위하여 각 명령어 프로토콜에 관한 함수 및 변수에서
출력 버퍼 관련 종속성을 제거하는 작업입니다.

해당 작업을 위해 connection 구조체에 아래의 변수가 추가되었습니다.

```
const void *terse; // single line string 출력을 위해 일시적으로 저장하는 변수
STATE_FUNC next_state; // 명령어 수행 이후 다음에 가야할 상태에 대한 변수
```

대부분의 경우 최대한 기존 memcached 로직에서 변경되지 않게 끔 구현했습니다.

Files changed에서 보이는 대부분은 아래의 두 경우로 생각하시면 됩니다.

out_string을 호출했던 부분  ⇨  terse 변수에 저장
```
ex) out_string(c, "ABCDE")  ⇨  c->teases = "ABCDE"
```
add_iov를 호출했던 부분   ⇨ add_dynamic_buffer을 호출
```
ex) add_iov(c, "ABCDE", 5) ⇨ add_dynamic_buffer(c, "ABCDE", 5)
```

```add_dynamic_buffer```의 경우 기존의 ```grow_dynamic_buffer```에서
유동적인 multi line string의 크기에 맞추어 동적으로 buffer의 크기를 변화하도록
변경된 함수입니다.

command 모듈에서 수행 및 결과 처리를 위해 ```init_cmd_setting```, ```clear_result``` 함수가 추가되었습니다.
```init_cmd_setting```에서는 이전 명령어 처리에서 dynamic_buffer 크기가 증가되었을 경우 다시 축소시키며,
기타 변수들을 초기화합니다. ```clear_result```의 경우 command 결과에 맞추어 out_string 혹은 add_iov를
수행시키고, state를 변경합니다.

이에 대한 내용 및 기타 사항은 추가된 것 위주로 따로 코멘트를 달겠습니다.