### PR TITLE
FIX: Use signal function instead of sigignore

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -643,7 +643,6 @@ fi
 AC_CHECK_FUNCS(mlockall)
 AC_CHECK_FUNCS(getpagesizes)
 AC_CHECK_FUNCS(memcntl)
-AC_CHECK_FUNCS(sigignore)
 
 AC_DEFUN([AC_C_ALIGNMENT],
 [AC_CACHE_CHECK(for alignment, ac_cv_c_alignment,
@@ -729,7 +728,7 @@ if test "$ICC" = "yes"
 then
    dnl ICC trying to be gcc.
    CFLAGS="$CFLAGS -diag-disable 187 -Wall -Werror"
-   AC_DEFINE([_GNU_SOURCE],[1],[find sigignore on Linux])
+   AC_DEFINE([_GNU_SOURCE],[1],[make sure IOV_MAX is defined])
 elif test "$GCC" = "yes"
 then
   GCC_VERSION=`$CC -dumpversion`
@@ -739,7 +738,7 @@ then
     CFLAGS="$CFLAGS -fno-strict-aliasing"
     ;;
   esac
-  AC_DEFINE([_GNU_SOURCE],[1],[find sigignore on Linux])
+  AC_DEFINE([_GNU_SOURCE],[1],[make sure IOV_MAX is defined])
 elif test "$SUNCC" = "yes"
 then
   CFLAGS="$CFLAGS -errfmt=error -errwarn -errshort=tags"

--- a/memcached.c
+++ b/memcached.c
@@ -14534,18 +14534,6 @@ static void remove_pidfile(const char *pid_file)
     }
 }
 
-#ifndef HAVE_SIGIGNORE
-static int sigignore(int sig)
-{
-    struct sigaction sa = { .sa_handler = SIG_IGN, .sa_flags = 0 };
-
-    if (sigemptyset(&sa.sa_mask) == -1 || sigaction(sig, &sa, 0) == -1) {
-        return -1;
-    }
-    return 0;
-}
-#endif /* !HAVE_SIGIGNORE */
-
 static void sigterm_handler(int sig)
 {
     assert(sig == SIGTERM || sig == SIGINT);
@@ -15626,7 +15614,7 @@ int main (int argc, char **argv)
     /* daemonize if requested */
     /* if we want to ensure our ability to dump core, don't chdir to / */
     if (do_daemonize) {
-        if (sigignore(SIGHUP) == -1) {
+        if (signal(SIGHUP, SIG_IGN) == SIG_ERR) {
             mc_logger->log(EXTENSION_LOG_WARNING, NULL,
                     "Failed to ignore SIGHUP: %s", strerror(errno));
         }
@@ -15692,7 +15680,7 @@ int main (int argc, char **argv)
      * ignore SIGPIPE signals; we can use errno == EPIPE if we
      * need that information
      */
-    if (sigignore(SIGPIPE) == -1) {
+    if (signal(SIGPIPE, SIG_IGN) == SIG_ERR) {
         mc_logger->log(EXTENSION_LOG_WARNING, NULL,
                 "failed to ignore SIGPIPE; sigaction");
         exit(EX_OSERR);


### PR DESCRIPTION
glibc 일정 버전 이상에서 컴파일되지 않는 문제를 수정합니다.

오픈소스 memcached 에서도 같은 이슈가 있었기에 동일한 방식으로 수정했습니다.

- memcached/memcached#707
- [```memcached/memcached/8e5148c```](https://github.com/memcached/memcached/commit/8e5148ca5c32fafca948e43c2e966db28a50a5f4)