### PR TITLE
INTERNAL: Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,64 @@
+ARG \
+    libevent_version="2.1.12-stable" \
+    zookeeper_version="3.5.9-p3" \
+    configure_options="--enable-zk-integration"
+
+FROM centos:7 AS builder
+RUN yum update -y
+RUN yum install -y gcc gcc-c++ make m4 perl autoconf automake libtool pkgconfig cppunit-devel ant which git
+ARG libevent_version zookeeper_version configure_options
+## Libevent
+WORKDIR /tmp
+ADD https://github.com/libevent/libevent/releases/download/release-${libevent_version}/libevent-${libevent_version}.tar.gz .
+RUN tar -zxf libevent-${libevent_version}.tar.gz
+WORKDIR libevent-${libevent_version}
+RUN ./configure --disable-openssl --prefix=/arcus
+RUN make && make install
+## ZooKeeper C client
+WORKDIR /tmp
+RUN git clone https://github.com/naver/arcus-zookeeper.git -b ${zookeeper_version}
+WORKDIR arcus-zookeeper
+RUN ant compile_jute
+WORKDIR zookeeper-client/zookeeper-client-c
+RUN autoreconf -if
+RUN ./configure --prefix=/arcus
+RUN make && make install
+## Memcached
+COPY . /tmp/arcus-memcached
+WORKDIR /tmp/arcus-memcached
+RUN ./config/autorun.sh
+RUN ./configure --prefix=/arcus --with-libevent=/arcus --with-zookeeper=/arcus ${configure_options}
+RUN make && make install
+
+FROM centos:7 AS base
+ARG libevent_version zookeeper_version configure_options
+LABEL \
+    libevent="$libevent_version" \
+    zookeeper="$zookeeper_version" \
+    configure="$configure_options"
+#   document="https://github.com/naver/arcus-memcached"
+COPY --from=builder /arcus /arcus
+ENV PATH ${PATH}:/arcus/bin
+
+ENTRYPOINT ["memcached",\
+ "-E", "/arcus/lib/default_engine.so",\
+ "-X", "/arcus/lib/ascii_scrub.so",\
+ "-u", "root",\
+ "-D", ":",\
+ "-r"]
+CMD [\
+ "-v",\
+ "-p", "11211",\
+ "-m", "100",\
+ "-c", "100"]
+
+# for arcus-operator
+FROM base
+RUN yum update -y
+RUN yum install -y bind-utils
+RUN yum clean all -y
+ENV MEMCACHED_DIR /arcus-memcached
+ENV PATH ${PATH}:${MEMCACHED_DIR}
+ENV ARCUS_USER root
+WORKDIR ${MEMCACHED_DIR}
+RUN ln -s /arcus/lib ${MEMCACHED_DIR}/.libs


### PR DESCRIPTION
- jam2in/arcus-docker#9
- jam2in/arcus-docker#19
- jam2in/arcus-works#447

[jam2in/arcus-docker의 Dockerfile](https://github.com/jam2in/arcus-docker/tree/develop/arcus-memcached)과 아래와 같은 차이가 있습니다.
- arcus-memcached를 clone받지 않고 copy해서 사용
  - EE의 경우 private repo이기 때문에 clone 과정이 복잡한데, 이를 생략 가능
  - commit하지 않은 로컬의 변경 사항이라도 docker image를 생성/테스트할 수 있음

- build-arg 및 label 사용
  - 의존성 버전이나 configure option을 빌드 단계에서 수정 가능
  예) `docker build --build-arg zookeeper_version="3.5.9-p2"`
  - arg를 label로 추가하여, 빌드 결과물 이미지에서 어떤 설정에 의해 빌드되었는지 확인 가능하도록 구성

- `make install` 사용
  - ~~기본 path인 `/usr/local`~~`/arcus` 하위에 설치
  - 현재는 아래와 같이 make 후 관련 파일을 삭제하는 방식인데, 부자연스럽다고 생각
  (소스코드를 제외한 doc 및 기타 파일들이 그대로 남아있게 되는 형태)
```dockerfile
RUN make
RUN rm -rf .git
RUN find . -type f \( -name "*.c" -or -name "*.o" \) -exec rm {} \;
```

# 하위 호환성 관련
- 기존 dockerfile에 작성된 경로에 심볼릭 링크를 생성하여 변경된 path로 연결되도록 해 두었습니다.
- startup-prove는 정확히 어떤 용도로 사용되는지 잘 모르겠어서, 에러만 나지 않도록 조치해 두었습니다.
startup-prove 수행하지 않으면(or 항상 성공하면) 어떤 문제가 발생하게 되나요?
- jam2in/arcus-docker#12
에서 ENTRYPOINT를 `/docker-entrypoint.sh`로 변경했는데요,
operator가 이 구성에 의존하고 있는 경우 ENTRYPOINT를 변경하는 것만으로 하위 호환성 문제가 발생할 수 있습니다.