### PR TITLE
FIX: Bring back and modify an error handling logic in UDP

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -138,8 +138,7 @@ enum try_read_result {
     READ_DATA_RECEIVED,
     READ_NO_DATA_RECEIVED,
     READ_ERROR,            /** an error occured (on the socket) (or client closed connection) */
-    READ_MEMORY_ERROR,     /** failed to allocate more memory */
-    READ_INVALID_DATA,     /** received a invalid data */
+    READ_MEMORY_ERROR      /** failed to allocate more memory */
 };
 
 static enum try_read_result try_read_network(conn *c);
@@ -13358,9 +13357,7 @@ static enum try_read_result try_read_udp(conn *c)
 
         /* If this is a multi-packet request, drop it. */
         if (buf[4] != 0 || buf[5] != 1) {
-            out_string(c, "NOT_SUPPORTED");
-            c->write_and_go = conn_waiting;
-            return READ_INVALID_DATA;
+            return READ_NO_DATA_RECEIVED;
         }
 
         /* Don't care about any of the rest of the header. */
@@ -13643,7 +13640,6 @@ bool conn_read(conn *c)
         conn_set_state(c, conn_closing);
         break;
     case READ_MEMORY_ERROR: /* Failed to allocate more memory */
-    case READ_INVALID_DATA: /* Received a invalid data */
         /* State already set by try_read_network */
         break;
     }


### PR DESCRIPTION
UDP 프로토콜에서 유효하지 않은 데이터(멀티 패킷)에 대한 처리 로직을
이전 방식대로 READ_NO_DATA_RECEIVED를 반환하도록 변경.
out_string을 제거했습니다.

변경 이유는 현재 사용되지 않는 기능에서 발생한 에러 처리에 대하여
이후 활용될 때 해당 부분을 다시 논의하는 것이 좋으며, 우선적으로
오픈소스 memcached 에서 활용하는 방안을 따르고자 합니다. 
 > 링크
https://github.com/memcached/memcached/blob/efee763c93249358ea5b3b42c7fd4e57e2599c30/memcached.c#L2415-L2418

- jam2in/arcus-works#439
- #681