### PR TITLE
FIX: Revert version.pl about unknown version

### DIFF
--- a/config/version.pl
+++ b/config/version.pl
@@ -12,14 +12,10 @@ chomp $version;
 #my $version = '1.4.3-rc1';
 #my $version = '1.4.3';
 
-#unless ($version =~ m/^\d+\.\d+\.\d+/) {
-#    write_file('m4/version.m4', "m4_define([VERSION_NUMBER], [UNKNOWN])\n");
-#    exit;
-#}
-my $unknown_version_message = "Can't find recent tag from current commit.
-If you forked the repository, the tag might not be included.
-You need to fetch tags from upstream repository.";
-$version =~ m/^\d+\.\d+\.\d+/ or die $unknown_version_message;
+unless ($version =~ m/^\d+\.\d+\.\d+/) {
+    write_file('m4/version.m4', "m4_define([VERSION_NUMBER], [1.13.4-unknown])\n");
+    exit;
+}
 
 my @version_tokens = split /-/, $version;
 if (scalar @version_tokens > 2) {


### PR DESCRIPTION
- jam2in/arcus-works#368
- #664 
- #689 

`git describe`에 실패하는 경우(tag 정보를 가져올 수 없는 경우) 실패하는 대신
`<latest release>-unknown` 버전을 사용하도록 변경합니다.

이 PR이 적용된 이후에는 매 릴리즈 마다 version.pl 파일을 함께 변경해 주어야 합니다.