### PR TITLE
INTERNAL: Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore


### PR DESCRIPTION
- #691 

Docker image build 시 모든 파일을 복사하는 경우, 이전 빌드에서 생성된 object 파일 등이 함께 복사되는 문제가 있습니다.
이를 방지하기 위해 `.dockerignore` 파일을 추가합니다.
- `.dockerignore`는 `.gitignore`와 동일한 내용을 가질 것으로 생각하여,
두 파일이 함께 수정/관리되도록 symbolic link로 생성했습니다.