### PR TITLE
FIX: Initialize array with 0

### DIFF
--- a/engines/default/coll_btree.c
+++ b/engines/default/coll_btree.c
@@ -1573,7 +1573,7 @@ static void do_btree_node_merge(btree_meta_info *info, btree_elem_posi *path,
                 }
             }
         } else { /* cur_node_count > 1 */
-            btree_elem_posi  upth[BTREE_MAX_DEPTH]; /* upper node path */
+            btree_elem_posi  upth[BTREE_MAX_DEPTH] = { 0 }; /* upper node path */
             btree_elem_posi  s_posi;
             int tot_unlink_cnt = 0;
             int cur_unlink_cnt = 0;


### PR DESCRIPTION
- jam2in/arcus-works#432

```
25.83 engines/default/coll_btree.c:1587:20: error: 'upth[upp_depth].node' may be used uninitialized [-Werror=maybe-uninitialized]
25.83  1587 |             s_posi = upth[upp_depth];
25.83       |             ~~~~~~~^~~~~~~~~~~~~~~~~
25.83 engines/default/coll_btree.c:1576:30: note: 'upth' declared here
25.83  1576 |             btree_elem_posi  upth[BTREE_MAX_DEPTH]; /* upper node path */
25.83       |                              ^~~~
```

컴파일 Warning 해결을 위해 배열 생성 시 값을 초기화합니다.