### PR TITLE
FIX: Add braces around initializer

### DIFF
--- a/engines/default/coll_btree.c
+++ b/engines/default/coll_btree.c
@@ -1573,7 +1573,7 @@ static void do_btree_node_merge(btree_meta_info *info, btree_elem_posi *path,
                 }
             }
         } else { /* cur_node_count > 1 */
-            btree_elem_posi  upth[BTREE_MAX_DEPTH] = { 0 }; /* upper node path */
+            btree_elem_posi  upth[BTREE_MAX_DEPTH] = {{ 0 }}; /* upper node path */
             btree_elem_posi  s_posi;
             int tot_unlink_cnt = 0;
             int cur_unlink_cnt = 0;


### PR DESCRIPTION
- #676 

```
engines/default/coll_btree.c: In function 'do_btree_node_merge':
engines/default/coll_btree.c:1576:13: error: missing braces around initializer [-Werror=missing-braces]
             btree_elem_posi  upth[BTREE_MAX_DEPTH] = { 0, }; /* upper node path */
             ^
engines/default/coll_btree.c:1576:13: error: (near initialization for 'upth[0]') [-Werror=missing-braces]
```

이전 PR 적용 후 생긴 Werror를 수정합니다.