### PR TITLE
TEST: Use a docker image

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,34 +8,22 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Install ARCUS Dependencies
-      run: sudo apt-get install -qq build-essential autoconf automake libtool libcppunit-dev python-setuptools python-dev ant
-    - name: Cache ARCUS Directory
-      id: arcus-cache
-      uses: actions/cache@v3.3.2
+    - name: Set Docker Buildx
+      uses: docker/setup-buildx-action@v3.0.0
+    - name: Build Arcus Server Image
+      uses: docker/build-push-action@v5.0.0
       with:
-        path: ~/arcus
-        key: ${{runner.os}}-arcus
-    - name: Install ARCUS
-      if: steps.arcus-cache.outputs.cache-hit != 'true'
-      run: |
-        set -e
-
-        # clone
-        git clone --recursive https://github.com/naver/arcus.git $HOME/arcus
-
-        # build dependencies
-        cd ~/arcus/scripts && ./build.sh
-
-    - name: Build Arcus Server
-      run: |
-          ./config/autorun.sh
-          ./configure --enable-zk-integration --with-zk-reconfig --with-libevent=${HOME}/arcus --with-zookeeper=${HOME}/arcus
-          make
-    - name: Test ARCUS Server
-      run: make test
+        context: .
+        push: false
+        load: true
+        tags: arcus-memcached
+        target: builder
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+    - name: Run Arcus Server Test
+      run: docker run arcus-memcached make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG \
 
 FROM centos:7 AS builder
 RUN yum update -y
-RUN yum install -y gcc gcc-c++ make m4 perl autoconf automake libtool pkgconfig cppunit-devel ant which git
+RUN yum install -y gcc gcc-c++ make m4 perl-core autoconf automake libtool pkgconfig cppunit-devel ant which git net-tools cpan
 ARG libevent_version zookeeper_version configure_options
 ## Libevent
 WORKDIR /tmp

--- a/t/issue_67.t
+++ b/t/issue_67.t
@@ -38,6 +38,10 @@ sub validate_port {
 sub run_server {
     my ($args) = @_;
 
+    if ($< == 0) {
+        $args .= " -u root";
+    }
+
     $args .= " -E $builddir/.libs/default_engine.so";
 
     my $exe = "$builddir/memcached";


### PR DESCRIPTION
CI 테스트를 도커를 활용하여 build 시간을 단축시킵니다.
Dockerfile을 통한 테스트 진행을 위해 2개의 기존 파일을 변경했습니다.

- Dockerfile : 패키지 설치시 test 진행에 필요한 net-tools, cpan, perl-core 설치
- 67번 test : 도커 컨테이너 구동 시 root 권한에서 구동이 가능하도록 서버 실행에 -u 옵션 추가