### PR TITLE
INTERNAL: Add CI test

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+      branches: [ "master" ]
+  pull_request:
+      branches: [ "develop" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Install ARCUS Dependencies
+      run: sudo apt-get install -qq build-essential autoconf automake libtool libcppunit-dev python-setuptools python-dev ant
+    - name: Cache ARCUS Directory
+      id: arcus-cache
+      uses: actions/cache@v3.3.2
+      with:
+        path: ~/arcus
+        key: ${{runner.os}}-arcus
+    - name: Install ARCUS
+      if: steps.arcus-cache.outputs.cache-hit != 'true'
+      run: |
+        set -e
+
+        # clone
+        git clone --recursive https://github.com/naver/arcus.git $HOME/arcus
+
+        # build dependencies
+        cd ~/arcus/scripts && ./build.sh
+
+    - name: Build Arcus Server
+      run: |
+          ./config/autorun.sh
+          ./configure --enable-zk-integration --with-zk-reconfig --with-libevent=${HOME}/arcus --with-zookeeper=${HOME}/arcus
+          make
+    - name: Test ARCUS Server
+      run: make test


### PR DESCRIPTION
GitHub action에 CI 테스트를 추가합니다.

관련 build 및 make test를 수행합니다.

환경의 경우 현재는 Arcus-java-client의 GitHub-action 환경과 유사하게 설정했습니다.