### PR TITLE
Add ifdef for ENABLE_DTRACE

### DIFF
--- a/engines/default/assoc.c
+++ b/engines/default/assoc.c
@@ -166,7 +166,9 @@ static void redistribute(void)
 hash_item *assoc_find(const char *key, const uint32_t nkey, uint32_t hash)
 {
     hash_item *it;
+#ifdef ENABLE_DTRACE
     int depth = 0;
+#endif
     uint32_t bucket = GET_HASH_BUCKET(hash, assocp->hashmask);
     uint32_t tabidx = CUR_HASH_TABIDX(hash, bucket);
 
@@ -177,7 +179,9 @@ hash_item *assoc_find(const char *key, const uint32_t nkey, uint32_t hash)
             break; /* found */
         }
         it = it->h_next;
+#ifdef ENABLE_DTRACE
         ++depth;
+#endif
     }
     MEMCACHED_ASSOC_FIND(key, nkey, depth);
     return it;


### PR DESCRIPTION
- jam2in/arcus-works#432

`ENABLE_DTRACE` 상태에서만 사용되는 depth 변수 관련 line에 `#ifdef`를 적용합니다.