### PR TITLE
DOC: Restructure markdown documentation directory

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,0 +1,129 @@
+# ARCUS Basic Concept
+ARCUS Cache Server는 하나의 데이터만을 value로 가지는 simple key-value 외에도
+여러 데이터를 구조화된 형태로 저장하는 collection을 하나의 value로 가지는
+확장된 key-value 데이터 모델을 제공한다.
+
+## Basic constraints
+ARCUS Cache Server의 key-value 모델은 아래의 기본 제약 사항을 가진다.
+
+- 기존 key-value 모델의 제약 사항
+  - Key의 최대 크기는 16000 character이다. (arcus-memcached 1.11 이후 버전)
+    - 기존 버전에서 key 최대 크기는 250 character이다.
+  - Value의 최대 크기는 1MB(trailing 문자인 `\r\n` 포함한 길이) 이다.
+- Collection 제약 사항
+  - 하나의 collection에 들어갈 수 있는 최대 element 개수는 50,000개이다.
+  - Collection의 각 element가 가지는 value의 최대 크기는 16KB(trailing 문자인 `\r\n` 포함한 길이)이며 이는 설정으로 변경 가능하다.
+
+## Cache Key
+Cache key는 ARCUS Cache Server에 저장할 데이터를 대표하는 코드이다. Cache key 형식은 아래와 같다.
+```
+  Cache Key : [<prefix>:]<subkey>
+```
+
+- `<prefix>` - Cache key의 앞에 붙는 namespace이다.
+  - Prefix 단위로 Cache Server에 저장된 key들을 그룹화하여 flush하거나 통계 정보를 볼 수 있다.
+  - Prefix를 생략할 수도 있지만, 가급적 사용하길 권한다.
+- delimiter - Prefix와 subkey를 구분하는 문자로 default delimiter는 콜론(`:`)이다.
+- `<subkey>` - 일반적으로 응용에서 사용하는 Key이다.
+
+Prefix와 subkey는 명명 규칙을 가지므로 주의하여야 한다.
+Prefix는 영문 대소문자, 숫자, 언더바(_), 하이픈(-), 플러스(+), 점(.) 문자만으로 구성될 수 있으며,
+이 중에 하이픈(-)은 prefix 명의 첫번째 문자로 올 수 없는 제약이 있다.
+Subkey는 공백을 포함할 수 없으며, 기본적으로 alphanumeric만을 사용하길 권장한다.
+
+## Cache Item
+
+ARCUS Cache Server는 simple key-value 외에 collection 지원으로 다양한 item 유형을 가진다.
+
+- simple key-value item - 기존 key-value item
+- collection item
+  - list item - 데이터들의 linked list을 value로 가지는 item
+  - set item - 유일한 데이터들의 집합을 value로 가지는 item
+  - map item - `<field, value>`쌍으로 구성된 데이터 집합을 value로 가지는 item
+  - b+tree item - b+tree key 기반으로 정렬된 데이터 집합을 value로 가지는 item
+
+## Expiration, Eviction, and Sticky
+
+각 cache item은 expiration time 속성을 가지며,
+이 값의 설정을 통해 expire되지 않는 item 또는 특정 시간 이후에 자동 expire될 item을 지정할 수 있다.
+이에 대한 자세한 설명은 [Item Attribute 설명](item-attributes.md)을 참고 바란다.
+
+ARCUS Cache Server는 memory cache이며, 한정된 메모리 공간을 사용하여 데이터를 caching한다.
+메모리 공간이 모두 사용된 상태에서 새로운 item 저장 요청이 들어올 경우,
+ARCUS Cache Server는 "out of memory" 오류를 내거나 LRU 기반의 eviction 방식
+즉, 가장 오랫동안 접근되지 않은 item을 제거하고 새로운 item 저장을 허용하는 방식을 사용한다.
+이러한 동작 방식은 ARCUS Cache Server의 -M 구동 옵션을 지정 가능하며,
+default로는 LRU 기반의 eviction 방식을 사용한다.
+
+특정 응용에서는 어떤 item이 expire & evict 대상이 되지 않기를 원하는 경우도 있다.
+ARCUS Cache Server는 이러한 item을 sticky item이라 하며,
+expiration time을 -1로 지정하면, sticky item으로 지원한다.
+Sticky item의 삭제는 전적으로 응용에 의해 관리되어야 함을 주의해야 한다.
+
+Sticky items은 일반적으로 많지 않을 것으로 예상하지만,
+응용의 실수로 인해 sticky item들이 ARCUS 서버의 전체 메모리 공간을 차지하게 되는 경우를 방지하기 위하여,
+전체 메모리 공간의 일부만이 sticky items에 의해 사용되도록 설정하는 -g(gummed or sticky) 구동 옵션을 제공한다.
+Sticky items의 메모리 공간으로 사용될 메모리 비율이며, 0 ~ 100 범위의 값으로 지정가능하다.
+디폴트인 0은 sticky items을 허용하지 않는다는 것이며,
+100은 전체 메모리를 sticky items 저장 용도로 사용할 수 있음을 의미한다.
+
+## Memory Allocator
+
+ARCUS Cache Server는 item 메모리 공간의 할당과 반환을 효율적으로 관리할 목적으로
+두 가지 memory allocator를 사용한다.
+
+### Slab Allocator
+
+Slab allocator는 메모리 크기 별로 메모리 공간을 나누어 관리하기 위해 slab class로 구분하고,
+각 slab class에서 동일 크기의 메모리 공간들인 slab들을 free list 형태로 관리하면서
+그 크기의 메모리 공간의 할당과 반환을 신속히 처리해 주는 memory allocator이다.
+기존 memcached에서 사용되던 대표적인 memory allocator이다.
+
+최대 slab 크기는 현재 1MB이다. 최소 slab 크기 즉, 첫 번째 slab class의 slab 크기와
+그 다음 slab class들의 slab 크기는 아래의 ARCUS Cache Server 구동 옵션으로 설정한다.
+
+- `-n <bytes>` : minimum space allocated from key+value+flags (default: 48)
+  - 최소 크기의 slab 크기를 결정한다.
+- `-f <factor>` : chunk size growth factor (default: 1.25)
+  - Slab class 별로 slab 크기의 증가 정도를 지정하며, 1.0보다 큰 값으로 지정해야 한다.
+
+### Small Memory Allocator
+
+Collection 지원으로 인해 작은 메모리 공간의 할당과 반환 요청이 많아졌다.
+이러한 작은 메모리 공간을 효율적으로 관리하기 위하여
+small memory allocator를 새로 개발하여 사용하고 있다.
+8000 바이트 이하의 메모리 공간은 small memory allocator가 담당하며,
+8000 바이트 초과의 메모리 공간은 기존 slab allocator가 담당한다.
+
+## Slab Class 별 LRU 리스트
+
+ARCUS Cache Server는 slab class 별 LRU 리스트를 유지하고,
+eviction 대상 item으로 오랫동안 접근되지 않은 item이 선택될 수 있게 한다.
+
+Small memory allocator 추가로 인해, slab class 별 LRU 리스트에 변동 사항이 있다.
+특별히, 0번 slab class를 두어 small memory allocator가 사용하고 있으며,
+small memory allocator로 부터 메모리 공간을 할당받는
+작은 크기의 key-value items과 collection items은 0번 LRU 리스트에 연결된다.
+따라서, 8000 바이트 이하의 메모리 공간에 해당하는
+기존 slab class의 LRU 리스트들은 empty가 상태가 된다.
+
+## Automatic Scrub (added since v1.11.3)
+
+ARCUS 캐시 클러스터에 새로운 캐시 노드를 추가하면, stale 데이터가 발생한다.
+이유는 기존 캐시 노드들에 있던 일부 데이터는 consistent hashing에 의해 새로 추가된 캐시 노드로 담당 노드가 변경되기 때문이다.
+이러한 stale 데이터는 기존 캐시 노드에 남아 있더라도 더 이상 접근되지 않으므로 대부분 문제가 없다.
+하지만, 새로 추가한 캐시 노드가 어떤 이유로 다운되고 ARCUS 캐시 클러스터에서 제거된다면 stale 데이터가 다시 접근될 수 있는 문제가 발생한다.
+결국, 이러한 stale 데이터를 제거하여야 한다.
+
+Expire time이 짧은 stale 데이터는 자동으로 제거되지만, 그렇지 않은 stale 데이터가 항상 존재할 수 있다.
+ARCUS 캐시 클러스터는 새로운 캐시 노드가 추가될 때마다 기존의 캐시 노드들은 모두 30초 후에 자신의 노드에서 stale 데이터를 찾아 제거하는 작업을 자동으로 수행한다.
+이를 automatic scrub 작업이라 한다. 이를 위해, ARCUS 캐시 노드는 캐시 클라이언트와 마찬가지로 키 분배(캐시 데이터 분배)를 위한 consistent hashing 로직을 동일하게 가지며,
+ZooKeeper Watcher를 통해 캐시 노드가 추가된 시점을 확인하면 background thread를 생성하여 자신 노드에 있는 모든 캐시 데이터를 순차 접근하면서 stale 데이터를 찾아 제거한다.
+
+stale 데이터 노출 관점
+- Automatic scrub 작업이 완료될 때까지 새로 추가한 캐시 노드가 다운되지 않는다면 stale 데이터는 노출되지 않는다.
+- Automatic scrub 작업이 완료되기 전에 새로 추가한 캐시 노드가 다운되어 ARCUS 캐시 클러스터에서 제거된다면, stale 데이터가 노출될 수 있다.
+- Automatic scrub 작업은 모든 캐시 데이터를 순차 접근하여 stale 여부를 검사하므로, 일정 시간이 소요된다.
+하지만, Automatic scrub 작업의 완료 전에 새로 추가된 캐시 노드가 다운되는 경우는 극히 드물다.
+
+참고로 명시적으로 수행할 수 있는 `scrub stale` 명령을 제공하고 있다. [Scrub 명령](ascii-protocol/09-administration.md#scrub)

--- a/documentation/SUMMARY.md
+++ b/documentation/SUMMARY.md
@@ -1,0 +1,22 @@
+# Table of contents
+
+* [Basic concept](README.md)
+* [Collection items](collection-items.md)
+* [Item attributes](item-attributes.md)
+
+## Manuals
+* [Commandline arguments](manuals/commandline_arguments.md)
+* [Compilation faq](manuals/compilation_faq.md)
+
+## Reference
+* [ascii protocol](ascii-protocol/00-arcus-ascii-protocol.md)
+  * [Key-Value](ascii-protocol/ch04-command-key-value.md)
+  * [List](ascii-protocol/ch05-command-list-collection.md)
+  * [Set](ascii-protocol/ch06-command-set-collection.md)
+  * [Map](ascii-protocol/ch07-command-map-collection.md)
+  * [B+Tree](ascii-protocol/ch08-command-btree-collection.md)
+  * [Pipelining](ascii-protocol/ch09-command-pipelining.md)
+  * [Item attribute](ascii-protocol/ch10-command-item-attribute.md)
+  * [Scan](ascii-protocol/ch11-command-scan.md)
+  * [Administraion](ascii-protocol/ch12-command-administration.md)
+  * [Appendix](ascii-protocol/ap01-arcus-telnet-interface.md)

--- a/documentation/ascii-protocol/00-arcus-ascii-protocol.md
+++ b/documentation/ascii-protocol/00-arcus-ascii-protocol.md
@@ -1,0 +1,66 @@
+# ARCUS Cache Server ASCII Protocol
+
+ARCUS Cache Server가 제공하는 명령들의 ASCII Protocol을 기술한다.
+Binary protocol은 현재 지원하지 않으므로, 논의에서 제외한다.
+
+본 문서는 ARCUS cache client 개발자를 주 대상으로 하며,
+ARCUS Cache Server에 관심있는 독자의 경우도 참고할 수 있다.
+
+Collection Support
+------------------
+
+ASCII Protocol 관점에서 ARCUS Cache Server는 기존 memcached 기능 외에 collection 기능을 제공한다.
+하나의 data만을 가지는 simple key-value 외에도 여러 data를 구조화된 형태로 저장/조회할 수 있으며,
+제공하는 collection 유형은 아래와 같다.
+
+- list : 데이터들의 linked list 구조
+- set : 유일한 데이터들의 집합으로 membership 검사에 적합
+- map : `<field, value>`쌍으로 구성된 데이터들의 집합으로 field 기준의 hash 구조
+- b+tree : b+tree 키 기준으로 정렬된 데이터들의 집합으로 range scan 처리에 적합
+
+Basic Concepts
+--------------
+
+ARCUS Cache Server를 사용함에 있어 필요한 cache key, item, slab 등의 기본 용어와 개념은
+[ARCUS 기본 개념](../README.md)에서 설명하므로, 이를 먼저 읽어보길 권한다.
+
+ARCUS Cache Server가 제공하는 collection과 element 구조, b+tree key, element flag 등의
+중요 요소들은 [Collection 기본 개념](../collection-items.md)에서 소개한다.
+
+Collection 기능을 제공함에 따라 item 속성들이 확장되었으며,
+이들은 [Item 속성 설명](../item-attributes.md)에서 자세히 다룬다.
+
+Simple Key-Value 기능
+---------------------
+
+ARCUS Cache Server는 memcached 1.4 기준의 key-value 명령을 그대로 제공하며, 일부에 대해 확장된 명령을 제공한다.
+따라서, 기존 memcached 1.4에서 사용한 명령들은 ARCUS Cache Server에서도 그대로 사용 가능하다.
+[Key-Value 명령](01-key-value.md)에서 key-value 유형의 item에 대해 수행가능한 명령들을 소개한다.
+
+Collection 기능
+---------------
+
+Collection 명령의 자세한 설명은 아래를 참고 바랍니다.
+
+- [List collection 명령](02-list-collection.md)
+- [Set collection 명령](03-set-collection.md)
+- [Map collection 명령](04-map-collection.md)
+- [B+tree collection 명령](05-btree-collection.md)
+
+Collection 일부 명령들은 command pipelining 처리가 가능하며,
+[Command Pipelining 기능](06-pipelining.md)에서 설명한다.
+
+Item Attributes 기능
+--------------------
+
+Collection 지원으로 인해 item 유형이 다양해 졌으며, 다양한 item 유형에 따라 item attributes도 확장되었다.
+Item attributes를 조회하거나 변경하기 위하여 [Item Attribute 명령](07-item-attribute.md)을 제공한다.
+
+Scan 기능
+--------------------
+조건에 맞는 item 혹은 prefix 목록을 가져오는 기능으로 [Scan 명령](08-scan.md)을 제공한다.
+
+Admin & Monitoring 기능
+-----------------------
+
+ARCUS Cache Server의 운영 상에 필요한 기능들은 [Admin & Monitoring 명령](09-administration.md)으로 제공한다.

--- a/documentation/ascii-protocol/01-key-value.md
+++ b/documentation/ascii-protocol/01-key-value.md
@@ -1,0 +1,112 @@
+# Simple Key-Value 명령
+
+ARCUS Cache Server는 memcached 1.4의 key-value 명령을 그대로 지원하며,
+이에 추가하여 incr/decr 명령은 그 기능을 확장 지원한다.
+
+Simple key-value 명령들의 요약은 아래와 같다.
+이들 명령들의 자세한 정보는 [memcached 1.4의 기존 ASCII protocol](https://github.com/naver/arcus-memcached/blob/master/doc/protocol.txt)를 참고하기 바란다.
+
+## storage 명령
+
+set, add, replace, append, prepend, cas 명령이 있으며 syntax는 다음과 같다.
+
+```
+<command name> <key> <flags> <exptime> <bytes> [noreply]\r\n<data>\r\n
+cas <key> <flags> <exptime> <bytes> <cas unique> [noreply]\r\n<data>\r\n
+```
+
+Response string과 그 의미는 아래와 같다.
+
+| Response String      | 설명                     |
+|----------------------|------------------------ |
+| "STORED"             | 성공
+| "NOT_STORED"         | 연산 조건에 부합하지 않아 저장에 실패 함. ex) 이미 존재하는 key에 대해 add 연산,  존재하지 않는 key에 대해 replace, append, prepend 연산.
+| "NOT_FOUND"          | cas 연산의 key miss.
+| "EXISTS"             | cas 연산의 응답으로, 해당 아이템이 클라이언트의 마지막 fetch 이후 수정된 적이 있음을 뜻함.
+| "TYPE_MISMATCH"      | 해당 아이템이 key-value 타입이 아님.
+| "CLIENT_ERROR"       | 클라이언트에서 잘못된 질의를 했음을 의미. 이어 나오는 문자열을 통해 오류의 원인을 파악 가능. 예) bad command line format
+| "SERVER ERROR"       | 서버 측의 오류로 저장하지 못했음을 의미. 이어 나오는 문자열을 통해 오류의 원인을 파악 가능. 예) out of memory
+
+## retrieval 명령
+
+하나의 cache item을 조회하는 get, gets 명령이 있으며, syntax는 다음과 같다.
+get 명령은 value만 조회하는 반면 gets 명령은 value와 함께 cas value도 조회한다.
+
+```
+get <key>\r\n
+gets <key>\r\n
+```
+
+한번에 여러 cache item들을 조회하기 위한 mget, mgets 명령이 있으며, syntax는 다음과 같다.
+mget, mgets 명령은 get, gets 처럼 mget 명령은 value만 조회하고 mgets 명령은 value와 함께 cas value도 조회한다.
+mget 명령은 1.11 버전부터 mgets 명령은 1.13 버전부터 제공한다.
+
+```
+mget <lenkeys> <numkeys>\r\n
+<"space separated keys">\r\n
+mgets <lenkeys> <numkeys>\r\n
+<"space separated keys">\r\n
+```
+- `<”space separated keys”>` - key list로, 스페이스(' ')로 구분한다.
+- `<lenkeys>`과 `<numkeys>` - key list 문자열의 길이와 key 개수를 나타낸다.
+
+retrieval 명령이 정상 수행되었을 경우, Response string은 아래와 같이 구성된다.
+
+- key hit된 아이템 정보를 모두 출력
+- key miss된 아이템은 별도 response 없이 생략
+- 응답의 끝에 "END\r\n" 출력
+
+```
+VALUE <key> <flags> <bytes> [<cas unique>]\r\n
+<data block>\r\n\
+...
+END\r\n
+```
+
+실패시 string은 아래와 같다.
+
+
+| Response String      | 설명                     |
+|----------------------|------------------------ |
+| "CLIENT_ERROR"       | 클라이언트에서 잘못된 질의를 했음을 의미. 이어 나오는 문자열을 통해 오류의 원인을 파악 가능. 예) bad command line format
+| "SERVER ERROR"       | 서버 측의 오류로 조회하지 못했음을 의미. 이어 나오는 문자열을 통해 오류의 원인을 파악 가능. 예) out of memory writing get response
+
+mget 명령에서 메모리 부족으로 일부 key에 대해서만 정상 조회한 후 실패한 경우, 전체 연산을 서버 에러 처리한다.
+
+## deletion 명령
+
+delete 명령이 있으며 syntax는 다음과 같다.
+
+```
+delete <key> [noreply]\r\n
+```
+
+Response string과 그 의미는 아래와 같다.
+
+| Response String      | 설명                     |
+|----------------------|------------------------ |
+| "DELETED"            | 성공
+| "NOT_FOUND"          | key miss
+| "CLIENT_ERROR"       | 클라이언트에서 잘못된 질의를 했음을 의미. 이어 나오는 문자열을 통해 오류의 원인을 파악 가능. 예) bad command line format
+
+## Increment/Decrement 명령
+
+incr, decr 명령이 있으며, syntax는 아래와 같다.
+ARCUS Cache Server는 이 명령을 확장하여,
+해당 key가 존재하지 않는 경우에 initial 값을 가지는 새로운 key-value item을 생성한다.
+
+```
+incr <key> <delta> [<flags> <exptime> <initial>] [noreply]\r\n
+decr <key> <delta> [<flags> <exptime> <initial>] [noreply]\r\n
+```
+
+성공시 Response string으로 incr, decr 연산을 적용한 값이 출력 된다.
+
+실패시 Response string과 의미는 아래와 같다.
+
+| Response String      | 설명                     |
+|----------------------|------------------------ |
+| "NOT_FOUND"          | key miss
+| "TYPE_MISMATCH"      | 해당 아이템이 key-value 타입이 아님
+| "CLIENT_ERROR"       | 클라이언트에서 잘못된 질의를 했음을 의미. 이어 나오는 문자열을 통해 오류의 원인을 파악 가능. 예) invalid numeric delta argument, cannot increment or decrement non-numeric value
+| "SERVER ERROR"       | 서버 측의 오류로 연산하지 못했음을 의미. 이어 나오는 문자열을 통해 오류의 원인을 파악 가능. 예) out of memory

--- a/documentation/ascii-protocol/02-list-collection.md
+++ b/documentation/ascii-protocol/02-list-collection.md
@@ -1,0 +1,147 @@
+# LIST 명령
+List collection에 관한 명령은 아래와 같다.
+
+- [List collection 생성: lop create](#lop-create)
+- List collection 삭제: delete (기존 key-value item의 삭제 명령을 그대로 사용)
+
+List element에 관한 명령은 아래와 같다.
+
+- [List element 삽입: lop insert](#lop-insert)
+- [List element 삭제: lop delete](#lop-delete)
+- [List element 조회: lop get](#lop-get)
+
+## lop create
+List collection을 empty 상태로 생성한다.
+
+```
+lop create <key> <attributes> [noreply]\r\n
+* attributes: <flags> <exptime> <maxcount> [<ovflaction>] [unreadable]
+```
+
+- `<key>` - 대상 item의 key string
+- `<attributes>` - 설정할 item attributes. [Item Attribute 설명](../ch03-item-attributes.md)을 참조 바란다.
+  - unreadable - 명시하면, readable 속성은 off로 설정됩니다.
+- noreply - 명시하면, response string을 전달받지 않는다.
+
+Response string과 그 의미는 아래와 같다.
+
+| Response String                        | 설명                     |
+|----------------------------------------|------------------------ |
+| "CREATED"                              | 성공
+| "EXISTS"                               | 동일 key string을 가진 item이 이미 존재
+| "NOT_SUPPORTED"                        | 지원하지 않음
+| “CLIENT_ERROR bad command line format” | protocol syntax 틀림
+| “SERVER_ERROR out of memory”           | 메모리 부족
+
+## lop insert
+List collection에 하나의 element를 삽입한다.
+List collection을 생성하면서 하나의 element를 삽입할 수도 있다.
+
+```
+lop insert <key> <index> <bytes> [create <attributes>] [noreply|pipe]\r\n<data>\r\n
+* attributes: <flags> <exptime> <maxcount> [<ovflaction>] [unreadable]
+```
+
+- `<key>` - 대상 item의 key string
+- `<index>` - 삽입 위치를 0-based index로 지정.
+  - 0, 1, 2, ... : list의 앞에서 시작하여 각 element 위치를 나타냄
+  - -1, -2, -3, ... : list의 뒤에서 시작하여 각 element 위치를 나타냄
+- `<bytes>` - 삽입할 데이터 길이 (trailing 문자인 "\r\n"을 제외한 길이)
+- create `<attributes>` - list collection 없을 시에 list 생성 요청.
+[Item Attribute 설명](../ch03-item-attributes.md)을 참조 바란다.
+  - unreadable - 명시하면, readable 속성은 off로 설정됩니다.
+- noreply or pipe - 명시하면, response string을 전달받지 않는다.
+pipe 사용은 [Command Pipelining](ch09-command-pipelining.md)을 참조 바란다.
+- `<data>` - 삽입할 데이터 (최대 크기는 [기본제약사항](../ch01-arcus-basic-concept.md#기본-제약-사항)을 참고)
+
+
+Response string과 그 의미는 아래와 같다.
+
+| Response String                          | 설명                     |
+|------------------------------------------|------------------------ |
+| "STORED"                                 | 성공 (element만 삽입)
+| “CREATED_STORED”                         | 성공 (collection 생성하고 element 삽입)
+| “NOT_FOUND”                              | key miss
+| “TYPE_MISMATCH”                          | 해당 item이 list collection이 아님
+| “OVERFLOWED”                             | overflow 발생
+| “OUT_OF_RANGE”                           | 삽입 위치가 list의 현재 element index 범위를 넘어섬. 예를 들어, 10개 element가 있는 상태에서 삽입 위치가 20인 경우임
+| "NOT_SUPPORTED"                          | 지원하지 않음
+| “CLIENT_ERROR bad command line format”   | protocol syntax 틀림
+| “CLIENT_ERROR too large value”           | 삽입할 데이터가 element value의 최대 크기보다 큼
+| “CLIENT_ERROR bad data chunk”            | 삽입할 데이터 길이가 `<bytes>`와 다르거나 "\r\n"으로 끝나지 않음
+| “SERVER_ERROR out of memory”             | 메모리 부족
+
+## lop delete
+List collection에 하나의 index 또는 index range에 해당하는 elements를 삭제한다.
+
+```
+lop delete <key> <index or "index range"> [drop] [noreply|pipe]\r\n
+lop delete 명령에서 각 인자의 설명은 아래와 같다.
+```
+- `<key>` - 대상 item의 key string
+- `<index or "index range">` - 삭제할 element의 index or index range.
+  Element index는 "lop insert" 명령에서 소개한 바와 같이 0-based index 형태로 지정하며,
+  index range는 index1..index2 형태로 표현하여, 그 예는 다음과 같다.
+  - 0..-1: 첫째 element부터 마지막 element까지 (forward 순서)
+  - 2..-2: 앞의 3번째 element부터 뒤의 2번째 element까지 (forward 순서)
+  - -3..-1: 뒤의 3번째 element부터 뒤의 1번째 element까지 (forward 순서)
+  - 4..2 : 앞의 5번째 element 부터 앞의 3번째 element까지 (backward 순서)
+  - -1..0: 마지막 element 부터 첫째 element 까지 (backward 순서)
+- drop - element 삭제로 인해 empty list가 될 경우, 그 list를 drop할 것인지를 지정한다.
+- noreply or pipe - 명시하면, response string을 전달받지 않는다.
+pipe 사용은 [Command Pipelining](ch09-command-pipelining.md)을 참조 바란다.
+
+Response string과 그 의미는 아래와 같다.
+
+| Response String                          | 설명                     |
+|------------------------------------------|------------------------ |
+| "DELETED"                                | 성공 (element만 삭제)
+| “DELETED_DROPPED”                        | 성공 (element 삭제하고 list를 drop한 상태)
+| “NOT_FOUND”                              | key miss
+| “NOT_FOUND_ELEMENT”                      | element miss (single index or index range에 해당하는 element가 없음)
+| “TYPE_MISMATCH”                          | 해당 item이 list collection이 아님
+| "NOT_SUPPORTED"                          | 지원하지 않음
+| “CLIENT_ERROR bad command line format”   | protocol syntax 틀림
+
+## lop get
+List collection에 하나의 index 또는 index range에 해당하는 elements를 조회한다.
+
+```
+lop get <key> <index or "index range"> [delete|drop]\r\n
+```
+
+- `<key>` - 대상 item의 key string
+- `<index or "index range">` - 조회할 element의 index or index range. "lop delete" 명령의 인자 참조
+- delete or drop - element 조회하면서 그 element를 delete할 것인지,
+그리고 delete로 인해 empty list가 될 경우 그 list를 drop할 것인지를 지정한다.
+
+성공 시의 response string은 아래와 같다.
+VALUE 라인의 `<count>`는 조회된 element 개수를 의미한다.
+마지막 라인은 END, DELETED, DELETED_DROPPED 중의 하나를 가지며,
+각각 element 조회만 수행한 상태, element 조회하고 삭제한 상태,
+element 조회 및 삭제하고 list를 drop한 상태를 의미한다.
+
+```
+VALUE <flags> <count>\r\n
+<bytes> <data>\r\n
+<bytes> <data>\r\n
+<bytes> <data>\r\n
+...
+END|DELETED|DELETED_DROPPED\r\n
+```
+
+실패 시의 response string과 그 의미는 아래와 같다.
+
+| Response String                                        | 설명                     |
+|--------------------------------------------------------|------------------------ |
+| “NOT_FOUND”                                            | key miss
+| “NOT_FOUND_ELEMENT”                                    | element miss (index or index range에 해당하는 element가 없음)
+| “TYPE_MISMATCH”                                        | 해당 item이 list collection이 아님
+| “UNREADABLE”                                           | 해당 item이 unreadable item임
+| "NOT_SUPPORTED"                                        | 지원하지 않음
+| “CLIENT_ERROR bad command line format”                 | protocol syntax 틀림
+| "SERVER_ERROR out of memory [writing get response]”    | 메모리 부족
+
+<!-- reference list -->
+[item-attribute]: ch03-item-attributes.md "Chapter 3. Item Attribute 설명"
+[command-pipelining]: ch09-command-pipelining.md "Chapter 9. Command Pipelining"

--- a/documentation/ascii-protocol/03-set-collection.md
+++ b/documentation/ascii-protocol/03-set-collection.md
@@ -1,0 +1,163 @@
+# SET 명령
+
+Set collection에 관한 명령은 아래와 같다.
+
+- [Set collection 생성: sop create](#sop-create)
+- Set collection 삭제: delete (기존 key-value item의 삭제 명령을 그대로 사용)
+
+Set element에 관한 명령은 아래와 같다.
+
+- [Set element 삽입: sop insert](#sop-insert)
+- [Set element 삭제: sop delete](#sop-delete)
+- [Set element 조회: sop get](#sop-get)
+- [Set element 존재유무 검사: sop exist](#sop-exist)
+
+## sop create
+Set collection을 empty 상태로 생성한다.
+
+```
+sop create <key> <attributes> [noreply]\r\n
+* <attributes>: <flags> <exptime> <maxcount> [<ovflaction>] [unreadable]
+```
+
+- `<key>` - 대상 item의 key string
+- `<attributes>` - 설정할 item attributes. [Item Attribute 설명](../item-attributes.md)을 참조 바란다.
+  - unreadable - 명시하면, readable 속성은 off로 설정됩니다.
+- noreply - 명시하면, response string을 전달받지 않는다.
+
+Response string과 그 의미는 아래와 같다.
+
+| Response String                          | 설명                    |
+|------------------------------------------|------------------------ |
+| "CREATED"                                | 성공
+| "EXISTS"                                 | 동일 key string을 가진 item이 이미 존재
+| "NOT_SUPPORTED"                          | 지원하지 않음
+| "CLIENT_ERROR bad command line format"   | protocol syntax 틀림
+| "SERVER_ERROR out of memory"             | 메모리 부족
+
+## sop insert
+Set collection에 하나의 element를 삽입한다.
+Set collection을 생성하면서 하나의 element를 삽입할 수도 있다.
+
+```
+sop insert <key> <bytes> [create <attributes>] [noreply|pipe]\r\n<data>\r\n
+* <attributes>: <flags> <exptime> <maxcount> [<ovflaction>] [unreadable]
+```
+
+- `<key>` - 대상 item의 key string
+- `<bytes>` - 삽입할 데이터 길이 (trailing 문자인 "\r\n"을 제외한 길이)
+- create `<attributes>` - set collection 없을 시에 set 생성 요청.
+[Item Attribute 설명](../item-attributes.md)을 참조 바란다.
+  - unreadable - 명시하면, readable 속성은 off로 설정됩니다.
+- noreply or pipe - 명시하면, response string을 전달받지 않는다.
+pipe 사용은 [Command Pipelining](06-pipelining.md)을 참조 바란다.
+- `<data>` - 삽입할 데이터 (최대 크기는 [기본제약사항](../README.md#basic-constraints)을 참고)
+
+Response string과 그 의미는 아래와 같다.
+
+| Response String                          | 설명                    |
+|------------------------------------------|------------------------ |
+| "STORED"                                 | 성공 (element만 삽입)
+| "CREATED_STORED"                         | 성공 (collection 생성하고 element 삽입)
+| "NOT_FOUND"                              | key miss
+| "TYPE_MISMATCH"                          | 해당 item이 set collection이 아님
+| "OVERFLOWED"                             | overflow 발생
+| "ELEMENT_EXISTS"                         | 동일 데이터를 가진 element가 존재. set uniqueness 위배
+| "NOT_SUPPORTED"                          | 지원하지 않음
+| "CLIENT_ERROR bad command line format"   | protocol syntax 틀림
+| "CLIENT_ERROR too large value"           | 삽입할 데이터가 element value의 최대 크기보다 큼
+| "CLIENT_ERROR bad data chunk"            | 삽입할 데이터 길이가 `<bytes>`와 다르거나 "\r\n"으로 끝나지 않음
+| "SERVER_ERROR out of memory"             | 메모리 부족
+
+## sop delete
+Set collection에서 하나의 element를 삭제한다.
+
+```
+sop delete <key> <bytes> [drop] [noreply|pipe]\r\n<data>\r\n
+```
+
+- `<key>` - 대상 item의 key string
+- `<bytes>` - 삭제할 데이터 길이 (trailing 문자인 "\r\n"을 제외한 길이)
+- drop - element 삭제로 인해 empty set이 될 경우, 그 set을 drop할 것인지를 지정한다.
+- noreply or pipe - 명시하면, response string을 전달받지 않는다.
+pipe 사용은 [Command Pipelining](06-pipelining.md)을 참조 바란다.
+- `<data>` - 삭제할 데이터
+
+Response string과 그 의미는 아래와 같다.
+
+| Response String                         | 설명                    |
+|-----------------------------------------|------------------------ |
+| "DELETED"                               | 성공 (element만 삭제)
+| "DELETED_DROPPED"                       | 성공 (element 삭제하고 collection을 drop한 상태)
+| "NOT_FOUND"                             | key miss
+| "NOT_FOUND_ELEMENT"                     | element miss (삭제할 element가 없음)
+| "TYPE_MISMATCH"                         | 해당 item이 set collection이 아님
+| "NOT_SUPPORTED"                         | 지원하지 않음
+| "CLIENT_ERROR bad command line format"  | protocol syntax 틀림
+| "CLIENT_ERROR too large value"          | 삭제할 데이터가 element value의 최대 크기보다 큼
+| "CLIENT_ERROR bad data chunk"           | 삭제할 데이터의 길이가 `<bytes>`와 다르거나 “\r\n”으로 끝나지 않음
+
+## sop get
+Set collection에서 N 개의 elements를 조회한다.
+
+```
+sop get <key> <count> [delete|drop]\r\n
+```
+
+- `<key>` - 대상 item의 key string
+- `<count>` - 조회할 elements 개수를 지정. 0이면 전체 elements를 의미한다.
+- delete or drop - element 조회하면서 그 element를 delete할 것인지,
+그리고 delete로 인해 empty set이 될 경우 그 set을 drop할 것인지를 지정한다.
+
+성공 시의 response string은 아래와 같다.
+VALUE 라인의 `<count>`는 조회된 element 개수를 의미한다.
+마지막 라인은 END, DELETED, DELETED_DROPPED 중의 하나를 가지며
+각각 element 조회만 수행한 상태, element 조회하고 삭제한 상태,
+element 조회 및 삭제하고 set을 drop한 상태를 의미한다.
+
+```
+VALUE <flags> <count>\r\n
+<bytes> <data>\r\n
+<bytes> <data>\r\n
+<bytes> <data>\r\n
+...
+END|DELETED|DELETED_DROPPED\r\n
+```
+
+실패 시의 response string과 그 의미는 아래와 같다.
+
+| Response String                                      | 설명                    |
+|------------------------------------------------------|------------------------ |
+| "NOT_FOUND"                                          | key miss
+| "NOT_FOUND_ELEMENT"                                  | element miss (element가 존재하지 않는 상태임)
+| "TYPE_MISMATCH"                                      | 해당 item이 set collection이 아님
+| "UNREADABLE"                                         | 해당 item이 unreadable item임
+| "NOT_SUPPORTED"                                      | 지원하지 않음
+| "CLIENT_ERROR bad command line format"               | protocol syntax 틀림
+| "SERVER_ERROR out of memory [writing get response]"  | 메모리 부족
+
+## sop exist
+Set collection에 특정 element의 존재 유무를 검사한다.
+
+```
+sop exist <key> <bytes> [pipe]\r\n<data>\r\n
+```
+
+- `<key>` - 대상 item의 key string
+- `<bytes>`와 `<data>` - 존재 유무를 검사할 데이터의 길이와 데이터 그 자체
+- pipe - 명시하면, response string을 전달받지 않는다.
+[Command Pipelining](ch09-command-pipelining.md)을 참조 바란다.
+
+Response string과 그 의미는 아래와 같다.
+
+| Response String                          | 설명                     |
+|------------------------------------------|------------------------ |
+| "EXIST"                                  | 성공 (주어진 데이터가 set에 존재)
+| "NOT_EXIST"                              | 성공 (주어진 데이터가 set에 존재하지 않음)
+| "NOT_FOUND"                              | key miss
+| "TYPE_MISMATCH"                          | 해당 item이 set collection이 아님
+| "UNREADABLE"                             | 해당 item이 unreadable item임
+| "NOT_SUPPORTED"                          | 지원하지 않음
+| "CLIENT_ERROR bad command line format"   | protocol syntax 틀림
+| "CLIENT_ERROR too large value"           | 주어진 데이터가 element value의 최대 크기보다 큼
+| "CLIENT_ERROR bad data chunk"            | 주어진 데이터의 길이가 `<bytes>`와 다르거나 “\r\n”으로 끝나지 않음

--- a/documentation/ascii-protocol/04-map-collection.md
+++ b/documentation/ascii-protocol/04-map-collection.md
@@ -1,0 +1,170 @@
+# MAP 명령
+Map collection에 관한 명령은 아래와 같다.
+
+- [Map collection 생성: mop create](#mop-create)
+- Map collection 삭제: delete (기존 key-value item의 삭제 명령을 그대로 사용)
+
+Map element에 관한 명령은 아래와 같다.
+
+- [Map element 삽입: mop insert](#mop-insert)
+- [Map element 변경: mop update](#mop-update)
+- [Map element 삭제: mop delete](#mop-delete)
+- [Map element 조회: mop get](#mop-get)
+
+## mop create
+Map collection을 empty 상태로 생성한다.
+
+```
+mop create <key> <attributes> [noreply]\r\n
+* <attributes>: <flags> <exptime> <maxcount> [<ovflaction>] [unreadable]
+```
+
+- `<key>` - 대상 item의 key string
+- `<attributes>` - 설정할 item attributes. [Item Attribute 설명](../item-attributes.md)을 참조 바란다.
+  - unreadable - 명시하면, readable 속성은 off로 설정됩니다.
+- noreply - 명시하면, response string을 전달받지 않는다.
+
+Response string과 그 의미는 아래와 같다.
+
+| Response String                        | 설명                     |
+|----------------------------------------|------------------------ |
+| "CREATED"                              | 성공
+| "EXISTS"                               | 동일 key string을 가진 item이 이미 존재
+| "NOT_SUPPORTED"                        | 지원하지 않음
+| "CLIENT_ERROR bad command line format" | protocol syntax 틀림
+| "SERVER_ERROR out of memory"           | 메모리 부족
+
+## mop insert
+Map collection에 하나의 field, element를 삽입한다.
+Map collection을 생성하면서 `<field, value>`로 구성된 하나의 element를 삽입할 수도 있다.
+
+```
+mop insert <key> <field> <bytes> [create <attributes>] [noreply|pipe]\r\n<data>\r\n
+* <attributes>: <flags> <exptime> <maxcount> [<ovflaction>] [unreadable]
+```
+
+- `<key>` - 대상 item의 key string
+- `<field>` - 삽입할 element의 field string
+- `<bytes>` - 삽입할 element의 데이터 길이 (trailing 문자인 "\r\n"을 제외한 길이)
+- create `<attributes>` - 해당 map collection 없을 시에 map 생성 요청.
+[Item Attribute 설명](../item-attributes.md)을 참조 바란다.
+  - unreadable - 명시하면, readable 속성은 off로 설정됩니다.
+- noreply or pipe - 명시하면, response string을 전달받지 않는다.
+pipe 사용은 [Command Pipelining](06-pipelining.md)을 참조 바란다.
+- `<data>` - 삽입할 데이터 (최대 크기는 [기본제약사항](../README.md#basic-constraints)을 참고)
+
+Response string과 그 의미는 아래와 같다.
+
+| Response String                         | 설명                     |
+|-----------------------------------------|------------------------ |
+| "STORED"                                | 성공 (field, element 삽입)
+| "CREATED_STORED"                        | 성공 (collection 생성하고 field, element 삽입)
+| "NOT_FOUND"                             | key miss
+| "TYPE_MISMATCH"                         | 해당 item이 map collection이 아님
+| "OVERFLOWED"                            | overflow 발생
+| "ELEMENT_EXISTS"                        | 동일 이름의 field가 이미 존재. map field uniqueness 위배
+| "NOT_SUPPORTED"                         | 지원하지 않음
+| "CLIENT_ERROR bad command line format"  | protocol syntax 틀림
+| "CLIENT_ERROR too large value"          | 삽입할 데이터가 element value의 최대 크기보다 큼
+| "CLIENT_ERROR bad data chunk"           | 삽입할 데이터 길이가 `<bytes>`와 다르거나 "\r\n"으로 끝나지 않음
+| "CLIENT_ERROR invalid prefix name"      | 유효하지(존재하지) 않는 prefix 명
+| "SERVER_ERROR out of memory"            | 메모리 부족
+
+## mop update
+Map collection에서 하나의 field에 대해 element 변경을 수행한다.
+현재 다수 field에 대한 변경연산은 제공하지 않는다.
+
+```
+mop update <key> <field> <bytes> [noreply|pipe]\r\n<data>\r\n
+```
+
+- `<key>` - 대상 item의 key string
+- `<field>` - 대상 element의 field string
+- `<bytes>` - 변경할 데이터 길이 (trailing 문자인 "\r\n"을 제외한 길이)
+- noreply or pipe - 명시하면, response string을 전달받지 않는다.
+pipe 사용은 [Command Pipelining](06-pipelining.md)을 참조 바란다.
+- `<data>` - 변경할 데이터 자체
+
+Response string과 그 의미는 아래와 같다.
+
+| Response String                          | 설명                     |
+|------------------------------------------|------------------------ |
+| "UPDATED"                                | 성공 (element 변경)
+| "NOT_FOUND"                              | key miss
+| "NOT_FOUND_ELEMENT"                      | field miss
+| "TYPE_MISMATCH"                          | 해당 item이 map collection이 아님
+| "NOT_SUPPORTED"                          | 지원하지 않음
+| "CLIENT_ERROR bad command line format"   | protocol syntax 틀림
+| "CLIENT_ERROR too large value"           | 삽입할 데이터가 element value의 최대 크기보다 큼
+| "CLIENT_ERROR bad data chunk"            | 삽입할 데이터 길이가 `<bytes>`와 다르거나 "\r\n"으로 끝나지 않음
+| "SERVER_ERROR out of memory"             | 메모리 부족
+
+## mop delete
+Map collection에서 하나 이상의 field 이름을 주어, 그에 해당하는 element를 삭제한다.
+
+```
+mop delete <key> <lenfields> <numfields> [drop] [noreply|pipe]\r\n
+[<"space separated fields">]\r\n
+```
+
+- "space separated fields" - 대상 map의 field list로, 스페이스(' ')로 구분한다.
+  - 하위 호환성(1.10.X 이하 버전)을 위해 콤마(,)도 지원하지만 권장하지 않는다.
+- `<key>` - 대상 item의 key string
+- `<lenfields>`과 `<numfields>` - field list 문자열의 길이와 field 개수를 나타낸다. 0이면 전체 field, element를 의미한다.
+- drop - field, element 삭제로 인해 empty map이 될 경우, 그 map을 drop할 것인지를 지정한다.
+- noreply or pipe - 명시하면, response string을 전달받지 않는다.
+pipe 사용은 [Command Pipelining](06-pipelining.md)을 참조 바란다.
+
+Response string과 그 의미는 아래와 같다.
+
+| Response String                         | 설명                     |
+|-----------------------------------------|------------------------ |
+| "DELETED"                               | 성공 (전체 또는 일부 field, element 삭제)
+| "DELETED_DROPPED"                       | 성공 (전체 또는 일부 field, element 삭제하고 collection을 drop한 상태)
+| "NOT_FOUND"                             | key miss
+| "NOT_FOUND_ELEMENT"                     | field miss (삭제할 field, element가 없음. 모든 field가 없을 시에만 리턴)
+| "TYPE_MISMATCH"                         | 해당 item이 map collection이 아님
+| "NOT_SUPPORTED"                         | 지원하지 않음
+| "CLIENT_ERROR bad command line format"  | protocol syntax 틀림
+
+## mop get
+Map collection에서 하나 이상의 field 이름을 주어, 그에 해당하는 element를 조회한다.
+
+```
+mop get <key> <lenfields> <numfields> [delete|drop]\r\n
+[<"space separated fields">]\r\n
+```
+
+- "space separated fields" - 대상 map의 field list로, 스페이스(' ')로 구분한다.
+  - 하위 호환성(1.10.X 이하 버전)을 위해 콤마(,)도 지원하지만 권장하지 않는다.
+- `<key>` - 대상 item의 key string
+- `<lenfields>` 과 `<numfields>` - field list 문자열의 길이와 field 개수를 나타낸다. 0이면 전체 field, element를 의미한다.
+- delete or drop - field, element 조회하면서 그 field, element를 delete할 것인지,
+그리고 delete로 인해 empty map이 될 경우 그 map을 drop할 것인지를 지정한다.
+
+성공 시의 response string은 아래와 같다.
+VALUE 라인의 `<count>`는 조회된 field 개수를 의미한다.
+마지막 라인은 END, DELETED, DELETED_DROPPED 중의 하나를 가지며
+각각 field 조회만 수행한 상태, field 조회하고 삭제한 상태,
+field 조회 및 삭제하고 map을 drop한 상태를 의미한다.
+
+```
+VALUE <flags> <count>\r\n
+<field> <bytes> <data>\r\n
+<field> <bytes> <data>\r\n
+<field> <bytes> <data>\r\n
+...
+END|DELETED|DELETED_DROPPED\r\n
+```
+
+실패 시의 response string과 그 의미는 아래와 같다.
+
+| Response String                                      | 설명                     |
+|------------------------------------------------------|------------------------ |
+| "NOT_FOUND"                                          | key miss
+| "NOT_FOUND_ELEMENT"                                  | field miss (주어진 field 이름들 중 하나라도 가진 element가 전혀 없는 상태임)
+| "TYPE_MISMATCH"                                      | 해당 item이 map collection이 아님
+| "UNREADABLE"                                         | 해당 item이 unreadable item임
+| "NOT_SUPPORTED"                                      | 지원하지 않음
+| "CLIENT_ERROR bad command line format"               | protocol syntax 틀림
+| "SERVER_ERROR out of memory [writing get response]"  | 메모리 부족

--- a/documentation/ascii-protocol/05-btree-collection.md
+++ b/documentation/ascii-protocol/05-btree-collection.md
@@ -1,0 +1,664 @@
+# B+Tree 명령
+
+B+tree collection에 관한 명령은 아래와 같다.
+
+- [B+tree collection 생성: bop create](#bop-create)
+- B+tree collection 삭제: delete (기존 key-value item의 삭제 명령을 그대로 사용)
+
+B+tree element에 관한 기본 명령은 아래와 같다.
+
+- [B+tree element 삽입/대체: bop insert/upsert](#bop-insertupsert)
+- [B+tree element 변경: bop update](#bop-update)
+- [B+tree element 삭제: bop delete](#bop-delete)
+- [B+tree element 조회: bop get](#bop-get)
+- [B+tree element 개수 계산: bop count](#bop-count)
+- [B+tree element 값의 증감: bop incr/decr](#bop-incrdecr)
+
+ARCUS cache server는 다수의 b+tree들에 대한 조회 기능을 특별히 제공하며, 이들은 아래와 같다.
+
+- [하나의 명령으로 여러 b+tree들에 대한 조회를 한번에 수행하는 기능:  bop mget](#bop-mget)
+- [여러 b+tree들에서 조회 조건을 만족하는 elements를 sort merge하여 최종 결과를 얻는 기능: bop smget](#bop-smget)
+
+ARCUS cache server는 bkey 기반의 element 조회 기능 외에도 b+tree position 기반의 element 조회 기능을 제공한다.
+B+tree에서 특정 element의 position이란 b+teee에서의 그 element의 위치 정보로서,
+bkey들의 정렬(ASC or DESC) 기준으로 봐서 몇 번째 위치한 element인지를 나타낸다.
+B+tree position은 0-based index로 표현한다.
+예를 들어, b+tree에 N개의 elements가 있다면 0부터 N-1까지의 index로 나타낸다.
+
+ARCUS cache server에서 제공하는 b+tree position 관련 명령은 다음과 같다.
+
+- [B+tree에서 특정 bkey의 position을 조회하는 기능 : bop position](#bop-position)
+- [B+tree에서 하나의 position 또는 position range에 해당하는 element를 조회하는 기능 : bop gbp(get by position)](#bop-gbp)
+- [B+tree에서 특정 bkey의 position과 element 그리고 그 위치 앞뒤의 element를 함께 조회하는 기능: bop pwg(position with get)](#bop-pwg)
+
+B+tree position 기반의 조회가 필요한 예를 하나 들면, ranking 시스템이 있다.
+Ranking 시스템에서는 특정 score를 bkey로 하여 해당 elements를 저장하고,
+조회는 최고/최저 score 기준으로 몇번째 위치 또는 위치의 범위에 해당하는 element를 찾는 경우가 많다.
+
+
+## bop create
+B+tree collection을 empty 상태로 생성한다.
+
+```
+bop create <key> <attributes> [noreply]\r\n
+* attributes: <flags> <exptime> <maxcount> [<ovflaction>] [unreadable]
+```
+
+- `<key>` - 대상 item의 key string
+- `<attributes>` - 설정할 item attributes.
+[Item Attribute 설명](../item-attributes.md)을 참조 바란다.
+  - unreadable - 명시하면, readable 속성은 off로 설정됩니다.
+- noreply - 명시하면, response string을 전달받지 않는다.
+
+Response string과 그 의미는 아래와 같다.
+
+| Response String                         | 설명                     |
+|-----------------------------------------|------------------------ |
+| "CREATED"                               | 성공
+| "EXISTS"                                | 동일 key string을 가진 item이 이미 존재
+| "NOT_SUPPORTED"                         | 지원하지 않음
+| "CLIENT_ERROR bad command line format"  | protocol syntax 틀림
+| "SERVER_ERROR out of memory"            | 메모리 부족
+
+## bop insert/upsert
+
+B+tree collection에 하나의 element를 추가하는 명령으로
+(1) 하나의 element를 삽입하는 bop insert 명령과
+(2) 현재 삽입하는 bkey를 가진 element가 없으면 현재의 element를 삽입하고
+그 bkey를 가진 element가 있으면 현재의 element로 대체시키는 bop upsert 명령이 있다.
+이들 명령 수행에서 b+tree collection을 생성하면서 하나의 element를 추가할 수도 있다.
+
+```
+bop insert <key> <bkey> [<eflag>] <bytes> [create <attributes>] [noreply|pipe|getrim]\r\n<data>\r\n
+bop upsert <key> <bkey> [<eflag>] <bytes> [create <attributes>] [noreply|pipe|getrim]\r\n<data>\r\n
+* attributes: <flags> <exptime> <maxcount> [<ovflaction>] [unreadable]
+```
+
+- `<key>` - 대상 item의 key string
+- `<bkey>` - 삽입할 element의 bkey
+- `<eflag>` - 삽입할 element의 optional flag
+- `<bytes>`와 `<data>` - 삽입할 element의 데이터의 길이와 데이터 그 자체 (최대 크기는 [기본제약사항](../README.md#basic-constraints)을 참고)
+- create `<attributes>` - b+tree collection 없을 시에 b+tree 생성 요청.
+[Item Attribute 설명](../item-attributes.md)을 참조 바란다.
+  - unreadable - 명시하면, readable 속성은 off로 설정됩니다.
+- noreply or pipe - 명시하면, response string을 전달받지 않는다.
+pipe 사용은 [Command Pipelining](06-pipelining.md)을 참조 바란다.
+- getrim - 새로운 element 추가로 maxcount 제약에 의한 overflow trim이 발생할 경우,
+trim된 element 정보를 가져온다.
+
+Trimmed element 정보가 리턴되는 경우, 그 response string은 아래와 같다.
+
+```
+VALUE <flags> <count>\r\n
+<bkey> [<eflag>] <bytes> <data>\r\n
+END\r\n
+```
+
+그 외의 response string과 의미는 아래와 같다.
+
+| Response String                         | 설명                     |
+|-----------------------------------------|------------------------ |
+| "STORED"                                | 성공 (element만 삽입)
+| "CREATED_STORED"                        | 성공 (collection 생성하고 element 삽입)
+| "REPLACED"                              | 성공 (element를 대체)
+| "NOT_FOUND"                             | key miss
+| "TYPE_MISMATCH"                         | 해당 item이 b+tree colleciton이 아님
+| "BKEY_MISMATCH"                         | 삽입할 bkey 유형과 대상 b+tree의 bkey 유형이 다름
+| "OVERFLOWED"                            | overflow 발생
+| "OUT_OF_RANGE"                          | 새로운 element 삽입이 maxcount 또는 maxbkeyrange 제약을 위배하면서 그 element의 bkey 값이 overflowaction에 의해 자동 삭제되는 경우이어서 삽입이 실패하는 경우이다. 예를 들어, smallest_trim 상황에서 새로 삽입할 element의 bkey 값이 b+tree의 smallest bkey 보다 작으면서 maxcount 개의 elements가 이미 존재하거나 maxbkeyrange를 벗어나는 경우가 이에 해당된다.
+| "ELEMENT_EXISTS"                        | 동일 bkey를 가진 element가 존재
+| "NOT_SUPPORTED"                         | 지원하지 않음
+| "CLIENT_ERROR bad command line format"  | protocol syntax 틀림
+| "CLIENT_ERROR too large value"          | 삽입할 데이터가 element value의 최대 크기보다 큼
+| "CLIENT_ERROR bad data chunk"           | 삽입할 데이터의 길이가 `<bytes>`와 다르거나 "\r\n"으로 끝나지 않음
+| "SERVER_ERROR out of memory"            | 메모리 부족
+
+## bop update
+
+B+tree collection에서 하나의 element에 대해 eflag 변경 그리고/또는 data 변경을 수행한다.
+현재 다수 elements에 대한 변경 연산은 제공하지 않고 있다.
+
+```
+bop update <key> <bkey> [<eflag_update>] <bytes> [noreply|pipe]\r\n[<data>\r\n]
+* eflag_update : [<fwhere> <bitwop>] <fvalue>
+```
+
+- `<key>` - 대상 item의 key string
+- `<bkey>` - 대상 element의 bkey
+- `<eflag_update>` - eflag update 명시.
+[Collection 기본 개념](../collection-items.md)에서 eflag update를 참조 바란다.
+- `<bytes>`와 `<data>` - 새로 변경할 데이터의 길이와 데이터 그 자체. 데이터 변경을 원치 않으면 `<bytes>`를 -1로 하고 `<data>`를 생략하면 된다.
+- noreply or pipe - 명시하면, response string을 전달받지 않는다.
+pipe 사용은 [Command Pipelining](06-pipelining.md)을 참조 바란다.
+
+Response string과 그 의미는 아래와 같다.
+
+| Response String                         | 설명                     |
+|-----------------------------------------|------------------------ |
+| "UPDATED"                               | 성공
+| "NOT_FOUND"                             | key miss
+| "NOT_FOUND_ELEMENT"                     | element miss (변경할 element가 없음)
+| "TYPE_MISMATCH"                         | 해당 item이 b+tree colleciton이 아님
+| "BKEY_MISMATCH"                         | 명령 인자로 주어진 bkey 유형과 대상 b+tree의 bkey 유형이 다름
+| "EFLAG_MISMATCH"                        | 해당 element의 eflag 값에 대해 `<eflag_update>`를 적용할 수 없음. 예를 들어, 변경하고자 하는 eflag가 존재하지 않거나, 존재하더라도 `<eflag_update>` 조건으로 명시된 부분의 데이터를 가지지 않은 상태이다.
+| "NOTHING_TO_UPDATE"                     | eflag 변경과 data 변경 중 어느 하나도 명시되지 않은 상태
+| "NOT_SUPPORTED"                         | 지원하지 않음
+| "CLIENT_ERROR bad command line format"  | protocol syntax 틀림
+| "CLIENT_ERROR too large value"          | 변경할 데이터가 element value의 최대 크기보다 큼
+| "CLIENT_ERROR bad data chunk"           | 변경할 데이터의 길이가 `<bytes>`와 다르거나 "\r\n"으로 끝나지 않음
+| "SERVER_ERROR out of memory"            | 메모리 부족
+
+## bop delete
+b+tree collection에서 하나의 bkey 또는 bkey range 조건과 eflag filter 조건을 만족하는
+N 개의 elements를 삭제한다.
+
+```
+bop delete <key> <bkey or "bkey range"> [<eflag_filter>] [<count>] [drop] [noreply|pipe]\r\n
+* <eflag_filter> : <fwhere> [<bitwop> <foperand>] <compop> <fvalue>
+```
+
+- `<key>` - 대상 item의 key string
+- `<bkey or "bkey range">` - 하나의 bkey 또는 bkey range 조회 조건.
+Bkey range는 "bkey1..bkey2" 형식으로 표현한다.
+- `<eflag_filter>` - eflag filter 조건.
+[Collection 기본 개념](../collection-items.md#eflag-filter)에서 eflag filter 참조 바란다.
+- `<count>` - 삭제할 elements 개수 지정
+- drop - element 삭제로 인해 empty b+tree가 될 경우, 그 b+tree를 drop할 것인지를 지정한다.
+- noreply or pipe - 명시하면, response string을 전달받지 않는다.
+pipe 사용은 [Command Pipelining](06-pipelining.md)을 참조 바란다.
+
+Response string과 그 의미는 아래와 같다.
+
+| Response String                         | 설명                    |
+|-----------------------------------------|------------------------ |
+| "DELETED"                               | 성공 (element만 삭제)
+| "DELETED_DROPPED"                       | 성공 (element 삭제하고 collection을 drop한 상태)
+| "NOT_FOUND"                             | key miss
+| "NOT_FOUND_ELEMENT"                     | element miss (삭제할 element가 없음)
+| "TYPE_MISMATCH"                         | 해당 item이 b+tree colleciton이 아님
+| "BKEY_MISMATCH"                         | 명령 인자의 bkey 유형과 대상 b+tree의 bkey 유형이 다름
+| "NOT_SUPPORTED"                         | 지원하지 않음
+| "CLIENT_ERROR bad command line format"  | protocol syntax 틀림
+
+## bop get
+B+tree collection에서 하나의 bkey 또는 bkey range 조건과 eflag filter 조건을 만족하는
+elements에서 offset 개를 skip한 후 count 개의 elements를 조회한다.
+
+```
+bop get <key> <bkey or "bkey range"> [<eflag_filter>] [[<offset>] <count>] [delete|drop]\r\n
+* <eflag_filter> : <fwhere> [<bitwop> <foperand>] <compop> <fvalue>
+```
+
+- `<key>` - 대상 item의 key string
+- `<bkey or "bkey range">` - 하나의 bkey 또는 bkey range 조회 조건. Bkey range는 "bkey1..bkey2" 형식으로 표현한다.
+- `<eflag_filter>` - eflag filter 조건. [Collection 기본 개념](../collection-items.md#eflag-filter)에서 eflag filter 참조 바란다.
+- [`<offset>`] `<count>` - 조회 조건을 만족하는 elements에서 skip 개수와 실제 조회할 개수
+- delete or drop - element 조회하면서 그 element를 delete할 것인지
+그리고 delete로 인해 empty b+tree가 될 경우 그 b+tree를 drop할 것인지를 지정한다.
+
+성공 시의 response string은 아래와 같다.
+
+```
+VALUE <flags> <count>\r\n
+<bkey> [<eflag>] <bytes> <data>\r\n
+<bkey> [<eflag>] <bytes> <data>\r\n
+<bkey> [<eflag>] <bytes> <data>\r\n
+…
+END|TRIMMED|DELETED|DELETED_DROPPED\r\n
+```
+
+위 response string에 대한 설명은 다음과 같다.
+
+VALUE 라인의 `<count>`는 조회된 element 개수를 나타내며,
+그 다음 라인 부터 조회된 각 element의 bkey, flag, data가 나타낸다.
+마지막 라인은 조회 상태로서 END, TRIMMED, DELETED, DELETED_DROPPED 중 하나를 가진다.
+END, DELEETED, DELEETD_DROPPED은 각각
+element 조회만 수행한 상태, element 조회하고 삭제한 상태,
+element 조회 및 삭제한 후 empty b+tree collection도 drop한 상태를 의미한다.
+TRIMMED는 특별한 의미로서, element 조회만 수행한 상태이면서
+element 조회 조건이 b+tree의 overflowaction으로 trim된 bkey 영역과 overlap 되었음을 나타낸다.
+이를 통해, 조회 조건을 만족하지만 overflow trim으로 조회되지 않은 elements가 있을 수 있음을
+해당 응용이 알 수 있게 한다. 그러면, 해당 응용은 필요시,
+back-end storage에서 조회되지 않은 나머지 elements를 다시 조회할 수 있다.
+참고로, overflow action으로 smallest_silent_trim 또는 largest_silent_trim을 사용한다면,
+b+tree collection 내부에 trim 발생 여부를 유지하지 않아 TRIMMED와 같은 trim 발생 상태를
+알려주지 않게 된다. 이 경우, trim 발생 여부에 대한 검사는 응용에서 자체적으로 수행해야 한다.
+
+실패 시의 response string과 그 의미는 아래와 같다.
+
+| Response String                                       | 설명                    |
+|-------------------------------------------------------|------------------------ |
+| "NOT_FOUND"                                           | key miss
+| "NOT_FOUND_ELEMENT"                                   | element miss (조회 조건을 만족하는 element가 없음)
+| "OUT_OF_RANGE"                                        | 조회 조건을 만족하는 element가 없으며, 또한 주어진 bkey range가 b+tree의 overflowaction에 의해 trim된 bkey 영역과 overlap 되었음을 나타낸다.
+| "TYPE_MISMATCH"                                       | 해당 item이 b+tree collection이 아님
+| "BKEY_MISMATCH"                                       | 명령 인자로 주어진 bkey 유형과 대상 b+tree의 bkey 유형이 다름
+| "UNREADABLE"                                          | 해당 item이 unreadable item임
+| "NOT_SUPPORTED"                                       | 지원하지 않음
+| "CLIENT_ERROR bad command line format"                | protocol syntax 틀림
+| "SERVER_ERROR out of memory [writing get response]"   | 메모리 부족
+
+## bop count
+
+b+tree collection에서 하나의 bkey 또는 bkey range 조건과 eflag filter 조건을 만족하는
+elements 개수를 구한다.
+
+```
+bop count <key> <bkey or "bkey range"> [<eflag_filter>]\r\n
+* <eflag_filter> : <fwhere> [<bitwop> <foperand>] <compop> <fvalue>
+```
+
+- `<key>` - 대상 item의 key string
+- `<bkey or "bkey range">` - 하나의 bkey 또는 bkey range 조회 조건.
+Bkey range는 "bkey1..bkey2" 형식으로 표현한다.
+- `<eflag_filter>` - eflag filter 조건.
+[Collection 기본 개념](../collection-items.md#eflag-filter)에서 eflag filter 참조 바란다.
+
+성공 시의 response string은 아래와 같다.
+
+```
+COUNT=<count>
+```
+
+실패 시의 return string과 그 의미는 아래와 같다.
+
+| Response String                          | 설명                    |
+|------------------------------------------|------------------------ |
+| "NOT_FOUND"                              | key miss
+| "TYPE_MISMATCH"                          | 해당 item이 b+tree collection이 아님
+| "BKEY_MISMATCH"                          | 명령 인자로 주어진 bkey 유형과 대상 b+tree의 bkey 유형이 다름
+| "UNREADABLE"                             | 해당 item이 unreadable item임
+| "NOT_SUPPORTED"                          | 지원하지 않음
+| "CLIENT_ERROR bad command line format"   | protocol syntax 틀림
+
+## bop incr/decr
+
+B+tree collection 특정 하나의 element에 있는 데이터를 increment 또는 decrement하고,
+증감된 데이터를 반환한다.
+이 명령은 key-value item에 대한 incr/decr 명령과 유사한 명령으로
+이 명령을 수행할 b+tree element의 데이터는 증감이 가능한 숫자형 데이터이어야 한다.
+
+```
+bop incr <key> <bkey> <delta> [<initial> [<eflag>]] [noreply|pipe]\r\n
+bop decr <key> <bkey> <delta> [<initial> [<eflag>]] [noreply|pipe]\r\n
+```
+
+- `<key>` - 대상 item의 key string
+- `<bkey>` - 대상 element의 bkey
+- `<delta>` - increment/decrement할 delta 값으로서, 0 보다 큰 숫자 값을 가져야 한다.
+  - increment 연산으로 64bit unsigned integer가 overflow되면, wrap around되어 잔여 값으로 설정된다.
+  - decrement 연산으로 64bit unsigned integer가 underflow되면, 새로운 값은 무조건 0으로 설정된다.
+- `<initial>` - 대상 element가 없을 경우, 새로운 element를 생성하고 initial 값으로 설정한다.
+  - `<eflag>`는 새로은 element에 eflag 값을 줄 경우에 명시할 수 있다.
+
+성공 시의 response string은 아래와 같다.
+Increment/decrement 수행 후의 데이터 값이다.
+
+```
+<value>\r\n
+```
+
+실패 시의 response string과 그 의미는 아래와 같다.
+
+| Response String                                                 | 설명                    |
+|-----------------------------------------------------------------|------------------------ |
+| "NOT_FOUND"                                                     | key miss
+| "NOT_FOUND_ELEMENT"                                             | element miss
+| "TYPE_MISMATCH"                                                 | 해당 item이 b+tree collection이 아님
+| "BKEY_MISMATCH"                                                 | 명령 인자로 주언진 bkey 유형과 대상 b+tree의 bkey 유형이 다름
+| "OUT_OF_RANGE"                                                  | 새로운 element 삽입이 maxcount 또는 maxbkeyrange 제약을 위배하면서 그 element의 bkey 값이 overflowaction에 의해 자동 삭제되는 경우이어서 삽입이 실패하는 경우이다. 예를 들어, smallest_trim 상황에서 새로 삽입할 element의 bkey 값이 b+tree의 smallest bkey 보다 작으면서 maxcount 개의 elements가 이미 존재하거나 maxbkeyrange를 벗어나는 경우가 이에 해당된다.
+| "OVERFLOWED"                                                    | overflow 발생
+| "NOT_SUPPORTED"                                                 | 지원하지 않음
+| "CLIENT_ERROR cannot increment or decrement non-numeric value"  | 해당 element의 데이터가 숫자형이 아님.
+| "CLIENT_ERROR bad command line format"                          | protocol syntax 틀림
+| "SERVER_ERROR out of memory [writing get response]"             | 메모리 부족
+
+## bop mget
+
+여러 b+tree들에 대해 동일 조회 조건(bkey range와 eflag filter)으로 element들을 한꺼번에 조회한다.
+여러 b+tree들에 대한 동일 조회 조건을 사용하므로, 대상 b+tree들은 동일 bkey 유형을 가져야 한다.
+그리고, eflag에 대해서도 동일 성격의 데이터를 사용하기를 권고한다.
+
+```
+bop mget <lenkeys> <numkeys> <bkey or "bkey range"> [<eflag_filter>] [<offset>] <count>\r\n
+<”space separated keys”>\r\n
+* <eflag_filter> : <fwhere> [<bitwop> <foperand>] <compop> <fvalue>
+```
+
+- `<”space separated keys”>` - 대상 b+tree들의 key list로, 스페이스(' ')로 구분한다.
+     - 하위 호환성(1.10.X 이하 버전)을 위해 콤마(,)도 지원하지만 권장하지 않는다.
+- `<lenkeys>`과 `<numkeys>` - key list 문자열의 길이와 key 개수를 나타낸다.
+- `<bkey or "bkey range">` - 하나의 bkey 또는 bkey range 조회 조건. Bkey range는 "bkey1..bkey2" 형식으로 표현한다.
+- `<eflag_filter>` - eflag filter 조건. [Collection 기본 개념](../collection-items.md#eflag-filter)에서 eflag filter 참조 바란다.
+- [`<offset>`] `<count>` - 조회 조건을 만족하는 elements에서 skip 개수와 실제 조회할 개수
+
+bop mget 명령은 O(small N) 수행 원칙을 위하여 다음의 제약 사항을 가진다.
+- key list에 지정 가능한 최대 key 수는 200이다.
+- count의 최대 값은 50이다.
+
+
+성공 시의 response string은 다음과 같다.
+
+```
+VALUE <key> <status> [<flags> <ecount>]\r\n
+[ELEMENT <bkey> [<eflag>] <bytes> <data>\r\n
+ ...
+ ELEMENT <bkey> [<eflag>] <bytes> <data>\r\n]
+VALUE <key> <status> [<flags> <ecount>]\r\n
+[ELEMENT <bkey> [<eflag>] <bytes> <data>\r\n
+ ...
+ ELEMENT <bkey> [<eflag>] <bytes> <data>\r\n]
+
+...
+
+VALUE <key> <status> [<flags> <ecount>]\r\n
+[ELEMENT <bkey> [<eflag>] <bytes> <data>\r\n
+ ...
+ ELEMENT <bkey> [<eflag>] <bytes> <data>\r\n]
+END\r\n
+```
+
+조회한 대상 key마다 VALUE 라인이 있으며, 대상 key string과 조회 상태가 나타난다.
+조회 상태는 아래 중의 하나가 되며, 각 의미는 bop get 명령의 response string을 참조 바란다.
+
+- OK : 정상 조회
+- TRIMMED : 정상 조회 But, trimmed element 존재
+- NOT_FOUND
+- NOT_FOUND_ELEMENT
+- OUT_OF_RANGE
+- TYPE_MISMATCH
+- BKEY_MISMATCH
+- UNREADABLE
+
+조회 상태가 정상 조회된 상태인 "OK"와 "TRIMMED"이면,
+그 key에 설정된 flags 값과 조회한 element 개수가 나오며,
+다음 라인부터 조회한 각 element의 bkey  optional eflag, data 길이와 data 그 자체가 나온다.
+그 외의 조회 상태는 해당 key에서 element 조회를 실패한 경우이므로,
+flags와 ecount를 포함하여 조회된 element 정보가 생략된다.
+
+실패 시의 response string과 그 의미는 다음과 같다.
+
+| Response String                                       | 설명                    |
+|-------------------------------------------------------|------------------------ |
+| "NOT_SUPPORTED"                                       | 지원하지 않음
+| "CLIENT_ERROR bad command line format"                | protocol syntax 틀림
+| "CLIENT_ERROR bad data chunk"                         | space separated key list의 길이가 `<lenkeys>`와 다르거나 “\r\n”으로 끝나지 않음
+| "CLIENT_ERROR bad value"                              | bop mget 명령의 제약 조건을 위배함.
+| "SERVER_ERROR out of memory [writing get response]"   | 메모리 부족
+
+## bop smget
+
+여러 b+tree들에서 bkey range 조건과 eflag filter 조건을 모두 만족하는
+elements를 sort merge 형태로 조회하면서 count 개의 elements를 가져온다.
+즉, 여러 b+tree들을 하나의 large b+tree로 구성되어 있다고 보고,
+이에 대한 element 조회 기능과 동일하다.
+
+smget 동작은 조회 범위와 어떤 b+tree의 trim 영역과의 겹침에 대한 처리로,
+아래 두 가지 동작 모드가 있다.
+
+1) 기존 smget 동작 (1.8.X 이하 버전에서 동작하던 방식)
+   - smget 조회 조건을 만족하는 첫번째 element가 trim된 b+tree가 하나라도 존재하면 OUT_OF_RANGE 응답을 보낸다.
+     이 경우, 응용은 모든 key에 대해 백엔드 저장소인 DB에서 elements 조회한 후에
+     응용에서 sort-merge 작업을 수행하여야 한다.
+   - OUT_OF_RANGE가 없는 상황에서 smget을 수행하면서
+     조회 조건을 만족하는 두번째 이후의 element가 trim된 b+tree를 만나게 되면,
+     그 지점까지 조회한 elements를 최종 elements 결과로 하고
+     smget 수행 상태는 TRIMMED로 하여 응답을 보낸다.
+     이 경우, 응용은 모든 key에 대해 백엔드 저장소인 DB에서 trim 영역의 elements를 조회하여
+     smget 결과에 반영하여야 한다.
+
+2) 신규 smget 동작 (1.9.0 이후 버전에서 추가된 방식)
+   - 기존의 OUT_OF_RANGE에 해당하는 b+tree를 missed keys로 분류하고
+     나머지 b+tree들에 대해 smget을 계속 수행한다.
+     따라서, 응용에서는 missed keys에 한해서만
+     백엔드 저장소인 DB에서 elements를 조회하여 최종 smget 결과에 반영할 수 있다.
+   - smget 조회 조건을 만족하는 두번째 이후의 element가 trim된 b+tree가 존재하더라도,
+     그 지점에서 smget을 중지하는 것이 아니라, 그러한 b+tree를 trimmed keys로 분류하고
+     원하는 개수의 elements를 찾을 때까지 smget을 계속 진행한다.
+     따라서, 응용에서는 trimmed keys에 한하여
+     백엔드 저장소인 DB에서 trim된 elements를 조회하여 최종 smget 결과에 반영할 수 있다.
+   - bkey에 대한 unique 조회 기능을 지원한다.
+     중복 bkey를 허용하여 조회하는 duplcate 조회 외에
+     중복 bkey를 제거하고 unique bkey만을 조회하는 unique 조회를 지원한다.
+   - 조회 조건에 offset 기능을 제거한다.
+
+기존 smget 연산을 사용하더라도, offset 값은 항상 0으로 사용하길 권고한다.
+양수의 offset을 사용하는 smget에서 missed keys가 존재하고
+missed keys에 대한 DB 조회가 offset으로 skip된 element를 가지는 경우,
+응용에서 정확한 offset 처리가 불가능해지기 때문이다.
+이전의 조회 결과에 이어서 추가로 조회하고자 하는 경우,
+이전에 조회된 bkey 값을 바탕으로 bkey range를 재조정하여 사용할 수 있다.
+
+```
+bop smget <lenkeys> <numkeys> <bkey or "bkey range"> [<eflag_filter>] <count> [duplicate|unique]\r\n
+<"space separated keys">\r\n
+* <eflag_filter> : <fwhere> [<bitwop> <foperand>] <compop> <fvalue>
+```
+
+- `<”space separated keys”>` - 대상 b+tree들의 key list로, 스페이스(' ')로 구분한다.
+     - 하위 호환성(1.10.X 이하 버전)을 위해 콤마(,)도 지원하지만 권장하지 않는다.
+- `<lenkeys>`과 `<numkeys>` - key list 문자열의 길이와 key 개수를 나타낸다.
+- `<bkey or "bkey range">` - 하나의 bkey 또는 bkey range 조회 조건.
+Bkey range는 "bkey1..bkey2" 형식으로 표현한다.
+- `<eflag_filter>` - eflag filter 조건.
+[Collection 기본 개념](../collection-items.md)에서 eflag filter 참조 바란다.
+- `<count>` - 조회할 element 개수
+- [duplicate|unique] - smget 동작 방식을 지정한다.
+  - 생략되면, 예전 smget 동작을 수행한다.
+  - 지정되면, 신규 smget 동작을 수행한다. duplicate는 중복 bkey를 허용하고, unique는 중복 bkey를 제거한다.
+
+bop smget 명령은 O(small N) 수행 원칙을 위하여 다음의 제약 사항을 가진다.
+- key list에 지정 가능한 최대 key 수는 10000이다.
+- count의 최대 값은 2000이다.
+
+기존 smget 동작에서 성공 시의 response string은 다음과 같다.
+
+```
+VALUE <ecount>\r\n
+<key> <flags> <bkey> [<eflag>] <bytes> <data>\r\n
+<key> <flags> <bkey> [<eflag>] <bytes> <data>\r\n
+<key> <flags> <bkey> [<eflag>] <bytes> <data>\r\n
+...
+MISSED_KEYS <kcount>\r\n
+<key>\r\n
+<key>\r\n
+…
+END|DUPLICATED|TRIMMED|DUPLICATRED_TRIMMED\r\n
+```
+
+위 response string에 대한 설명은 다음과 같다.
+
+- VALUE 부분: 조회한 elements를 나타낸다.
+  - Element 정보는 조회한 element가 속한 b+tree의 key string과 flags 정보
+    그리고 그 element의 bkey, optional eflag, data로 구성된다.
+  - Element 정보는 bkey 기준으로 정렬되며,
+    동일 bkey를 가진 elements는 key string 기준으로 정렬된다.
+- MISSED_KEYS 부분: smget 조회에 참여하지 못한 key list와 그 원인을 나타낸다.
+  - `<key>`는 smget에 참여하지 못한 key string이다.
+- 마지막 라인은 smget response string의 마지막을 나타낸다.
+  - END: 조회 결과에 중복 bkey가 없음
+  - DUPLICATED: 조회 결과에 중복 bkey가 있음.
+  - TRIMMED: 조회 범위가 trim 영역과 겹치는 b+tree를 발견한 상태이다.
+  - DUPLICATED_TRIMMED: DUPLICATED와 TRIMMED 의미를 모두 가진다.
+
+신규 smget 동작에서 성공 시의 response string은 다음과 같다.
+
+```
+ELEMENTS <ecount>\r\n
+<key> <flags> <bkey> [<eflag>] <bytes> <data>\r\n
+<key> <flags> <bkey> [<eflag>] <bytes> <data>\r\n
+<key> <flags> <bkey> [<eflag>] <bytes> <data>\r\n
+...
+MISSED_KEYS <kcount>\r\n
+<key> <cause>\r\n
+<key> <cause>\r\n
+…
+TRIMMED_KEYS <kcount>\r\n
+<key> <bkey>\r\n
+<key> <bkey>\r\n
+…
+END|DUPLICATED\r\n
+
+* <cause> = NOT_FOUND | UNREADABLE | OUT_OF_RANGE
+```
+
+위 response string에 대한 설명은 다음과 같다.
+
+- ELEMENTS 부분: 조회한 elements를 나타낸다.
+  - Element 정보는 조회한 element가 속한 b+tree의 key string과 flags 정보
+    그리고 그 element의 bkey, optional eflag, data로 구성된다.
+  - Element 정보는 bkey 기준으로 정렬되며,
+    동일 bkey를 가진 elements는 key string 기준으로 정렬된다.
+- MISSED_KEYS 부분: smget 조회에 참여하지 못한 key list와 그 원인을 나타낸다.
+  - `<key>`는 smget에 참여하지 못한 key string이다.
+  - `<cause>`는 smget에 참여하지 못한 원인을 나타낸다.
+    - NOT_FOUND: 그 key가 cache에 존재하지 않음
+    - UNREADABLE: 그 key가 unreadable 상태에 있음
+    - OUT_OF_RANGE: bkey range의 시작 부분이 그 key의 trim 영역과 겹쳐 있음
+- TRIMMED_KEYS 부분: smget 조회 범위의 뒷 부분에서 trim이 발생한 key list이다.
+  - `<key>`는 trim이 발생한 key string이다.
+  - `<bkey>`는 trim 직전에 있던 마지막 bkey 이다.
+  - Timmed keys 정보는 bkey 기준으로 정렬된다.
+- 마지막 라인은 smget response string의 마지막을 나타낸다.
+  - END: 조회 결과에 중복 bkey가 없음
+  - DUPLICATED: 조회 결과에 중복 bkey가 있음.
+
+
+smget 수행의 실패 시의 response string은 다음과 같다.
+
+| Response String                                      | 설명                    |
+|------------------------------------------------------|------------------------ |
+| "TYPE_MISMATCH"                                      | 어떤 key가 b+tree type이 아님
+| "BKEY_MISMATCH"                                      | smget에 참여된 b+tree들의 bkey 유형이 서로 다름.
+| "OUT_OF_RANGE"                                       | 기존 smget 동작에서만 발생할 수 있는 실패 response string이다.
+| "NOT_SUPPORTED"                                      | 지원하지 않음
+| "CLIENT_ERROR bad command line format"               | protocol syntax 틀림
+| "CLIENT_ERROR bad data chunk"                        | 주어진 key 리스트에 중복 key가 존재하거나 주어진 key 리스트의 길이가 `<lenkeys>` 길이와 다르거나 "\r\n"으로 끝나지 않음.
+| "CLIENT_ERROR bad value"                             | 앞서 기술한 smget 연산의 제약 조건을 위배
+| "SERVER_ERROR out of memory [writing get response]"   | 메모리 부족
+
+
+## bop position
+
+b+tree collection에서 특정 element의 position을 조회한다.
+Element의 position이란 b+tree에서의 위치 정보로서,
+bkey들의 정렬(ASC or DESC) 기준으로 몇 번째 위치한 element인지를 나타내는
+0부터 N-1까지의 index를 의미한다.
+
+```
+bop position <key> <bkey> <order>\r\n
+* <order> = asc | desc
+```
+
+- `<key>` - 대상 item의 key string
+- `<bkey>` - 대상 element의 bkey
+- `<order>` - 어떤 bkey 정렬 기준으로 position을 얻을 것인지 명시
+
+성공 시의 response string은 아래와 같다.
+
+```
+POSITION=<position>\r\n
+```
+
+실패 시의 response string과 그 의미는 아래와 같다.
+
+| Response String                          | 설명                    |
+|------------------------------------------|------------------------ |
+| "NOT_FOUND"                              | key miss
+| "NOT_FOUND_ELEMENT"                      | element miss
+| "TYPE_MISMATCH"                          | b+tree collection 아님
+| "BKEY_MISMATCH"                          | 명령 인자로 주어진 bkey 유형과 대상 b+tree의 bkey 유형이 다름
+| "UNREADABLE"                             | 해당 item이 unreadable item임
+| "NOT_SUPPORTED"                          | 지원하지 않음
+| "CLIENT_ERROR bad command line format"   | protocol syntax 틀림
+
+## bop gbp
+
+B+tree collection에서 position 기반으로 elements를 조회한다.
+
+```
+bop gbp <key> <order> <position or "position range">\r\n
+* <order> = asc | desc
+```
+
+- `<key>` - 대상 item의 key string
+- `<order>` - 어떤 bkey 정렬 기준으로 position을 적용할 지를 명시
+- `<position or "position range">` - 조회할 elements의 하나의 position 또는 position range.
+Position range는 "position1..position2" 형식으로 표현.
+
+성공 시의 response string은 아래와 같다.
+bop get 성공 시의 response string을 참조 바란다.
+
+```
+VALUE <flags> <count>\r\n
+<bkey> [<eflag>] <bytes> <data>\r\n
+<bkey> [<eflag>] <bytes> <data>\r\n
+<bkey> [<eflag>] <bytes> <data>\r\n
+…
+END\r\n
+```
+
+실패 시의 response string과 그 의미는 아래와 같다.
+
+| Response String                                      | 설명                    |
+|------------------------------------------------------|------------------------ |
+| "NOT_FOUND"                                          | key miss
+| "NOT_FOUND_ELEMENT"                                  | element miss
+| "TYPE_MISMATCH"                                      | b+tree collection 아님
+| "UNREADABLE"                                         | 해당 item이 unreadable item임
+| "NOT_SUPPORTED"                                      | 지원하지 않음
+| "CLIENT_ERROR bad command line format"               | protocol syntax 틀림
+| "SERVER_ERROR out of memory [writing get response]"  | 메모리 부족
+
+## bop pwg
+`version 1.8.0`
+
+B+tree collection에서 특정 bkey의 position을 조회하면서,
+그 bkey를 가진 element를 포함하여 앞뒤에(양방향) 위치한 element N개 씩을 한번에 조회한다.
+
+```
+bop pwg <key> <bkey> <order> [<count>]\r\n
+* <order> = asc | desc
+```
+
+- `<key>` - 대상 item의 key string
+- `<bkey>` - 대상 element의 bkey
+- `<order>` - 어떤 bkey 정렬 기준으로 position을 얻을 것인지 명시
+- `<count>` - 조회한 position의 앞뒤에서 각각 몇 개의 element를 조회할 것인지를 명시 (**최대 값은 100으로 제한**)
+  - 0이면, 조회한 position의 element만 조회
+  - 양수이면, 조회한 position의 element 외에 그 position의 앞뒤에서 각각 그 수만큼 element 조회
+
+성공 시의 response string은 아래와 같다.
+
+```
+VALUE <position> <flags> <count> <index>\r\n
+<bkey> [<eflag>] <bytes> <data>\r\n
+...
+<bkey> [<eflag>] <bytes> <data>\r\n
+END\r\n
+```
+
+위의 VALUE 라인에서 각 값의 의미는 다음과 같다.
+그 아래 라인들에서 element 값의 표현은 bop get 경우와 동일하다.
+
+- `<position>` : 주어진 bkey의 position
+- `<flags>` : b+tree item의 flags 속성값
+- `<count>` : 조회한 전체 element 개수
+- `<index>` : 전체 element list에서 주어진 bkey를 가진 element 위치 (0-based index)
+  - 주어진 bkey의 position과 element만 조회하면, count는 1이 되고, index는 0이 된다.
+  - 주어진 bkey의 position과 element 외에 양방향 10개 element 조회에서,
+    그 position 앞에 5개 element가 존재하고 뒤에 10개 element가 존재한다면
+    count는 (5 + 1 + 10) = 16이 되고, index는 5가 된다.
+
+실패 시의 response string과 그 의미는 아래와 같다.
+
+| Response String                                     | 설명                    |
+|-----------------------------------------------------|-------------------------|
+| "NOT_FOUND"                                         | key miss
+| "NOT_FOUND_ELEMENT"                                 | element miss
+| "TYPE_MISMATCH"                                     | b+tree collection 아님
+| "BKEY_MISMATCH"                                     | 명령 인자로 주어진 bkey 유형과 대상 b+tree의 bkey 유형이 다름
+| "UNREADABLE"                                        | 해당 item이 unreadable item임
+| "NOT_SUPPORTED"                                     | 지원하지 않음
+| "CLIENT_ERROR bad command line format"              | protocol syntax 틀림
+| "SERVER_ERROR out of memory [writing get response]" | 메모리 부족

--- a/documentation/ascii-protocol/06-pipelining.md
+++ b/documentation/ascii-protocol/06-pipelining.md
@@ -1,0 +1,70 @@
+# Command Pipelining
+
+Command pipelining은
+“pipe” 키워드를 통해 여러 collection 명령들을 pipelining하여 cache server에 전달하고,
+cache server는 각 명령을 처리한 즉시 그 response를 client로 전달하는 것이 아니라
+그 response를 reply queue에 보관해 두었다가, 마지막 명령 처리 후에 reply queue에 보관해 둔 전체 response를
+한번에 client로 전달하는 기능이다.
+기존에 N 번의 request – response를 전달하던 것에 비해
+command pipelining은 한 번의 request stream과 한 번의 response stream을 전달할 수 있게 함으로써
+network 비용을 상당히 줄일 수 있으며, 전체 latency를 줄일 수 있는 장점을 가진다.
+
+Command pipelining은 현재 collection 명령들 중 일부에 한해서만 가능하다.
+Command pipelining 가능한 명령은 아래와 같으며, 단순 response string을 가지는 명령만 이에 해당된다.
+한번에 pipelining이 가능한 최대 명령의 수는 `500`개로 제한을 두고 있음을 주의하여야 한다.
+
+* lop 명령들 - lop insert/delete
+* sop 명령들 - sop insert/delete/exist
+* mop 명령들 - mop insert/delete/update
+* bop 명령들 - bop insert/upsert/delete/update/incr/decr
+
+Command pipelining 수행 예로,
+특정 list의 tail 쪽으로 10개 elements를 추가하고자 한다면,
+아래와 같이 lop insert 명령을 연속하여 cache server로 보내면 된다.
+첫 번째 명령부터 마지막 바로 이전 명령까지는 모두 “pipe” 인자를 사용하여 연결하여야 하고,
+마지막 명령에서는 “pipe” 인자를 생략함으로써 pipelining의 끝임을 표현하여야 한다.
+
+```
+ lop insert lkey -1 6 pipe\r\ndatum0\r\n
+ lop insert lkey -1 6 pipe\r\ndatum1\r\n
+ lop insert lkey -1 6 pipe\r\ndatum2\r\n
+ lop insert lkey -1 6 pipe\r\ndatum3\r\n
+ lop insert lkey -1 6 pipe\r\ndatum4\r\n
+ lop insert lkey -1 6 pipe\r\ndatum5\r\n
+ lop insert lkey -1 6 pipe\r\ndatum6\r\n
+ lop insert lkey -1 6 pipe\r\ndatum7\r\n
+ lop insert lkey -1 6 pipe\r\ndatum8\r\n
+ lop insert lkey -1 6\r\ndatum9\r\n
+```
+
+Command pipelining의 response string은 아래와 같다.
+
+```
+RESPONSE <count>\r\n
+<STATUS of the 1st pipelined command>\r\n
+<STATUS of the 2nd pipelined command>\r\n
+...
+<STATUS of the last pipelined command>\r\n
+END|PIPE_ERROR <error_string>\r\n
+```
+
+RESPONSE 라인에서 `<count>`는 전체 결과 수를 나타내고,
+그 다음 라인들은 각 명령의 수행 결과를 차례로 나타낸다.
+각 명령의 결과는 각 명령마다 다르므로 각 명령에 대한 설명을 참조하여야 한다.
+마지막 라인은 pipelining 수행 상태를 나타내며, 아래 중의 하나를 가진다.
+
+- "END" - pipelining 연산이 정상 수행됨
+- “PIPE_ERROR command overflow” - pipelining 가능한 최대 commands 수인 500개를 초과하였다.
+  이 경우, 500개까지의 command들만 하나의 command pipelining으로 처리되고 하나의 response stream으로 리턴된다.
+  그 이후의 commands들은 처리되지 않는다.
+- “PIPE_ERROR memory overflow” - ARCUS cache server 내부에서 pipelining 처리를 위한
+  메모리 공간이 부족한 상태를 의미한다. ARCUS cache server는 500개 commands의 result를 담아둘 공간을
+  미리 확보하여 수행하므로 이 오류가 발생할 가능성은 거의 없다.
+  단, 의도하지 않은 이유에 의한 경우를 대비하여 이 오류를 추가해 둔 것이다.
+  이 오류가 발생하면, 그 시점에 command pipelining을 중지하고 그 즉시 response stream을 client에 전달한다.
+  이 경우의 response stream에는 가장 마지막에 수행된 command의 response string이 생략된다.
+  그리고, 그 이후의 commands들은 처리되지 않는다.
+- “PIPE_ERROR bad error” - pipelining 으로 어떤 command를 수행 중
+  “CLIENT_ERROR”와 “SERVER_ERROR”로 시작하는 중요 오류가 발생한 경우이다.
+  이 경우에도, 그 즉시 command pipelining을 중지하고 현재까지의 response stream을 client에 전달한다.
+  그리고, 그 이후의 commands들은 처리되지 않는다.

--- a/documentation/ascii-protocol/07-item-attribute.md
+++ b/documentation/ascii-protocol/07-item-attribute.md
@@ -1,0 +1,61 @@
+# Item Attribute 명령
+
+Item attributes를 조회하는 getattr 명령과 변경하는 setattr 명령을 소개한다.
+
+ARCUS에서 어떤 item attributes를 제공하는 지를 알고자 한다면,
+[Item Attibute 설명](../item-attributes.md)을 참고 바란다.
+
+
+## getattr (Item Attribute 조회)
+
+Item attributes를 조회하는 getattr 명령은 아래와 같다.
+
+```
+getattr <key> [<name> ...]\r\n
+```
+
+- `<key>` - 대상 item의 key string
+- [`<name>` ...] - 조회할 attribute name을 순차적으로 지정하는 것이며,
+  이를 생략하면, item 유형에 따라 조회가능한 모든 attributes 값을 조회한다.
+
+성공 시의 response string은 아래와 같다.
+getattr 명령의 인자로 지정한 attribute name 순서대로 name과 value의 쌍을 리턴한다.
+
+```
+ATTR <name>=<value>\r\n
+ATTR <name>=<value>\r\n
+...
+END\r\n
+```
+
+실패 시의 response string과 그 의미는 아래와 같다.
+
+| Response String                         | 설명                     |
+|-----------------------------------------|------------------------ |
+| "NOT_FOUND"                             | key miss
+| "ATTR_ERROR not found"                  | 인자로 지정한 attribute가 존재하지 않거나 해당 item 유형에서 지원되지 않는 attribute임.
+| "CLIENT_ERROR bad command line format"  | protocol syntax 틀림
+
+
+## setattr (Item Attribute 변경)
+
+Item attributes를 변경하는 setattr 명령은 아래와 같다.
+모든 attributes에 대해 조회가 가능하지만, 변경은 일부 attributes에 대해서만 가능하다.
+변경가능한 attributes로는 expiretime, maxcount, overflowaction, readable, maxbkeyrange가 있다.
+
+```
+setattr <key> <name>=<value> [<name>=<value> ...]\r\n
+```
+
+- `<key>` - 대상 item의 key string
+- `<name>`=`<value>` - 변경할 attribute의 name과 value 쌍을 하나 이상 명시하여야 한다.
+
+이 명령의 response string과 그 의미는 아래와 같다.
+
+| Response String                         | 설명                     |
+|-----------------------------------------|------------------------ |
+| "OK"                                    | 성공
+| "NOT_FOUND"                             | key miss
+| "ATTR_ERROR not found"                  | 인자로 지정한 attribute가 존재하지 않거나 해당 item 유형에서 지원되지 않는 attribute임.
+| "ATTR_ERROR bad value"                  | 해당 attribute에 대해 새로 변경하고자 하는 value가 allowed value가 아님.
+| "CLIENT_ERROR bad command line format"  | protocol syntax 틀림

--- a/documentation/ascii-protocol/08-scan.md
+++ b/documentation/ascii-protocol/08-scan.md
@@ -1,0 +1,151 @@
+# Scan 명령
+
+- [SCAN KEY 명령](#scan-key)
+- [SCAN PREFIX 명령](#scan-prefix)
+
+## Scan key
+
+특정 조건을 만족하는 아이템들의 키 목록을 얻어올 수 있는 scan key 기능을 제공한다.
+scan key 기능은 제한된 시간(5ms) 내에서 아이템들을 스캔하고 응용에게 찾은 키 스트링 목록과
+다음 스캔할 위치를 응답해준다. 응용은 응답 받은 위치를 다시 주어 scan key 를 반복 호출하는
+iteration 방식으로 전체 아이템을 스캔한다.
+scan key 명령 요청 syntax는 아래와 같다.
+
+```
+scan key <cursor> [count <count>] [match <pattern>] [type <type>]\r\n
+```
+
+- `<cursor>` - 스캔 시작 위치.
+처음부터 스캔한다면 0을, 이전 스캔이 끝난 다음 지점부터 이어서 한다면 이전 스캔에서 응답 받은 cursor 값을 그대로 지정한다.
+- `<count>` - 스캔할 아이템 개수. 1~2000 범위에서 지정할 수 있고, 지정하지 않을 시 20 으로 설정된다.
+지정한 수만큼의 아이템들을 스캔하여 그 중 조건(type, pattern)과 일치하는 아이템들의 키 목록을 응답한다.
+응답한 키 목록의 개수는 scan key 내부 구현 로직 상 count 보다 적거나 많을 수 있다.
+count 보다 적은 경우는 조건과 불일치한 아이템이 존재하거나 long query 방지를 위해 scan key 수행시간이 제한시간을 초과하여 수행을 종료한 경우이다.
+count 보다 많은 경우는 스캔 동작이 해시테이블의 버켓 단위로 수행하기 때문에 하나의 버켓에 대해 스캔을 시작하면 마지막 지점까지 스캔을 완료하므로 count 보다 많은 수의 아이템을 스캔할 수 있다.
+이렇게 설계한 이유는 버켓 중간에서 스캔을 중지할 경우 다음 스캔 요청이 들어올 때까지 그 버켓의 상태가 변경되지 않게 유지해야 하는
+복잡성을 제거하여 stateless한 scan key api를 제공하기 위함이다.
+- `<pattern>` - 키 문자열 패턴. 최대 문자열 길이: 64, 최대 '\*' 입력 개수: 4 . 지정하지 않을 시 모든 키 문자열을 조회한다.
+glob style 패턴 문자열을 지정하여 해당 패턴과 일치하는 키 문자열을 갖는 아이템들을 찾는다. glob 문자는 `*`, `?`, `\` 을 지원한다.
+문자열 비교 알고리즘의 worst case 수행 시간이 오래 걸리는 것을 방지하기 위해 패턴 문자열에 길이와 '\*' 입력 개수에 제약을 두었다.
+- `<type>` - 아이템 타입. 각 타입별 지정 값은 다음과 같다. 지정하지 않을 시 'A' 로 설정된다.
+All type : 'A', KV : 'K', List : 'L', Set : 'S', Map : 'M', Btree : 'B'
+
+scan key 명령 응답 syntax는 아래와 같다.
+
+```
+KEYS <key_count> <cursor>\r\n
+key1 <type> <expiretime>\r\n
+key2 <type> <expiretime>\r\n
+key3 <type> <expiretime>\r\n
+...
+```
+
+첫 번째 줄에는 KEYS 로 시작하는 응답 문자열이 나온다.
+`<key_count>`는 조건과 일치한 아이템 개수로 두 번째 줄부터 키 문자열이 `<key_count>` 개 만큼 나온다.
+`<cursor>`는 스캔할 다음 지점으로 이어서 스캔할 경우 이 값을 그대로 주어 scan key 호출하면 된다.
+이 값이 0 이 나오면 전체 아이템을 스캔 완료했음을 나타낸다. 따라서 응용은 0이 나올때까지 반복 호출하면 된다.
+
+두 번째 줄부터 scan된 key 목록이 나온다.
+`<type>` - 아이템 타입. 각 타입별 지정 값은 다음과 같다.
+KV : 'K', List : 'L', Set : 'S', Map : 'M', Btree : 'B'
+`<expiretime>`은 아이템 만료 시간을 나타낸다.
+
+scan key 사용 예시이다.
+1000개의 아이템을 스캔하여 그 중 KV 타입이고, `*key1*` 패턴과 일치하는 키 목록을 조회한다.
+```
+scan key 0 count 1000 match *key1* type K
+```
+
+5개의 키가 조회되었고, 다음 스캔 지점 cursor 값은 8000이다.
+0이 아니므로 전체 아이템을 스캔하지 못했음을 의미한다. 0이 나올때까지 응답받은 cursor 를 주어 scan key 를 반복 호출하면 된다.
+```
+KEYS 5 8000\r\n
+akey12 K 0\r\n
+bkey13 K 10\r\n
+ccckey14 K 0\r\n
+cckey16 K 0\r\n
+keykey13 K 3600\r\n
+```
+
+scan key 명령 실패 시에 response string 은 다음과 같다.
+
+| Response String                        | 설명                     |
+|----------------------------------------|------------------------ |
+| CLIENT_ERROR bad cursor value          | cursor 문자열 길이가 32 이상인 경우
+| CLIENT_ERROR bad count value           | count 가 0 이거나 2000 보다 큰 경우
+| CLIENT_ERROR bad pattern string        | 패턴 문자열 길이가 65 이상이거나 패턴 문자열에 * 을 5개 이상 주었거나 '\\' 다음에 패턴 문자('\\', '\*', '\?')가 없는 경우
+| CLIENT_ERROR bad item type             | type 값을 잘못 준 경우
+| CLIENT_ERROR invalid cursor            | cursor 에 숫자가 아닌 값을 준 경우
+| CLIENT_ERROR bad command line format   | protocol syntax 틀림
+
+## Scan prefix
+
+특정 조건을 만족하는 Prefix 목록을 얻어올 수 있는 scan prefix 기능을 제공한다.
+scan prefix 기능은 제한된 시간(5ms) 내에서 Prefix들을 스캔하고 응용에게 찾은 Prefix 목록과
+다음 스캔할 위치를 응답해준다. 응용은 응답 받은 위치를 다시 주어 scan prefix 를 반복 호출하는
+iteration 방식으로 전체 Prefix를 스캔한다.
+scan prefix 명령 요청 syntax는 아래와 같다.
+
+```
+scan prefix <cursor> [count <count>] [match <pattern>]\r\n
+```
+
+- `<cursor>` - 스캔 시작 위치.
+처음부터 스캔한다면 0을, 이전 스캔이 끝난 다음 지점부터 이어서 한다면 이전 스캔에서 응답 받은 cursor 값을 그대로 지정한다.
+- `<count>` - 스캔할 Prefix 개수. 1~2000 범위에서 지정할 수 있고, 지정하지 않을 시 20 으로 설정된다.
+지정한 수만큼의 Prefix들을 스캔하여 그 중 조건(pattern)과 일치하는 Prefix 목록을 응답한다.
+응답한 Prefix 목록의 개수는 scan prefix 내부 구현 로직 상 count 보다 적거나 많을 수 있다.
+count 보다 적은 경우는 조건과 불일치한 Prefix가 존재하거나 long query 방지를 위해 scan prefix 수행시간이 제한시간을 초과하여 수행을 종료한 경우이다.
+count 보다 많은 경우는 스캔 동작이 해시테이블의 버켓 단위로 수행하기 때문에 하나의 버켓에 대해 스캔을 시작하면 마지막 지점까지 스캔을 완료하므로 count 보다 많은 수의 Prefix를 스캔할 수 있다.
+이렇게 설계한 이유는 버켓 중간에서 스캔을 중지할 경우 다음 스캔 요청이 들어올 때까지 그 버켓의 상태가 변경되지 않게 유지해야 하는
+복잡성을 제거하여 stateless한 scan prefix api를 제공하기 위함이다.
+- `<pattern>` - 키 문자열 패턴. 최대 문자열 길이: 64, 최대 '\*' 입력 개수: 4 . 지정하지 않을 시 모든 키 문자열을 조회한다.
+glob style 패턴 문자열을 지정하여 해당 패턴과 일치하는 키 문자열을 갖는 Prefix들을 찾는다. glob 문자는 `*`, `?`, `\` 을 지원한다.
+문자열 비교 알고리즘의 worst case 수행 시간이 오래 걸리는 것을 방지하기 위해 패턴 문자열에 길이와 '\*' 입력 개수에 제약을 두었다.
+
+scan prefix 명령 응답 syntax는 아래와 같다.
+
+```
+PREFIXES <prefix_count> <cursor>\r\n
+prefix1 <item_count> <item_bytes> <create_time>\r\n
+prefix2 <item_count> <item_bytes> <create_time>\r\n
+prefix3 <item_count> <item_bytes> <create_time>\r\n
+...
+```
+
+첫 번째 줄에는 PREFIXES 로 시작하는 응답 문자열이 나온다.
+`<prefix_count>`는 조건과 일치한 Prefix 개수로 두 번째 줄부터 Prefix 문자열이 `<prefix_count>` 개 만큼 나온다.
+`<cursor>`는 스캔할 다음 지점으로 이어서 스캔할 경우 이 값을 그대로 주어 scan prefix 호출하면 된다.
+이 값이 0 이 나오면 전체 Prefix를 스캔 완료했음을 나타낸다. 따라서 응용은 0이 나올때까지 반복 호출하면 된다.
+
+두 번째 줄부터 scan된 prefix 목록이 나온다.
+`<item_count>`는 해당 prefix의 아이템 개수를 나타낸다.
+`<item_bytes>`는 해당 prefix의 아이템들이 차지하는 메모리 용량을 byte 단위로 나타낸다.
+`<create_time>`은 해당 prefix가 생성된 시간을 나타낸다.
+
+scan prefix 사용 예시이다.
+1000개의 Prefix를 스캔하여 그 중 `*prefix1*` 패턴과 일치하는 Prefix 목록을 조회한다.
+```
+scan prefix 0 count 1000 match *prefix1*
+```
+
+5개의 키가 조회되었고, 다음 스캔 지점 cursor 값은 8이다.
+0이 아니므로 전체 Prefix를 스캔하지 못했음을 의미한다. 0이 나올때까지 응답받은 cursor 를 주어 scan prefix 를 반복 호출하면 된다.
+```
+PREFIXES 5 8\r\n
+aprefix12 1 96 20220621095219\r\n
+bprefix13 12 2016 20220621095219\r\n
+cccprefix14 25 2704 20220621095219\r\n
+ccprefix16 2 256 20220621095219\r\n
+prefixprefix13 3 288 20220621095219\r\n
+```
+
+scan prefix 명령 실패 시에 response string 은 다음과 같다.
+
+| Response String                        | 설명                     |
+|----------------------------------------|------------------------ |
+| CLIENT_ERROR bad cursor value          | cursor 문자열 길이가 32 이상인 경우
+| CLIENT_ERROR bad count value           | count 가 0 이거나 2000 보다 큰 경우
+| CLIENT_ERROR bad pattern string        | 패턴 문자열 길이가 65 이상이거나 패턴 문자열에 * 을 5개 이상 주었거나 '\\' 다음에 패턴 문자('\\', '\*', '\?')가 없는 경우
+| CLIENT_ERROR invalid cursor            | cursor 에 숫자가 아닌 값을 준 경우
+| CLIENT_ERROR bad command line format   | protocol syntax 틀림

--- a/documentation/ascii-protocol/09-administration.md
+++ b/documentation/ascii-protocol/09-administration.md
@@ -1,0 +1,1023 @@
+# Chapter 12. Admin & Monitoring 명령
+
+- [FLUSH 명령](#flush)
+- [SCRUB 명령](#scrub)
+- [STATS 명령](#stats)
+- [CONFIG 명령](#config)
+- [CMDLOG 명령](#command-logging)
+- [LQDETECT 명령](#long-query-detect)
+- [KEY DUMP 명령](#key-dump)
+- [ZKENSEMBLE 명령](#zkensemble)
+- [HELP 명령](#help)
+
+## Flush
+
+ARCUS Cache Server는 items을 invalidate 시키기 위한 두 가지 flush 명령을 제공한다.
+
+- flush_all : 모든 items을 flush
+- flush_prefix: 특정 prefix의 items들만 flush
+
+Flush 작업은 items을 invalidate시키더라도 그 items이 차지한 메모리 공간을 즉각 반환하지 않는다.
+대신, ARCUS Cache Server의 global 정보로 flush 수행 시점 정보를 기록해 둠으로써,
+그 시점 이전에 존재했던 items은 invalidated items이라는 것을 알 수 있게 한다.
+따라서, item 접근할 때마다 invalidated item인지를 확인하여야 하는 부담이 있지만,
+flush 작업 자체는 O(1) 시간에 그 수행이 완료된다.
+
+flush_all 명령은 flush 수행 시점 정보만 기록해 두고, 전체 prefix들의 통계 정보는 그대로 남겨 둔다.
+따라서, flush_all을 수행하더라도  prefix 관련한 통계 정보를 조회할 수 있다.
+해당 prefix에 속한 items이 모두 제거되는 시점에, 그 prefix의 통계 정보는 함께 제거된다.
+반면, flush_prefix 명령은 해당 prefix에 대한 flush 수행 시점 정보를 기록해 두면서,
+그 prefix의 통계 정보를 모두 reset시켜 제거한다는 것이 차이가 있다.
+따라서, flush_prefix 수행 이후에는 해당 prefix에 대한 통계 정보를 조회할 수 없게 된다.
+
+두 flush 명령의 syntax는 아래와 같다.
+
+```
+flush_all [<delay>] [noreply]\r\n
+flush_prefix <prefix> [<delay>] [noreply]\r\n
+```
+
+- `<prefix>` - prefix string. "`<null>`"을 사용하면, prefix string이 없는 item들을 invalidate시킨다.
+- `<delay>` - 지연된 invalidation 요청 시에 명시하며, 그 지연 기간을 초(second) 단위로 지정한다.
+- noreply - 명시하면, response string이 생략된다.
+
+Response string과 그 의미는 아래와 같다.
+
+| Response String                         | 설명                     |
+|-----------------------------------------|------------------------ |
+| "OK"                                    | 성공
+| "NOT_FOUND"                             | prefix miss (flush_prefix 명령인 경우만 해당)
+| "CLIENT_ERROR bad command line format"  | protocol syntax 틀림
+
+## Scrub
+
+ARCUS Cache Server에는 유효하지 않으면서 메모리를 차지하고 있는 items이 존재할 수 있다.
+이 items은 아래 두 유형으로 구분된다.
+
+- ARCUS Cache Server에서 어떤 items이 expired되더라도 그 items은 즉각 제거되지 않으며,
+  flush 명령으로 어떤 items을 invalidate시키더라도 그 items은 즉각 제거되지 않는다.
+  이들 items은 ARCUS Cache Server 내부에 메모리를 차지하면서 계속 존재하고 있다.
+  어떤 이유이든 이 items에 대한 접근이 발생할 때
+  ARCUS Cache Server는 expired/flushed 상태임을 알게 되며,
+  그 items을 제거함으로써 그 items이 차지한 메모리를 반환한다.
+- Cache cloud를 형성하고 consistent hashing의 key-to-node mapping을 사용하는 환경에서,
+  그 cache cloud에 특정 node의 추가나 삭제에 의해 key-to-node remapping이 발생하게 된다.
+  이러한 key-to-node remapping이 발생하면, 어떤 node에 있던 기존 items은 더 이상 사용되지 않게 된다.
+  이러한 items을 stale items이라 한다. 이러한 stale items은 자연스럽게 expired 되기도 하지만,
+  old data를 가지고 남아 있다가 그 이후의 key-to-node remapping에 의해
+  유효한 items으로 다시 전환될 여지가 있다.
+  따라서, 이러한 stale items은 cache cloud의 node list가 변경될 때마다 제거하여야 한다.
+
+Scrub 기능이란 (1) expired item, flushed item과 같은 invalidated item들을 명시적으로 제거하는 기능과
+(2) cache cloud에서 key-to-node remapping으로 발생한 stale items들을 명시적으로 제거하는 기능을 의미한다.
+
+이러한 scrub 기능은 daemon thread에 의해 background 작업으로 수행되며,
+한 순간에 하나의 scrub 작업만 수행될 수 있다.
+즉, scrub 작업이 진행 중인 상태에서 새로운 scrub 작업을 요청할 수 없다.
+
+```
+scrub [stale]\r\n
+```
+
+- stale - 명시하지 않으면 invalidated item을 제거하고, 명시하면 stale item을 제거한다.
+
+Response string과 그 의미는 아래와 같다.
+
+| Response String                         | 설명                     |
+|-----------------------------------------|------------------------ |
+| "OK"                                    | 성공
+| "BUSY"                                  | 현재 scrub 작업이 수행 중이어서 새로운 scrub 작업을 요청할 수 없음
+| "NOT_SUPPORTED"                         | 지원되지 않는 scrub 명령
+| "CLIENT_ERROR bad command line format"  | protocol syntax 틀림
+
+참고 사항으로, scrub 명령은 ASCII 명령의 extension 기능으로 구현되었기에,
+ARCUS Cache Server 구동 시에 ascii_scrub.so 파일을 dynamic linking 하는
+구동 옵션을 주어야 scrub 명령을 사용할 수 있다.
+
+
+## Stats
+
+ARCUS Cache Server의 각종 통계 정보를 조회하거나 그 통계 정보를 reset한다.
+
+```
+stats [<args>]\r\n
+```
+
+`<args>`를 생략하거나, 어떤 값을 주느냐에 따라 stats 명령의 동작은 아래와 같이 달라진다.
+
+```
+ <args>             | stats 명령의 동작
+ ------------------ | -------------------------------------------
+                    | General purpose 통계 정보 조회
+ settings           | Configuration 정보 조회
+ items              | Item 통계 정보 조회
+ slabs              | Slab 통계 정보 조회
+ prefixes           | Prefix 별 item 통계 정보 조회
+ detail on|off|dump | Prefix 별 수행 명령 통계 정보 조회 및 제어
+ zookeeper          | Zookeeper 정보 조회
+ scrub              | scrub 수행 상태 조회
+ cachedump          | slab class 별 cache key dump
+ reset              | 모든 통계 정보를 reset
+ persistence        | Persistence 정보 조회
+```
+
+stats 명령은 직접 한번씩 수행해 보기를 권하며, 아래에서는 추가 설명이 필요한 부분들만 기술한다.
+
+### General purpose 정보
+
+특정 분류에 국한되지 않은 일반적인 통계를 알기 위한 명령이다. 다음은 stats 명령 결과의 예이다.
+
+```
+STAT pid 3553
+STAT uptime 6910
+STAT time 1584942539
+STAT version 1.11.7
+STAT libevent 2.1.11-stable
+STAT pointer_size 64
+STAT rusage_user 1.241010
+STAT rusage_system 2.843840
+STAT daemon_connections 2
+STAT curr_connections 1
+STAT quit_connections 0
+STAT reject_connections 0
+STAT total_connections 3
+STAT connection_structures 3
+STAT cmd_get 0
+STAT cmd_set 0
+STAT cmd_incr 0
+STAT cmd_decr 0
+STAT cmd_delete 0
+STAT cmd_flush 0
+STAT cmd_flush_prefix 0
+STAT cmd_cas 0
+STAT cmd_lop_create 0
+STAT cmd_lop_insert 0
+STAT cmd_lop_delete 0
+STAT cmd_lop_get 0
+STAT cmd_sop_create 0
+STAT cmd_sop_insert 0
+STAT cmd_sop_delete 0
+STAT cmd_sop_get 0
+STAT cmd_sop_exist 0
+STAT cmd_mop_create 0
+STAT cmd_mop_insert 0
+STAT cmd_mop_update 0
+STAT cmd_mop_delete 0
+STAT cmd_mop_get 0
+STAT cmd_bop_create 0
+STAT cmd_bop_insert 0
+STAT cmd_bop_update 0
+STAT cmd_bop_delete 0
+STAT cmd_bop_get 0
+STAT cmd_bop_count 0
+STAT cmd_bop_position 0
+STAT cmd_bop_pwg 0
+STAT cmd_bop_gbp 0
+STAT cmd_bop_mget 0
+STAT cmd_bop_smget 0
+STAT cmd_bop_incr 0
+STAT cmd_bop_decr 0
+STAT cmd_getattr 0
+STAT cmd_setattr 0
+STAT auth_cmds 0
+STAT auth_errors 0
+STAT get_hits 0
+STAT get_misses 0
+STAT delete_misses 0
+STAT delete_hits 0
+STAT incr_misses 0
+STAT incr_hits 0
+STAT decr_misses 0
+STAT decr_hits 0
+STAT cas_misses 0
+STAT cas_hits 0
+STAT cas_badval 0
+STAT lop_create_oks 0
+STAT lop_insert_misses 0
+STAT lop_insert_hits 0
+STAT lop_delete_misses 0
+STAT lop_delete_elem_hits 0
+STAT lop_delete_none_hits 0
+STAT lop_get_misses 0
+STAT lop_get_elem_hits 0
+STAT lop_get_none_hits 0
+STAT sop_create_oks 0
+STAT sop_insert_misses 0
+STAT sop_insert_hits 0
+STAT sop_delete_misses 0
+STAT sop_delete_elem_hits 0
+STAT sop_delete_none_hits 0
+STAT sop_get_misses 0
+STAT sop_get_elem_hits 0
+STAT sop_get_none_hits 0
+STAT sop_exist_misses 0
+STAT sop_exist_hits 0
+STAT mop_create_oks 0
+STAT mop_insert_misses 0
+STAT mop_insert_hits 0
+STAT mop_update_misses 0
+STAT mop_update_elem_hits 0
+STAT mop_update_none_hits 0
+STAT mop_delete_misses 0
+STAT mop_delete_elem_hits 0
+STAT mop_delete_none_hits 0
+STAT mop_get_misses 0
+STAT mop_get_elem_hits 0
+STAT mop_get_none_hits 0
+STAT bop_create_oks 0
+STAT bop_insert_misses 0
+STAT bop_insert_hits 0
+STAT bop_update_misses 0
+STAT bop_update_elem_hits 0
+STAT bop_update_none_hits 0
+STAT bop_delete_misses 0
+STAT bop_delete_elem_hits 0
+STAT bop_delete_none_hits 0
+STAT bop_get_misses 0
+STAT bop_get_elem_hits 0
+STAT bop_get_none_hits 0
+STAT bop_count_misses 0
+STAT bop_count_hits 0
+STAT bop_position_misses 0
+STAT bop_position_elem_hits 0
+STAT bop_position_none_hits 0
+STAT bop_pwg_misses 0
+STAT bop_pwg_elem_hits 0
+STAT bop_pwg_none_hits 0
+STAT bop_gbp_misses 0
+STAT bop_gbp_elem_hits 0
+STAT bop_gbp_none_hits 0
+STAT bop_mget_oks 0
+STAT bop_smget_oks 0
+STAT bop_incr_elem_hits 0
+STAT bop_incr_none_hits 0
+STAT bop_incr_misses 0
+STAT bop_decr_elem_hits 0
+STAT bop_decr_none_hits 0
+STAT bop_decr_misses 0
+STAT getattr_misses 0
+STAT getattr_hits 0
+STAT setattr_misses 0
+STAT setattr_hits 0
+STAT stat_prefixes 0
+STAT bytes_read 23
+STAT bytes_written 771
+STAT limit_maxbytes 8589934592
+STAT threads 6
+STAT conn_yields 0
+STAT curr_prefixes 0
+STAT reclaimed 0
+STAT evictions 0
+STAT outofmemorys 0
+STAT sticky_items 0
+STAT curr_items 0
+STAT total_items 0
+STAT sticky_bytes 0
+STAT bytes 0
+STAT sticky_limit 0
+STAT engine_maxbytes 8589934592
+END
+```
+
+명령 별 주요 통계를 정리하면 다음과 같다.
+
+- `cmd_<command_name>`: 해당 명령의 수행 횟수
+- `<command_name>_hits`: 해당 명령의 key hit 횟수
+- `<command_name>_misses`: 해당 명령의 key miss 횟수
+- 콜렉션 명령의 key hit 횟수는 따로 제공하지 않으며, 아래 횟수의 합으로 계산할 수 있다.
+  - `<collection_name>_<command_name>_elem_hits`: 콜렉션 명령의 key hit 그리고 element hit 횟수
+  - `<collection_name>_<command_name>_none_hits`: 콜렉션 명령의 key hit 그러나 element miss 횟수
+
+다음은 그 외의 개별 통계이다.
+
+| stats                 | 설명                                                         |
+| --------------------- | ------------------------------------------------------------ |
+| pid                   | 캐시 노드의 프로세스 id                                      |
+| uptime                | 캐시 서버를 구동한 시간(초)                                  |
+| time                  | 현재 시간 (unix time)                                        |
+| version               | 현재 arcus-memcached 버전                                    |
+| libevent              | 사용중인 libevent 버전                                       |
+| pointer_size          | 포인터의 크기(bit 단위)                                      |
+| rusage_user           | 프로세스의 누적 user time.                                   |
+| rusage_system         | 프로세스의 누적 system time.                                 |
+| daemon_connections    | 서버가 사용하는 daemon connection 개수                       |
+| curr_connections      | 현재 열려있는 connection 개수                                |
+| quit_connections      | 클라이언트가 quit 명령을 이용해 연결을 끊은 횟수             |
+| reject_connections    | 클라이언트와의 연결을 거절한 횟수                            |
+| total_connections     | 서버 구동 이후 누적 connection 총합                          |
+| connection_structures | 서버가 할당한 connection 구조체 개수                         |
+| auth_cmds             | sasl 인증 횟수                                               |
+| auth_errors           | sasl 인증 실패 횟수                                          |
+| cas_badval            | 키는 찾았으나 cas 값이 맞지 않은 요청의 횟수                 |
+| bytes_read            | 서버가 네트워크에서 읽은 데이터 용량 총합(bytes)             |
+| bytes_written         | 서버가 네트워크에 쓴 데이터 용량 총합(bytes)                 |
+| limit_maxbytes        | 서버에 허용된 최대 메모리 용량(bytes)                        |
+| threads               | worker thread 개수                                           |
+| conn_yields           | 이벤트당 최대 요청 수의 제한                                 |
+| curr_prefixes         | 현재 저장된 prefix 개수                                      |
+| reclaimed             | expired된 아이템의 공간을 사용해 새로운 아이템을 저장한 횟수 |
+| evictions             | eviction 횟수                                                |
+| outofmemorys          | outofmemory (메모리가 부족한 상황에서 eviction이 허용되지 않거나 실패) 발생 횟수 |
+| sticky_items          | 현재 sticky 아이템의 개수                                    |
+| curr_items            | 현재 서버에 저장된 아이템의 개수                             |
+| total_items           | 서버 구동 후 저장한 아이템의 누적 개수                       |
+| sticky_bytes          | sticky 아이템이 차지하는 메모리 용량(bytes)                  |
+| bytes                 | 현재 사용중인 메모리 용량(bytes)                             |
+| sticky_limit          | sticky item을 저장할 수 있는 최대 메모리 용량(bytes)         |
+| engine_maxbytes       | 엔진에 허용된 최대 저장 용량                                 |
+
+### Settings 통계 정보
+
+각종 설정값에 대한 통계 정보를 보는 명령이다. 다음은 stats settings 실행 결과의 예이다.
+
+```
+STAT maxbytes 8589934592
+STAT maxconns 3000
+STAT tcpport 11911
+STAT udpport 0
+STAT sticky_limit 0
+STAT inter NULL
+STAT verbosity 1
+STAT oldest 0
+STAT evictions on
+STAT domain_socket NULL
+STAT umask 700
+STAT growth_factor 1.25
+STAT chunk_size 48
+STAT num_threads 6
+STAT stat_key_prefix :
+STAT detail_enabled yes
+STAT allow_detailed yes
+STAT reqs_per_event 5
+STAT cas_enabled yes
+STAT tcp_backlog 8192
+STAT binding_protocol auto-negotiate
+STAT auth_enabled_sasl no
+STAT auth_sasl_engine none
+STAT auth_required_sasl no
+STAT item_size_max 1048576
+STAT max_list_size 50000
+STAT max_set_size 50000
+STAT max_map_size 50000
+STAT max_btree_size 50000
+STAT max_element_bytes 16384
+STAT scrub_count 96
+STAT topkeys 0
+STAT logger syslog
+STAT ascii_extension scrub
+END
+```
+
+| stats              | 설명                                                         |
+| ------------------ | ------------------------------------------------------------ |
+| maxbytes           | 캐시 서버의 최대 저장 용량(byte)                             |
+| maxconns           | 접속할 수 있는 클라이언트의 최대 개수                        |
+| tcpport            | listen하고 있는 TCP port                                     |
+| udpport            | listen하고 있는 UDP port                                     |
+| sticky_limit       | sticky 아이템을 저장할 수 있는 최대 공간의 크기(bytes)       |
+| inter              | listen interface                                             |
+| verbosity          | 현재 verbosity 레벨(0~3)                                     |
+| oldest             | 가장 오래된 아이템이 저장되고 지난 시간                      |
+| evictions          | eviction의 허용 여부                                         |
+| domain_socket      | domain socket의 경로                                         |
+| umask              | domain socket의 umask                                        |
+| growth_factor      | slab class의 chunk 크기 증가 팩터                            |
+| chunk_size         | 아이템을 저장하기 위해 할당하는 최소의 공간(key + value + flags)의 크기(bytes) |
+| stat_key_prefix    | prefix와 key를 구분하는 문자                                 |
+| detail_enabled     | detailed stat(prefix별 통계) 수집 여부                       |
+| allow_detailed     | stat detail 명령 허용 여부                                   |
+| reqs_per_event     | io 이벤트에서 처리할 수 있는 최대 io 연산 수                 |
+| cas_enabled        | cas 연산 허용 여부                                           |
+| tcp_backlog        | tcp의 backlog 큐 크기                                        |
+| binding_protocol   | 사용중인 프로토콜. ASCII, binary, auto(negotiating) 세 가지임 |
+| auth_enabled_sasl  | sasl 인증 사용 여부                                          |
+| auth_sasl_engine   | sasl 인증에 사용할 엔진                                      |
+| auth_required_sasl | sasl 인증 필수 여부                                          |
+| item_size_max      | 아이템의 최대 사이즈                                         |
+| max_list_size      | list collection의 최대 element 갯수                          |
+| max_set_size       | set collection의 최대 element 갯수                           |
+| max_map_size       | map collection의 최대 element 갯수                           |
+| max_btree_size     | btree collection의 최대 element 갯수                         |
+| max_element_bytes  | collection element 데이터의 최대 크기                        |
+| topkeys            | 추적하고 있는 topkey 개수                                    |
+| logger             | 사용 중인 logger extension                                   |
+| ascii_extension    | 사용 중인 ASCII protocol extension                           |
+
+### Items 통계 정보
+
+item에 대한 slab class 별 통계 정보를 조회하는 명령이다. 다음은 stats items 실행 결과의 예이다.
+
+```
+STAT items:0:number 2000002
+STAT items:0:sticky 0
+STAT items:0:age 5401
+STAT items:0:evicted 0
+STAT items:0:evicted_nonzero 0
+STAT items:0:evicted_time 0
+STAT items:0:outofmemory 0
+STAT items:0:tailrepairs 0
+STAT items:0:reclaimed 0
+END
+```
+
+'items:' 옆에 표기된 숫자가 slab class id이다. 통계 정보의 의미는 다음과 같다.
+
+| stats           | 설명                                                         |
+| --------------- | ------------------------------------------------------------ |
+| number          | 해당 클래스에 저장된 아이템의 개수                           |
+| sticky          | sticky로 설정된 아이템의 개수. [basic concept 문서](../ch01-arcus-basic-concept.md#expiration-eviction-and-sticky) 참조 |
+| age             | LRU 체인에서 가장 오래된 아이템이 생성되고 나서 지난 시간(초) |
+| evicted         | evict된 아이템의 개수                                        |
+| evicted_nonzero | evict된 아이템 중, expired time이 명시적인 양수 값으로 설정되어 있던 아이템의 개수 |
+| evicted_time    | 가장 최근에 evict된 아이템에 마지막으로 접근하고 나서 지난 시간(초) |
+| out_of_memory   | 메모리 부족으로 아이템을 저장하는데 실패한 횟수              |
+| tailrepairs     | slab allocator를 refcount leak에서 복구한 횟수               |
+| reclaimed       | expired된 아이템의 공간을 사용해 새로운 아이템을 저장한 횟수 |
+
+### Slabs 통계 정보
+
+각 slab 클래스의 통계 정보와 전체 클래스에 대한 메타 정보를 조회하는 명령이다. 다음은 stats slabs 실행 결과의 예이다.
+
+```
+STAT SM:free_min_classid 709
+STAT SM:free_max_classid -1
+STAT SM:used_total_space 472
+STAT SM:used_01pct_space 288
+STAT SM:free_small_space 0
+STAT SM:free_bslot_space 261640
+STAT SM:free_avail_space 261640
+STAT SM:free_chunk_space 0
+STAT SM:free_limit_space 0
+STAT SM:space_shortage_level 0
+STAT 0:chunk_size 262144
+STAT 0:chunks_per_page 4
+STAT 0:reserved_pages 0
+STAT 0:total_pages 1
+STAT 0:total_chunks 4
+STAT 0:used_chunks 1
+STAT 0:free_chunks 0
+STAT 0:free_chunks_end 3
+STAT 0:mem_requested 262144
+STAT active_slabs 1
+STAT memory_limit 8589934592
+STAT total_malloced 1048576
+END
+```
+
+콜론(:)앞의 문자는 slab 클래스 번호를 의미한다. 'SM'이라고 표기된 클래스는 작은 크기의 데이터를 관리하는 small manager 클래스이다.
+
+일반 클래스의 통계 정보가 뜻하는 의미는 다음과 같다.
+
+| stats           | 설명                                                         |
+| --------------- | ------------------------------------------------------------ |
+| chunk_size      | 각 chunk가 사용하는 메모리 공간들의 크기 합(bytes)           |
+| chunks_per_page | 페이지 당 chunk의 개수                                       |
+| reserved_pages  | 해당 클래스에 할당하기 위해 예약된 페이지 수                 |
+| total_pages     | 해당 클래스에 할당된 페이지의 개수                           |
+| total_chunks    | 해당 클래스에 할당된 청크의 개수                             |
+| used_chunks     | 이미 아이템에게 할당된 chunk의 개수                          |
+| free_chunks     | 아직 할당되지 않았거나 삭제 연산으로 인해 free된 chunk의 개수 |
+| free_chunks_end | 마지막으로 할당된 페이지 끝에 남아있는 chunk 개수            |
+| mem_requested   | 해당 클래스에 요청된 메모리 공간의 크기 합(bytes)            |
+
+ small manager 클래스의 통계 정보가 뜻하는 의미는 다음과 같다.
+
+| stats                | 설명                                                         |
+| -------------------- | ------------------------------------------------------------ |
+| free_min_classid     | free slot의 id 중 최소값                                     |
+| free_max_classid     | free slot의 id 중 최대값(마지막 슬롯인 big free slot의 id는 제외) |
+| used_total_space     | 사용중인 공간의 크기 합(bytes)                               |
+| used_01pct_space     | 크기가 상위 1퍼센트에 속하는 슬롯들이 사용하는 공간의 크기 합(bytes) |
+| free_small_space     | 할당되지 않았고, 할당될 가능성이 낮은 작은 메모리 공간의 크기 합(bytes) |
+| free_bslot_space     | big free slot의 남은 공간의 크기 합(bytes)                   |
+| free_avail_space     | 할당되지 않았고, 할당될 가능성이 높은 큰 메모리 공간의 크기 합(bytes) |
+| free_chunk_space     | 메모리 블락(chunk)를 할당할 수 있는 공간의 크기 합(bytes)    |
+| free_limit_space     | 항상 비운 채로 유지되어야 하는 최소한의 여유 공간의 크기 합(bytes) |
+| space_shortage_level | 공간이 부족한 정도를 0~100 으로 수치화한 레벨.               |
+
+space_shortage_level이 10 이상으로 올라가면, background에서 아이템을 evict 하는 별도의 쓰레드를 실행해 메모리 공간을 확보한다. LRU 체인의 끝부터 space_shortage_level 만큼 아이템을 삭제하게 된다. (ssl이 10이라면 10개의 아이템 삭제)
+
+기타 메타 통계를 정리하면 다음과 같다.
+
+| stats          | 설명                                            |
+| -------------- | ----------------------------------------------- |
+| active_slabs   | 할당된 slab class의 총 개수                     |
+| memory_limit   | 캐시 서버의 최대 용량(bytes)                    |
+| total_malloced | slab page에 할당된 메모리 공간의 크기 합(bytes) |
+
+### Prefix 통계 정보
+
+모든 prefix들의 item 통계 정보는 "stats prefixes" 명령으로 조회하고,
+모든 prefix들의 연산 통계 정보는 "stats detail dump" 명령으로 조회한다.
+그리고, Prefix들의 연산 통계 정보에 한해,
+통계 정보의 수집 여부를 on 또는 off 할 수 있다.
+
+모든 prefix들의 item 통계 정보의 결과 예는 아래와 같다.
+`<null>` prefix 통계는 prefix를 가지지 않는 items 통계이다.
+
+```
+PREFIX <null> itm 2 kitm 1 litm 1 sitm 0 mitm 0 bitm 0 tsz 144 ktsz 64 ltsz 80 stsz 0 mtsz 0 btsz 0 time 20121105152422
+PREFIX a itm 5 kitm 5 litm 0 sitm 0 mitm 0 bitm 0 tsz 376 ktsz 376 ltsz 0 stsz 0 mtsz 0 btsz 0 time 20121105152422
+PREFIX b itm 2 kitm 2 litm 0 sitm 0 mitm 0 bitm 0 tsz 144 ktsz 144 ltsz 0 stsz 0 mtsz 0 btsz 0 time 20121105152422
+END
+```
+
+각 prefix의 item 통계 정보에
+itm은 전체 item 수이고, kitm, litm, sitm, mitm, bitm은 각각 kv, list, set, map, b+tree item 수이며,
+tsz(total size)는 전체 items이 차지하는 공간의 크기이고,
+ktsz, ltsz, stsz, mtsz, btsz는 각각 kv, list, set, map, b+tree items이 차지하는 공간의 크기이다.
+time은 prefix 생성 시간이다.
+
+모든 prefix들의 연산 통계 정보의 결과 예는 아래와 같다.
+각 PREFIX 라인은 실제로 하나의 line으로 표시되지만, 본 문서는 이해를 돕기 위해 여러 line으로 표시한다.
+
+
+```
+PREFIX <null> get 2 hit 2 set 2 del 0
+       lcs 0 lis 0 lih 0 lds 0 ldh 0 lgs 0 lgh 0
+       scs 0 sis 0 sih 0 sds 0 sdh 0 sgs 0 sgh 0 ses 0 seh 0
+       mcs 0 mis 0 mih 0 mus 0 muh 0 mds 0 mdh 0 mgs 0 mgh 0
+       bcs 0 bis 0 bih 0 bus 0 buh 0 bds 0 bdh 0 bps 0 bph 0 bms 0 bmh 0 bgs 0 bgh 0 bns 0 bnh 0
+       pfs 0 pfh 0 pgs 0 pgh 0
+       gas 0 sas 0
+PREFIX a get 5 hit 5 set 5 del 0
+       lcs 0 lis 0 lih 0 lds 0 ldh 0 lgs 0 lgh 0
+       scs 0 sis 0 sih 0 sds 0 sdh 0 sgs 0 sgh 0 ses 0 seh 0
+       mcs 0 mis 0 mih 0 mus 0 muh 0 mds 0 mdh 0 mgs 0 mgh 0
+       bcs 0 bis 0 bih 0 bus 0 buh 0 bds 0 bdh 0 bps 0 bph 0 bms 0 bmh 0 bgs 0 bgh 0 bns 0 bnh 0
+       pfs 0 pfh 0 pgs 0 pgh 0
+       gas 0 sas 0
+PREFIX b get 2 hit 2 set 2 del 0
+       lcs 0 lis 0 lih 0 lds 0 ldh 0 lgs 0 lgh 0
+       scs 0 sis 0 sih 0 sds 0 sdh 0 sgs 0 sgh 0 ses 0 seh 0
+       mcs 0 mis 0 mih 0 mus 0 muh 0 mds 0 mdh 0 mgs 0 mgh 0
+       bcs 0 bis 0 bih 0 bus 0 buh 0 bds 0 bdh 0 bps 0 bph 0 bms 0 bmh 0 bgs 0 bgh 0 bns 0 bnh 0
+       pfs 0 pfh 0 pgs 0 pgh 0
+       gas 0 sas 0
+END
+```
+
+각 prefix의 연산 통계 정보에서
+get, hit, set, del은 kv 유형의 items에 대한 연산 통계이고,
+'l', 's', 'm', 'b'로 시작하는 3 character는 각각 list, set, map, b+tree 유형의 items에 대한 연산 통계이며,
+'p'로 시작하는 3 character는 특별히 b+tree에 대한 position 연산의 통계이다.
+gas와 sas는 item attribute 연산의 통계이다.
+
+연산 통계에서 각 3 character의 의미는 다음과 같다.
+
+- list 연산 통계
+  - lcs - lop create 수행 횟수
+  - lis, lih - lop insert 수행 횟수와 hit 수
+  - lds, ldh – lop delete 수행 횟수와 hit 수
+  - lgs, lgh – lop get 수행 횟수와 hit 수
+- set 연산 통계
+  - scs - sop create 수행 횟수
+  - sis, sih - sop insert 수행 횟수와 hit 수
+  - sds, sdh – sop delete 수행 횟수와 hit 수
+  - sgs, sgh – sop get 수행 횟수와 hit 수
+  - ses, seh - sop exist 수행 횟수와 hit 수
+- map 연산 통계
+  - mcs - mop create 수행 횟수
+  - mis, mih - mop insert 수행 횟수와 hit 수
+  - mus, muh – mop update 수행 횟수와 hit 수
+  - mds, mdh – mop delete 수행 횟수와 hit 수
+  - mgs, mgh – mop get 수행 횟수와 hit 수
+- b+tree 연산 통계
+  - bcs – bop create 수행 횟수
+  - bis, bih – bop insert/upsert 수행 횟수와 hit 수
+  - bus, buh – bop update 수행 횟수와 hit 수
+  - bps, bph – bop incr(plus 의미) 수행 횟수와 hit 수
+  - bms, bmh - bop decr(minus 의미) 수행 횟수와 hit 수
+  - bds, bdh – bop delete 수행 횟수와 hit 수
+  - bgs, bgh – bop get 수행 횟수와 hit 수
+  - bns, bnh – bop count 수행 횟수와 hit 수
+- b+tree position 연산 통계
+  - pfs, pfh - bop position 수행 횟수와 hit 수
+  - pgs, pgh - bop gbp 수행 횟수와 hit 수
+- item attribute 연산 통계
+  - gas - getattr 수행 횟수
+  - sas - setattr 수행 횟수
+
+### Zookeeper 상태 정보
+
+zookeeper 상태 정보를 보는 명령이다. 다음은 stats zookeeper 실행 결과의 예이다.
+
+```
+STAT zk_connected true
+STAT zk_failstop on
+STAT zk_timeout 30000
+STAT zk_reconfig on
+STAT zk_reconfig_version 100000000
+END
+```
+
+| stats              | 설명                                                         |
+| ------------------ | ------------------------------------------------------------ |
+| zk_connected       | 주키퍼 연결 상태                                             |
+| zk_failstop        | 주키퍼 세션 만료 시 서버 자동 종료 여부                      |
+| zk_timeout         | 주키퍼 세션 타임아웃(msec)                                   |
+| zk_reconfig        | zookeeper dynamic reconfiguration 기능 사용 여부             |
+| zk_reconfig_version| zookeeper dynamic reconfiguration 반영한 버전(16진수)        |
+
+### Scrub 수행 상태
+
+Scrub 수행 상태를 조회한 결과 예는 다음과 같다.
+
+```
+STAT scrubber:status stopped
+STAT scrubber:last_run 0
+STAT scrubber:visited 0
+STAT scrubber:cleaned 0
+END
+```
+
+- status - 현재 scrub 작업이 running 중인지 stopped 상태인지를 나타낸다.
+- last_run - 이전에 완료된 scrub 작업의 소요 시간을 초 단위로 나타낸다.
+- visited - 현재 수행중인 또는 이전에 수행된 scrub에서 접근한 item들의 수를 나타낸다.
+- cleaned - 현재 수행중인 또는 이전에 수행된 scrub에서 삭제한 item들의 수를 나타낸다.
+
+### slab class 별 cache key dump
+
+slab class 별 LRU에 달려있는 item들의 cache key들을 dump하기 위하여,
+아래의 stats cachedump 명령을 제공한다.
+
+```
+stats cachedump <slab_clsid> <limit> [ forward | backward [sticky] ]\r\n
+```
+
+- `<slab_clsid>` - dump 대상 LRU를 지정하기 위한 slab class id이다.
+- `<limit>` - dump하고자 하는 item 개수로서 0 ~ 200 범위에서 지정이 가능하다.
+0이면 default로 50개로 지정되며, 200 초과이면 200개만 dump한다.
+해당 LRU의 head 또는 tail에서 시작하여 limit 개 item들의 cache key들을 dump한다.
+- forward or backward - LRU의 head 또는 tail 중에 어디에서 dump를 시작할 것인지를 지정한다.
+forward이면 head에서 시작하고, backward이면 tail에서 시작한다.
+지정하지 않으면, default는 forward이다.
+- sticky - 하나의 slab class에서 non-sticky item들의 LRU 리스트와 sticky item들의 LRU 리스트가 별도로 유지되어 있다.
+sticky가 지정되면 sticky LRU에서 dump하고, 지정되지 않으면 non-sticky LRU에서 dump한다.
+
+Cachedump 결과의 예는 아래와 같다.
+
+```
+ITEM a:bkey2
+ITEM a:bkey1
+ITEM b:bkey3
+ITEM b:bkey1
+ITEM b:bkey2
+ITEM c:bkey1
+ITEM c:bkey2
+END
+```
+
+### Persistence 정보 조회
+
+Persistence의 설정 정보와 수행 결과를 조회한 결과 예는 다음과 같다.
+
+```
+STAT use_persistence on
+STAT data_path /home/test/arcus/data/ARCUS-DB
+STAT logs_path /home/test/arcus/data/ARCUS-DB
+STAT async_logging false
+STAT chkpt_interval_pct_snapshot 100
+STAT chkpt_interval_min_logsize 256
+STAT recovery_elapsed_time_sec 5
+STAT last_chkpt_in_progress true
+STAT last_chkpt_failure_count 0
+STAT last_chkpt_start_time 20201222182102
+STAT last_chkpt_elapsed_time_sec 8
+STAT last_chkpt_snapshot_filesize_bytes 423333
+STAT current_command_log_filesize_bytes 65555
+END
+```
+
+- use_persistence - 현재 Persistence 모드가 on인지 off인지 나타낸다.
+- data_path - 스냅샷 파일이 생성되는 경로를 나타낸다.
+- logs_path - 명령 로그 파일이 생성되는 경로를 나타낸다.
+- async_logging - 명령 로깅의 동작 모드로 동기 로깅 모드면 false, 비동기 로깅 모드면 true로 나타낸다.
+- chkpt_interval_pct_snapshot - 체크포인트 수행 주기 설정으로, 스냅샷 파일 크기에 대비하여 명령 로그 파일의 추가 증가된 크기 비율을 나타낸다.
+- chkpt_interval_min_logsize - 체크포인트 수행 주기 설정으로, 체크포인트를 수행할 명령 로그 파일의 최소 크기를 나타낸다.
+- recovery_elapsed_time_sec - ARCUS 인스턴스 재구동 후, 데이터를 복구하는데 걸리는 시간을 나타낸다. (unit : seconds)
+- last_chkpt_in_progress - 현재 체크포인트의 수행 여부를 나타낸다.
+- last_chkpt_failure_count - 이전 체크포인트가 수행되거나 성공될 때까지 몇 번 실패한 것인지를 나타낸다.
+- last_chkpt_start_time - 이전 체크포인트가 조건이 충족되어 시작한 시간을 나타낸다. (unit : absolute timestamp)
+- last_chkpt_elapsed_time_sec - 이전 체크포인트 수행하는데 걸린 시간을 나타낸다. (unit : seconds)
+- last_chkpt_snapshot_filesize_bytes - 이전 체크포인트 스냅샷 파일 크기를 나타낸다. (unit : bytes)
+- current_command_log_filesize_bytes - 현재 명령 로그 파일 크기를 나타낸다. (unit : bytes)
+
+## Config
+
+ARCUS Cache Server는 특정 configuration에 대해 동적으로 변경하거나 현재의 값을 조회하는 기능을 제공한다.
+동적으로 변경가능한 configuration들은 현재 아래만 지원한다.
+
+- verbosity
+- memlimit
+- zkfailstop
+- hbtimeout
+- hbfailstop
+- maxconns
+- max_collection_size
+- max_element_bytes
+- scrub_count
+
+### Config verbosity
+
+ARCUS Cache Server의 verbose log level을 동적으로(restart 없이) 변경/조회한다.
+
+```
+config verbosity [<verbose>]\r\n
+```
+
+`<verbose>`는 새로 지정할 verbose log level 값으로, 허용가능한 범위는 0 ~ 2이다.
+이 인자가 생략되면 현재 설정되어 있는 verbose 값을 조회한다.
+
+### Config memlimit
+
+ARCUS Cache Server 구동 시에 -m 옵션으로 설정된 memory limit을 동적으로(restart 없이) 변경/조회한다.
+
+```
+config memlimit [<memsize>]\r\n
+```
+
+`<memsize>`는 새로 지정할 memory limit으로 MB 단위로 설정하며,
+ARCUS Cache Server가 현재 사용 중인 메모리 크기인 total_malloced 보다 큰 크기로만 설정이 가능하다.
+이 인자가 생략되면 현재 설정되어 있는 memory limit 값을 조회한다.
+
+### Config zkfailstop
+
+ARCUS Cache Server의 automatic failstop 기능을 on 또는 off 한다.
+
+```
+config zkfailstop [on|off]\r\n
+```
+
+Network failure 상태에서 정상적인 서비스를 진행하지 못하는 cache server가 cache cloud에 그대로 존재할 경우, 해당 cache server가 담당하고 있는 data 범위에 대한 요청이 모두 실패하고 DB에 부담을 주게 된다. 또한 이후에 ZooKeeper에 재연결 되더라도 old data를 가지고 있을 가능성이 있으며 이로 인해 응용에 오동작을 발생시킬 수 있다. ARCUS Cache Server는 이를 해결하기 위해 ZooKeeper session timeout이 발생할 경우 failed cache server를 cache cloud에서 자동으로 제거하는 automatic failstop 기능을 기본적으로 제공한다.
+
+### Config hbtimeout
+
+hbtimeout 값을 변경/조회한다.
+
+```
+config hbtimeout [<hbtimeout>]\r\n
+```
+
+ARCUS Cache Server에는 주기적으로 노드의 정상 작동 여부를 확인하는 heartbeat 연산이 존재한다. hbtimeout은 heartbeat 연산의 timeout 시간을 의미한다. hbtimeout으로 설정한 시간이 지나도 heartbeat 연산이 이루어지지 않으면 해당 heartbeat는 timeout된 것으로 간주한다. 최소 50ms, 최대 10000ms로 설정할 수 있으며 디폴트 값은 10000ms이다.
+
+### Config hbfailstop
+
+hbfailstop 값을 변경/조회한다.
+
+```
+config hbfailstop [hbfailstop]\r\n
+```
+
+ARCUS Cache Server는 heartbeat 지연이 계속될 경우 서버를 강제 종료할 수 있다. 연속된 timeout이 발생할 때마다 hbtimeout 값을 누적하여 더하고, 누적된 값이 hbfailstop 값을 넘길 경우 failstop을 수행한다. 예를 들어 hbfailstop이 30초, hbtimeout이 10초이면 hbtimeout이 연속으로 3번 발생하였을 경우 failstop이 발생한다. 최소 3000ms, 최대 300000ms로 설정할 수 있으며 디폴트 값은 60000ms이다.
+
+### Config maxconns
+
+ARCUS Cache Server 구동 시에 -c 옵션으로 설정된 최대 연결 수를 동적으로(restart 없이) 변경/조회한다.
+
+```
+config maxconns [<maxconn>]\r\n
+```
+
+`<maxconn>`는 새로 지정할 최대 연결 수로서, 현재의 연결 수보다 10% 이상의 큰 값으로만 설정이 가능하다.
+이 인자가 생략되면 현재 설정되어 있는 최대 연결 수 값을 조회한다.
+
+### Config max_collection_size
+
+콜렉션 아이템의 최대 element 수를 조회/변경한다.
+
+```
+config max_<collection>_size [<max_size>]\r\n
+* <collection>: list|set|btree|map
+```
+
+기본 설정은 50000개이며 최소 10000개, 최대 1000000개 까지 설정할 수 있다. 기존 값보다 작게 설정할 수 없다. 기본 설정보다 큰 값으로 설정하고 나서, 한 번에 많은 element 들을 조회한다면 조회 응답 속도가 느려질 뿐만 아니라 다른 연산의 응답 속도에도 부정적 영향을 미친다. 따라서, 주의 사항으로, 최대 element 수를 늘리더라도 응용은  한번에 적은 수의 element 만을 조회하는 요청을 반복하는 형태로 구현하여야 한다.
+
+### Config max_element_bytes
+
+Collection element가 가지는 value의 최대 크기를 byte 단위로 설정한다. 기본 설정은 16KB이며 1~32KB까지 설정 가능하다.
+
+```
+config max_element_bytes [<maxbytes>]\r\n
+```
+
+### Config scrub_count
+
+ARCUS Cache Server에는 더 이상 유효하지 않은 아이템을 일괄 삭제하는 scrub 명령이 존재한다. config scrub_count 명령은 daemon thread가 scrub 명령을 수행할 때, 한 번의 연산마다 몇 개의 아이템을 지울지를 설정/조회한다. 기본 값은 96이며 최소 16, 최대 320으로 설정할 수 있다.
+
+```
+config scrub_count [<scrub_count>]\r\n
+```
+
+## Command Logging
+
+ARCUS Cache Server에 입력되는 command를 logging 한다.
+start 명령을 시작으로 logging이 종료될 때 까지의 모든 command를 기록한다.
+단, 성능유지를 위해 skip되는 command가 있을 수 있으며 stats 명령을 통해 그 수를 확인할 수 있다.
+10MB log 파일 10개를 사용하며, 초과될 경우 자동 종료한다.
+
+```
+cmdlog [start [<log_file_path>] | stop | stats]\r\n
+```
+
+`<log_file_path>`는 logging 정보를 저장할 file의 path이다.
+- path는 생략 가능하며, 생략할 경우 default로 지정된다.
+  - default로 자동 지정할 경우 log file은 memcached 구동 위치 / command_log 디렉터리 안에 생성된다.
+  - command_log 디렉터리는 자동생성되지 않으며, memcached process가 구동된 위치에 생성해 주어야 한다.
+  - 생성되는 log file의 파일명은 command_port_bgndate_bgntime_{n}.log 이다.
+- path는 직접 지정할 경우 절대 path, 상대 path 지정이 가능하다. 최종 파일이 생성될 디렉터리까지 지정해 주어야 한다.
+
+start 명령의 결과로 log file에 출력되는 내용은 아래와 같다.
+
+```
+---------------------------------------
+format : <time> <client_ip> <command>\n
+---------------------------------------
+
+19:14:45.530198 127.0.0.1 bop insert arcustest-Collection_Btree:vuRYyfqyeP0Egg8daGF72 0x626B65795F6279746541727279323239 0x45464C4147 80 create 0 600 4000
+19:14:45.530387 127.0.0.1 lop insert arcustest-Collection_List:pGhEn6DFv5MixbYObBgp1 -1 64 create 0 600 4000
+19:14:45.530221 127.0.0.1 lop insert arcustest-Collection_List:hhSAED2pFBH9xGqEgAeW1 -1 80 create 0 600 4000
+19:14:45.530334 127.0.0.1 bop insert arcustest-Collection_Btree:RGSXLACxWpKwLPdC86qn0 0x626B65795F6279746541727279303331 0x45464C4147 80 create 0 600 4000
+19:14:45.530385 127.0.0.1 lop insert arcustest-Collection_List:PwFTiFSEWlenireHcxNb2 -1 80 create 0 600 4000
+19:14:45.530407 127.0.0.1 bop insert arcustest-Collection_Btree:P1lfJrJyVFyP0ogrw27h1 0x626B65795F6279746541727279313238 0x45464C4147 101 create 0 600 4000
+19:14:45.530537 127.0.0.1 sop exist arcustest-Collection_Set:gTx8KDPBiufiGN9ArtgG3 81 pipe
+19:14:45.530757 127.0.0.1 sop exist arcustest-Collection_Set:gTx8KDPBiufiGN9ArtgG3 81
+```
+
+stop 명령은 logging이 완료되기 전 중지하고 싶을 때 사용할 수 있다.
+
+stats 명령은 가장 최근 수행된(수행 중인) command logging의 상태를 조회하고 결과는 아래와 같다.
+
+```
+Command logging stats : running                                      //Not started | stopped by causes(request or overflow or error) | running
+The last running time : 20160126_192729 ~ 20160126_192742            //bgndate_bgntime ~ enddate_endtime
+The number of entered commands : 146783                              //entered_commands
+The number of skipped commands : 0                                   //skipped_commands
+The number of log files : 1                                          //file_count
+The log file name: /Users/temp/command_11211_20160126_192729_{n}.log //path/file_name
+```
+
+## Long Query Detect
+
+ARCUS Cache Server에서 collection item에 대한 요청 중에는 그 처리 시간이 오래 걸리는 요청이 존재한다.
+이를 detect하기 위한 기능으로 lqdetect 명령을 제공한다.
+start 명령을 시작으로 detection이 종료될 때 까지 long query 가능성이 있는 command에 대하여,
+그 command 처리에서 접근한 elements 수가 특정 기준 이상인 command를 추출,
+command 별로 detect된 명령어 20개를 샘플로 저장한다.
+long query 대상이 되는 모든 command에 대해 20개의 샘플 저장이 완료되면 자동 종료한다.
+저장된 샘플은 show 명령을 통해 확인할 수 있다.
+
+long query detection 대상이 되는 command는 아래와 같다.
+
+```
+1. sop get
+2. mop delete
+3. mop get
+4. lop insert
+5. lop delete
+6. lop get
+7. bop delete
+8. bop get
+9. bop count
+10. bop gbp
+```
+
+lqdetect command는 아래와 같다.
+
+```
+lqdetect [start [<detect_threshold>] | stop | show | stats]\r\n
+```
+
+`<detect_threshold>`는 long query로 분류하는 기준으로 해당 요청에서 접근하는 elements 수로 나타내며, 어떤 요청에서 주어진 threshold 이상으로 많은 elements를 접근하는 요청을 long query로 구분한다. 생략 시 default threshold는 4000이다.
+
+start 명령으로 detection을 시작할 수 있다.
+
+stop 명령은 detection이 완료되기 전 중지하고 싶을 때 사용할 수 있다.
+
+show 명령은 저장된 명령어 샘플을 출력하고 그 결과는 아래와 같다.
+
+```
+-----------------------------------------------------------
+format : <time> <client_ip> <count> <command> <arguments>\n
+-----------------------------------------------------------
+
+sop get : 0
+mop delete : 0
+mop get : 0
+lop insert : 0
+lop delete : 0
+lop get : 92
+17:56:33.276847 127.0.0.1 <46> lop get arcustest-Collection_List:YN8UCtNaoD4hHnMMwMJq1 0..44
+17:56:33.278116 127.0.0.1 <43> lop get arcustest-Collection_List:orjTteJo7F0bWdXDDGcP0 0..41
+17:56:33.279856 127.0.0.1 <48> lop get arcustest-Collection_List:r7ERYr3IdiD3RO8hLNvI3 0..46
+17:56:33.304063 127.0.0.1 <45> lop get arcustest-Collection_List:0OWKNF3Z17NaTSaDTZG61 0..43
+bop delete : 0
+bop get : 81
+17:56:33.142590 127.0.0.1 <47> bop get arcustest-Collection_Btree:0X6mqSiwBx6fEZVLuwKF0 0x626B65795F62797465417272793030..0x626B65795F6279746541727279303530 efilter 0 47
+17:56:33.142762 127.0.0.1 <49> bop get arcustest-Collection_Btree:PiX8strLCv7iWywd1ZuE0 0x626B65795F62797465417272793030..0x626B65795F6279746541727279303530 efilter 0 49
+17:56:33.143326 127.0.0.1 <46> bop get arcustest-Collection_Btree:PiX8strLCv7iWywd1ZuE1 0x626B65795F62797465417272793130..0x626B65795F6279746541727279313530 efilter 0 48
+bop count : 0
+bop gbp : 0
+```
+
+stats 명령은 가장 최근 수행된(수행 중인) long query detection의 상태를 조회하고 그 결과는 아래와 같다.
+
+```
+Long query detection stats : running              //stopped by causes(request or overflow) | running
+The last running time : 20160126_175629 ~ 0_0     //bgndate_bgntime ~ enddate_endtime
+The number of total long query commands : 1152    //detected_commands
+The detection threshold : 43                      //threshold
+```
+
+## Key dump
+
+ARCUS Cache Server의 key를 dump 한다.
+
+Dump ASCII command는 아래와 같다.
+
+```
+dump start key [<prefix>] filepath\r\n
+dump stop\r\n
+stats dump\r\n
+```
+
+dump start명령.
+- 첫번째 인자는 무조건 "key"이다.
+  - 현재는 일단 key string만을 dump한다.
+  - 향후에 key or item을 선택할 수 있게 하여, item인 경우 item 전체 내용을 dump할 수 있다.
+- 두번째 인자는 `<prefix>`는 cache key의 prefix를 의미하며, 생략 가능하다.
+  - 생략하면, 모든 key string을 dump한다.
+  - "`<null>`"을 주면, prefix가 없는 key string을 dump한다.
+  - 어떤 prefix를 주면, 그 prefix의 모든 key string을 dump한다.
+- 세번째 인자는 `<file path>`이다.
+  - 반드시 명시해야 한다.
+  - 절대 path로 줄 수도 있으며, 상대 path도 가능하다.
+  - 상대 path이면 memcached process가 구동된 위치에서의 상대 path이다.
+
+dump stop은 혹시나 dump 작업이 너무 오려 걸려
+중지하고 싶을 경우에 사용할 수 있다.
+
+stats dump는 현재 진행중인 dump 또는 가장 최근에 수행된 dump의 stats을 보여 준다.
+
+dump 파일은 무조건 하나의 file로 만들어 진다.
+file 내용의 format은 아래와 같다.
+
+```
+<type> <key_string> <exptime>\n
+...
+<type> <key_string> <exptime>\n
+DUMP SUMMARY: { prefix=<prefix>, count=<count>, total=<total> elapsed=<elapsed> }\n
+```
+
+위의 결과에서 각 의미는 아래와 같다.
+- key dump 결과 부분
+  - `<type>`은 item type으로 1 character로 표시한다.
+     - "K" : kv
+     - "L" : list
+     - "S" : set
+     - "M" : map
+     - "B" : b+tree
+  - `<key_string>`은 cache server에 저장되어 있는 key string 이다.
+  - `<exptime>`은 key의 exptime으로 아래 값들 중 하나이다.
+    -  0 (exptime = 0인 경우)
+    - -1 : sticky item (exptime = -1인 경우)
+    - timestamp (exptime > 0인 경우)으로
+      "time since the Epoch (00:00:00 UTC, January 1, 1970), measured in seconds" 이다.
+- DUMP SUMMARY 부분
+  - `<prefix>`는 prefix name이다.
+    - 모든 key dump이면, "`<all>`"이 명시된다.
+    - prefix 없는 key dump이면, "`<null>`"이 명시된다.
+    - 특정 prefix의 key dump이면, 그 prefix name이 명시된다.
+  - `<count>`는 dump한 key 개수이다.
+  - `<total>`은 cache에 있는 전체 key 개수이다.
+  - `<elapsed>`는 dump하는 데 소요된 시간(단위: 초) 이다.
+
+## ZKensemble
+
+ARCUS Cache Server가 연결되어 있는 ZooKeeper ensemble 설정에 대한 명령을 제공한다.
+
+```
+zkensemble set <ensemble_list>\r\n
+zkensemble get\r\n
+zkensemble rejoin\r\n
+```
+
+set 명령은 ZK ensemble 주소를 변경한다. ensemble_list는 `<ip:port>`,...,`<ip:port>`  와 같은 ZK server 들의 list 형태 혹은 ZK ensemble의 도메인 주소 형태로 지정할 수 있다.
+
+get 명령은 ZK ensemble 주소를 조회한다. 조회 결과는 `<ip:port>`,...,`<ip:port>` 형식으로 확인할 수 있다.
+
+rejoin 명령은 ZK ensemble 과의 연결을 끊고 cache cloud에서 빠져 대기하는 cache server를 다시 ZK ensemble에 연결하도록 하는 명령이다. Cache cloud에서 cache server가 빠져나가는 경우는 아래와 같다.
+- Failstop off 상태에서 ZooKeeper session timeout이 일어난 경우
+- 운영자의 실수로 cache_list에 등록된 cache server의 ephemeral znode가 삭제된 경우
+
+
+## Help
+
+ARCUS Cache Server의 ASCII command syntax를 조회한다.
+
+```
+help [<subcommand>]\r\n
+```
+
+`<subcommand>`로는 kv, lop, sop, mop, bop, stats, flush, config, etc가 있으며,
+`<subcommand>`가 생략되면, help 명령에서 사용가능한 subcommand 목록이 출력된다.

--- a/documentation/ascii-protocol/appendix.md
+++ b/documentation/ascii-protocol/appendix.md
@@ -1,0 +1,116 @@
+# ARCUS Telnet Interface
+
+ARCUS cache server의 동작을 간단히 확인하는 방법으로, telnet interface를 이용할 수 있다.
+
+## Telnet 사용법
+
+OS prompt 상에서 아래와 같이 telnet 명령을 실행시킨다.
+telnet 명령의 인자로는 연결하고자 하는 ARCUS cache server인 memcached의 IP와 port number를 준다.
+
+```
+$ telnet {memcached-ip} {memcached-port}
+```
+
+## Telnet 연결
+
+Localhost에 11211 포트 번호로 memcached가 구동되어 있다고 가정한다.
+telnet 명령으로 해당 memcached에 연결하기 위해,
+OS prompt 상에서 아래의 명령을 수행한다.
+
+```
+$ telnet localhost 11211
+Trying 127.0.0.1...
+Connected to localhost.localdomain (127.0.0.1).
+Escape character is '^]'.
+```
+
+telnet 명령으로 memcached에 연결한 이후에는 ARCUS ASCII 명령을 직접 수행해 볼 수 있다.
+아래에서 그 예들을 든다. ARCUS ASCII 명령의 자세한 설명은 [ARCUS cache server ascii protocol](00-arcus-ascii-protocol.md)을 참고하기 바란다.
+
+
+### 예제 1.  get/set
+
+하나의 key-value item으로 <"foo", "fooval">을 저장하기 위해, set 명령을 입력한다.
+
+```
+set foo 0 0 6
+fooval
+```
+
+set 명령의 수행 결과로 정상적으로 key-value item이 저장되었다는 string이 리턴된다.
+
+```
+STORED
+```
+
+저장된 foo item을 조회하기 위해, get 명령을 입력한다.
+
+
+```
+get foo
+```
+
+get 명령으로 조회한 foo item 결과는 아래와 같다.
+
+
+```
+VALUE foo 0 6
+fooval
+END
+```
+
+### 예제 2.  b+tree
+
+하나의 b+tree item을 생성하면서 5개의 elements를 추가하기 위해,
+아래의 5개 bop insert 명령을 차례로 수행한다.
+
+```
+bop insert bkey1 90 6 create 11 0 0
+datum9
+bop insert bkey1 70 6
+datum7
+bop insert bkey1 50 6
+datum5
+bop insert bkey1 30 6
+datum3
+bop insert bkey1 10 6
+datum1
+```
+
+5개 bop insert 명령의 수행 결과는 아래와 같다.
+
+
+```
+CREATED_STORED
+STORED
+STORED
+STORED
+STORED
+```
+
+b+tree에서 30부터 80까지의 bkey(b+tree key) range에 속하는 elements를 조회하기 위하여,
+bop get 명령을 입력한다.
+
+
+```
+bop get bkey1 30..80
+```
+
+bop get 명령으로 조회한 결과는 아래와 같다.
+
+
+```
+VALUE 11 3
+30 6 datum3
+50 6 datum5
+70 6 datum7
+END
+```
+
+## Telnet 종료
+
+현재의 telnet 연결을 종료하려면, quit 명령을 입력한다.
+
+```
+quit
+```

--- a/documentation/collection-items.md
+++ b/documentation/collection-items.md
@@ -1,0 +1,169 @@
+# Collection Concept
+
+## Collection 구조와 특징
+
+Collection 유형과 그 구조 및 특징은 아래와 같다.
+
+**List** - linked list
+
+> Element들의 doubly linked list 구조를 가진다.
+  Head element와 tail element 정보를 유지하면서, head/tail에서 시작하여 forward/backward 방향으로
+  특정 위치에 있는 element를 접근할 수 있다.
+  많은 element를 가진 list에서 중간 위치의 임의 element 접근 시에 성능 이슈가 있으므로,
+  list를 queue 개념으로 사용하길 권한다.
+
+**Set** - unordered set of unique value
+
+> Set 자료 구조는 membership checking에 적합하다.
+  Unordered set of unique value 저장을 위해 내부적으로 hash table 구조를 사용한다.
+  하나의 set에 들어가는 elements 개수에 비례하여 hash table 전체 크기를 동적으로 조정하기 위해,
+  일반적인 tree 구조와 유사하게 여러 depth로 구성되는 hash table 구조를 가진다.
+
+**Map** - unordered set of `<field, value>`
+
+> Map 자료 구조는 `<field, value>` 쌍을 저장한다.
+  Field 값의 유일성 보장과 field 기준으로 해당 element 탐색을 빠르게 하기 위한 hash table 구조를 사용한다.
+  하나의 map에 들어가는 elements 개수에 비례하여 hash table 전체 크기를 동적으로 조정하기 위해,
+  일반적인 tree 구조와 유사하게 여러 depth로 구성되는 hash table 구조를 가진다.
+
+
+**B+tree** - sorted map based on b+tree key
+
+> 각 element 마다 unique key를 두고, 이를 기준으로 정렬된 elements 집합을 b+tree 구조로 저장하며,
+  이러한 unique key 기반으로 forward/backward 방향의 range scan을 제공한다.
+  Elements 수에 비례하여 동적으로 depth를 조정하는 b+tree 구조를 사용하여 메모리 사용을 최소화한다.
+  그 외에, b+tree의 nonleaf node는 각 하위 node 중심의 sub-tree에 저장된 element 개수 정보를
+  담고 있도록 해서, 특정 element의 position 조회 및 position 기반의 element 조회 기능도 제공한다.
+
+Collection item은 `<key, collection meta info>` 구조를 가진다.
+Collection meta info는 collection 유형에 따른 속성 정보를 가지며,
+해당 collection의 elements에 신속히 접근하기 정보를 가진다.
+예를 들어, list의 head/tail element 주소, set의 최상위 hash table 주소,
+map의 최상위 hash table 구조, b+tree의 root node 주소가 이에 해당된다.
+
+## Element 구조
+
+Collection 유형에 따른 element 구조는 아래와 같다.
+
+- list/set element : `<data>`
+
+  각 element는 하나의 데이터 만을 가진다.
+
+- map element : `<field(map element key), data>`
+
+  map에서 각 element를 구분하기 위한 field를 필수적으로 가지며,
+  field는 중복을 허용하지 않는다.
+
+- b+tree element : `<bkey(b+tree key), eflag(element flag), data>`
+
+  b+tree에서 elements를 어떤 기준으로 정렬하기 위한 bkey를 필수적으로 가지며,
+  옵션 사항으로 bkey 기반의 scan 시에 특정 element를 filtering하기 위한 eflag를 가질 수 있으며,
+  bkey에 종속되어 단순 저장/조회 용도로 사용되는 data를 가진다.
+
+## BKey (B+Tree Key)
+
+B+tree collection에서 사용가능한 bkey 데이터 유형은 아래 두 가지이다.
+
+- 8 bytes unsigned integer
+
+  0 ~ 18446744073709551615 범위의 값을 지정할 수 있다.
+  이 유형이 성능 및 메모리 공간 관점에서 hexadecimal 유형보다 유리하므로, 이 유형의 bkey 사용을 권장한다.
+
+- hexadecimal
+
+  “0x”로 시작하는 짝수 개의 hexadecimal 문자열로 표현하며, 대소문자 모두 사용 가능하다.
+  ARCUS cache server는 두 hexadecimal 문자를 1 byte로 저장하며,
+  1 ~ 31 길이의 variable length byte array로 저장한다.
+
+  hexadecimal 표현이 올바른 경우의 저장 바이트 수와 잘못된 경우의 이유는 아래와 같다.
+
+  hexadecimal value | storage bytes | incorrect reason
+  ----------------- | ------------- | ----------------
+  0x34F40056        | 4 bytes       |
+  0xabcd00778899    | 6 bytes       |
+  34F40056          |               | 앞에 "0x"가 없음
+  0x34F40           |               | 홀수 개의 hexadecimal 문자열
+  0x34F40G          |               | 'G'가 hexadecimal 문자가 아님
+
+bkey의 대소 비교는 8 bytes unsigned integer 유형의 값이면 두 integer 값의 단순한 비교 연산으로 수행하며,
+hexadecimal 유형의 값이면 아래와 같은 lexicographical order로 두 값을 비교한다.
+
+- 두 hexadecimal의 첫째 바이트부터 차례로 바이트 단위로 대소를 비교하여, 차이나면 대소 비교를 종료한다.
+- 두 hexadecimal 중 작은 길이만큼의 비교에서 두 값이 동일하면, 긴 길이의 hexadecimal 값이 크다고 판단한다.
+- 두 hexadecimal의 길이도 같고 각 바이트의 값도 동일하면, 두 hexadecimal 값은 같다라고 판단한다.
+
+## EFlag (Element Flag)
+
+eflag는 현재 b+tree element에만 존재하는 필드이다.
+eflag 데이터 유형은 hexadecimal 유형만 가능하며,
+bkey의 hexadecimal 표현과 저장 방식을 그대로 따른다.
+
+## EFlag Filter
+
+eflag에 대한 filter 조건은 아래와 같이 표현하며,
+(1) eflag의 전체/부분 값과 특정 값과의 compare 연산이나
+(2) eflag의 전체/부분 값에 대해 어떤 operand로 bitwise 연산을 취한 후의 결과와 특정 값과의 compare 연산이다.
+
+```
+eflag_filter: <fwhere> [<bitwop> <foperand>] <compop> <fvalue>
+```
+
+- `<fwhere>`
+  - eflag 값에서 bitwise/compare 연산을 취할 시작 offset을 바이트 단위로 나타낸다.
+    bitwise/compare 연산을 취할 데이터의 length는 `<fvalue>`의 length로 한다.
+    예를 들어, eflag 전체 데이터를 선택한다면, `<fwhere>`는 0이어야 하고
+    `<fvalue>`의 length는 eflag 전체 데이터의 length와 동일하여야 한다.
+- `[<bitwop> <foperand>]`
+  - 생략 가능하며, eflag에 대한 bitwise 연산을 지정한다.
+  - bitwise 연산이 지정되면 이 연산의 결과가 compare 연산의 대상이 되며,
+    생략된다면 eflag 값 자체가 compare 연산의 대상이 된다.
+  - `<bitwop>`는 “&”(bitwise and), “|”(bitwise or), “^”(bitwise xor) 중의 하나로 bitwise 연산을 지정한다.
+  - `<foperand>`는 bitwise 연산을 취할 operand로 hexadecimal로 표현한다.
+    `<foperand>`의 길이는 compare 연산을 취한 `<fvalue>`의 길이와 동일하여야 한다.
+- `<compop> <fvalue>`
+  - eflag에 대한 compare 연산을 지정한다.
+  - `<compop>`는 "EQ", "NE", "LT", "LE", "GT", "GE" 중의 하나로 compare 연산을 지정하며,
+    `<fvalue>`는 compare 연산을 취할 대상 값으로 마찬가지로 hexadecimal로 표현한다.
+  - IN 또는 NOT IN 조건을 명시할 수도 있다.
+    IN 조건은 "EQ" 연산과 comma separated hexadecimal values로 명시하면 되고,
+    NOT IN 조건은 "NE" 연산과 comma separated hexadecimal values로 명시하면 된다.
+    이 경우, comma로 구분된 hexadecimal values의 최대 수는 100 개까지만 지원한다.
+
+하나의 b+tree의 element에는 동일 길이의 element flag를 사용하길 권장한다.
+하지만 응용이 필요하다면, 하나의 b+tree에 소속된 elements 이더라도
+eflag가 생략될 수도 있고 서로 다른 길이의 eflag를 가질 수도 있다.
+이 경우, 아래와 같이 eflag filtering이 애매모호해 질 수 있다.
+이 상황에서는 filter 조건의 비교 연산이 “NE”이면 true로 판별하고, 그 외의 비교 연산이면 false로 판별한다.
+
+- eflag가 없는 element에 eflag_filter 조건이 주어질 수 있다.
+- eflag가 있지만 eflag_filter 조건에서 명시된 offset과 length의 데이터를 가지지 않을 수 있다.
+  예를 들어, eflag가 4 bytes인 상황에서
+  (1) eflag_filter 조건의 offset은 5인 경우이거나
+  (2) eflag_filter 조건의 offset은 3이고 length는 4인 경우가 있을 수 있다.
+
+## EFlag Update
+
+Eflag의 전체 또는 부분 값에 update 연산도 가능하며 아래와 같이 표현한다.
+Eflag 전체 변경은 새로운 eflag 값으로 교체하는 것이며,
+부분 변경은 eflag의 부분 데이터에 대해 bitwise 연산을 취한 결과로 교체한다.
+
+```
+eflag_update: [<fwhere> <bitwop>] <fvalue>
+```
+
+- `[<fwhere> <bitwop>]`
+  - eflag를 부분 변경할 경우만 지정한다.
+  - `<fwhere>`은 eflag에서 부분 변경할 데이터의 시작 offset을 바이트 단위로 나타내며,
+    이 경우, 부분 변경할 데이터의 length는 뒤에 명시되는 `<fvalue>`의 length로 결정된다.
+  - `<bitwop>`는 부분 변경할 데이터에 대한 취할 bitwise 연산으로,
+    “&”(bitwise and), “|”(bitwise or), “^”(bitwise xor) 중의 하나로 지정할 수 있다.
+- `<fvalue>`
+  - 변경할 new value를 나타낸다.
+  - 앞서 기술한 `<fwhere>`과 `<bitwop>`가 생략되면, eflag의 전체 데이터를 `<fvalue>`로 변경한다.
+    부분 변경을 위한 `<fwhere>`과 `<bitwop>`가 지정되면
+    `<fvalue>`는 eflag 부분 데이터에 대해 bitwise 연산을 취할 operand로 사용되며,
+    bitwise 연산의 결과가 eflag의 new value로 변경된다.
+
+
+기존 eflag 값을 delete하여 eflag가 없는 상태로 변경할 수 있다.
+이를 위해서는 `<fwhere>`과 `<bitwop>`를 생략하고 `<fvalue>` 값으로 0을 주면 된다.

--- a/documentation/item-attributes.md
+++ b/documentation/item-attributes.md
@@ -1,0 +1,150 @@
+# Item Attribute 설명
+
+ARCUS Cache Server는 collection 기능 지원으로 인해,
+기존 key-value item 유형 외에 list, set, map, b+tree item 유형을 가진다.
+각 item 유형에 따라 설정/조회 가능한 속성들(attributes)이 구분되며, 이들의 개요는 아래 표와 같다.
+아래 표는 각 속성이 적용되는 item 유형, 속성의 간단한 설명, 허용가능한 값들과 디폴트 값을 나타낸다.
+
+```
+|-----------------------------------------------------------------------------------------------------------------|
+| Attribute Name | Item Type   | Description           | Allowed Values                 | Default Value           |
+|-----------------------------------------------------------------------------------------------------------------|
+| flags          | all         | data specific flags   | 4 bytes unsigned integer       | 0                       |
+|-----------------------------------------------------------------------------------------------------------------|
+| expiretime     | all         | item expiration time  | 4 bytes singed integer         | 0                       |
+|                |             |                       |  -1: sticky                    |                         |
+|                |             |                       |   0: never expired             |                         |
+|                |             |                       |  >0: expired in the future     |                         |
+|-----------------------------------------------------------------------------------------------------------------|
+| type           | all         | item type             | "kv", "list", "set", "map",    | N/A                     |
+|                |             |                       | "b+tree"                       |                         |
+|-----------------------------------------------------------------------------------------------------------------|
+| count          | collection  | current # of elements | 4 bytes unsigned integer       | N/A                     |
+|-----------------------------------------------------------------------------------------------------------------|
+| maxcount       | collection  | maximum # of elements | 4 bytes unsigned integer       | 4000                    |
+|-----------------------------------------------------------------------------------------------------------------|
+| overflowaction | collection  | overflow action       | “error”: all collections       | list: "tail_trim"       |
+|                |             |                       | “head_trim”: list              | set: "error"            |
+|                |             |                       | “tail_trim”: list              | map: "error"            |
+|                |             |                       | “smallest_trim”: b+tree        | b+tree: "smallest_trim" |
+|                |             |                       | “largest_trim”: b+tree         |                         |
+|                |             |                       | “smallest_silent_trim”: b+tree |                         |
+|                |             |                       | “largest_silent_trim”: b+tree  |                         |
+|-----------------------------------------------------------------------------------------------------------------|
+| readable       | collection  | readable/unreadable   | “on”, “off”                    | "on"                    |
+|-----------------------------------------------------------------------------------------------------------------|
+| maxbkeyrange   | b+tree only | maximum bkey range    | 8 bytes unsigned integer or    | 0                       |
+|                |             |                       | hexadecimal (max 31 bytes)     |                         |
+|-----------------------------------------------------------------------------------------------------------------|
+```
+
+ARCUS Cache Server는 item 속성들을 조회하거나 변경하는 용도의 getattr 명령과 setattr 명령을 제공한다.
+이들 명령에 대한 자세한 설명은 [Item Attribute 명령](ascii-protocol/07-item-attribute.md)을 참고 바란다.
+
+
+Item 속성들 중 정확한 이해를 돕기 위해 추가 설명이 필요한 속성들에 대해 아래에서 자세히 설명한다.
+
+## flags 속성
+
+Flags는 item의 data-specific 정보를 저장하기 위한 목적으로 사용된다.
+예를 들어, ARCUS java client는 어떤 java object를 Cache Server에 저장할 경우,
+그 java object의 type에 따라 serialization(or marshalling)하여 저장할 data를 만들고,
+그 java object의 type 정보를 flags 값으로 하여 ARCUS Cache Server에 요청하여 저장한다.
+Data 조회 시에는 ARCUS Cache Server로 부터 data와 함께 flags 정보를 함께 얻어와서,
+해당 java object의 type에 따라 그 data를 de-serialization(or de-marshalling)하여 java object를 생성한다.
+
+## expiretime 속성
+
+Item의 expiretime 속성으로 그 item의 expiration time을 초(second) 단위로 설정한다.
+
+ARCUS Cache Server는 expire 되지 않고 메모리 부족 상황에서도 evict 되지 않는 sticky item 기능을 제공한다.
+Sticky item 또한 expiretime 속성으로 지정한다.
+
+- -1 : sticky item으로 설정
+- 0 : never expired item으로 설정, 그러나 메모리 부족 시에 evict될 수 있다.
+- X <= (60 * 60 * 24 * 30) : 30일 이하의 값이면, "현재 시간 + X(초)"로 expiration time이 설정된다.
+- X > (60 * 60 * 24 * 30) : 30일 초과의 값이면, X를 unix time으로 인식하여 expiration time을 설정한다.
+X가 현재 시간보다 작으면 그 즉시 expire되므로 주의하여야 한다.
+
+## maxcount 속성
+
+Collection item에만 유효한 속성으로, 하나의 collection에 저장할 수 있는 최대 element 수를 규정한다.
+
+Maxcount 속성의 hard limit과 default(설정 생략 또는 0을 값으로 주는 경우) 값은 아래와 같다.
+- hard limit : 50000
+- default value : 4000
+
+Maxcount 속성의 hard limit을 작게 규정한 이유는 O(small N)의 수행 비용을 가지도록 하기 위한 것이다.
+Event-driven processing 모델에 따라
+하나의 worker thread가 비동기 방식으로 여러 client requests를 처리해야 하는 상황에서,
+한 request의 처리 비용이 가급적 작아야만 다른 request의 execution latency에 주는 영향을 최소화할 수 있다.
+
+## overflowaction 속성
+
+Collection의 maxcount를 초과하여 element 추가하면 overflow가 발생하며, 이 경우 취할 action을 지정한다.
+
+- "error"
+  - 모든 collection 유형에 설정 가능한 속성이다.
+  - set과 map collection의 default overflow action이다.
+  - 새로운 element 추가를 허용하지 않고 overflow 오류를 리턴한다.
+- "head_trim", "tail_trim"
+  - list collection에만 설정 가능한 overflow action이다.
+  - list collection의 default overflow action은 "tail_trim"이다.
+  - 새로운 element 추가를 허용하는 대신 list의 head 또는 tail에 위치한 기존 element를 제거한다.
+  - Overflow trim 발생 시, trim 발생 여부를 나타내는 trim flag를 내부적으로 유지하지 않는다.
+- "smallest_trim", "largest_trim"
+  - b+tree collecton에만 설정 가능한 overflow action이다.
+  - b+tree collecton의 default overflow action은 "smallest_trim"이다.
+  - 새로운 element 추가를 허용하는 대신 smallest bkey 또는largest bkey를 가진 기존 element를 제거한다.
+  - Overflow trim 발생 시, trim 발생 여부를 나타내는 trim flag를 내부적으로 유지하며,
+    trim 발생한 bkey 영역을 조회할 경우 응답 결과에 trim 발생 여부를 포함시킨다.
+- "smallest_silent_trim", "largest_silent_trim"
+  - "samllest_trim", "largest_trim"과 동일하게 동작하는 overflow action이다.
+  - 차이점은 overflow trim이 발생하더라도 trim flag를 내부적으로 유지하지 않으며,
+    trim 발생한 bkey 영역을 조회하더라도 조회 결과에 trim 발생 여부를 포함시키지 않는다.
+  - 응용에서 주의할 사항은 trim 여부나 trim된 데이터에 대한 검사를 직접 수행하여야 한다.
+
+참고로, 아래에 기술하는 maxbkeyrange 속성에 따라 element를 제거하는 경우에도
+overflow action이 참조된다.
+
+## readable 속성
+
+ARCUS Cache Server는 다수 element를 가진 collection을 atomic하게 생성하는 명령을 제공하지 않는다.
+대신, 하나의 element를 추가하는 명령을 반복 수행함으로써 원하는 collection을 만들 수 있다.
+이 경우, 하나의 collection이 완성되기 전의 incomplete collection이 응용에게 노출될 수 있는 문제가 있다.
+예를 들어, 어떤 사용자의 SNS 친구 정보를 set collection 형태로 cache에 저장한다고 가정한다.
+일부 친구 정보만 set collection에 저장된 상태에서 그 사용자의 전체 친구 정보를 조회하는 요청이 들어온다면,
+incomplete 친구 정보가 응용에게 노출되게 된다.
+이러한 문제를 방지하기 위해 collection 생성에 대해 read atomicity를 제공하는 기능이 필요하며,
+이 기능의 구현을 위해 readable 속성을 제공한다.
+
+처음 empty collection 생성 시에 readable 속성을 off 상태로 설정해서
+그 collection에 대한 조회 요청은 UNREADABLE 오류를 발생시키게 하고,
+그 collection에 모든 element들을 추가한 후에 마지막으로 readable 속성을 다시 on 상태로 변경함으로써
+complete collection이 응용에 의해 조회될 수 있게 할 수 있다.
+
+## maxbkeyrange 속성
+
+B+tree only 속성으로 smallest bkey와 largest bkey의 최대 범위를 규정한다.
+B+tree에 설정된 maxbkeyrange를 위배시키는 새로운 bkey를 가진 element를 삽입하는 경우,
+b+tree의 overflow action 정책에 따라 오류를 내거나
+smallest/largest bkey를 가진 elements를 제거함으로써 항상 maxbkeyrange 특성을 준수하게 한다.
+
+Maxbkeyrange 속성에 의한 element 제거는 응용 요청에 의한 명시적인 element 제거와 동일하므로,
+trim으로 처리하지 않는다. 결국, maxcount 속성에 의한 overflow trim 만을 trim으로 처리한다.
+
+maxbkeyrange의 사용 예로,
+어떤 응용이 data 생성 시간을 bkey로 하여 그 data를 b+tree에 저장하고
+최근 2일치 data 만을 b+tree에 유지하길 원한다고 가정한다.
+초 단위의 시간 값을 bkey 값으로 사용한다면,
+maxbkeyrange는 2일치에 해당하는 값인 172880(2 * 24 * 60 * 60)으로 지정하고,
+최근 data만을 보관하기 위해 overflowaction은 "smallest_trim"으로 지정하면 된다.
+이러한 지정으로, 새로운 data가 추가될 때마다 b+tree에서 2일치가 지난 data는
+maxbkeyrange와 overflowaction에 의해 자동으로 제거된다.
+만약, 이런 기능이 없다면, 응용에서 오래된(2일이 지난) data를 직접 제거하는 작업을 수행해야 한다.
+
+maxbkeyrange 설정은 bkey의 데이터 유형에 맞게 설정하여야 하며,
+maxbkeyrange 설정이 생략되거나 명시적으로 0을 줄 경우의 default 값은
+bkey 데이터 유형에 무관하게 unlimited maxbkeyrange를 의미한다.
+
+maxbkeyrange는 bkey와 동일하게 8 bytes unsinged integer 유형과 hexadecimal 유형의 값으로 설정할 수 있다. 허용하는 값의 자세한 사항은 [BKey(B+Tree Key)](collection-items.md#bkey-btree-key)를 참고하기 바란다.

--- a/documentation/manuals/commandline_arguments.md
+++ b/documentation/manuals/commandline_arguments.md
@@ -1,0 +1,53 @@
+## 필수 옵션
+
+| 옵션 | 설명 | 기타|
+| --- | --- | --- |
+| `-E` | Engine to load, (for example, -E .libs/default_engine.so) |  |
+
+## 기본 옵션
+
+| 옵션 | 설명 | 기본값 | 기타 |
+| --- | --- | --- | --- |
+| `-p <num>` | TCP 포트 번호 | 11211 |  |
+| `-U <num>` | UDP 포트 번호 | 11211 | 0 is off |
+| `-s <file>` | UNIX socket path |  |  |
+| `-a <mask>` | mask for UNIX socket | 0700 | in octal |
+| `-l <ip_addr>` | interface to listen on | INADDR_ANY(모든 주소) |  |
+| `-d` | 백그라운드 실행 (`-E`와 `-X`의 인자를 절대경로 사용하거나 `-r` 또는 `-P` 옵션과 함께 사용해야 함) |  |  |
+| `-r` | maximize core file limit |  |  |
+| `-u <username>` | `<username>`이 실행한 것으로 가정 |  | root 실행 시 |
+| `-c` | max simultaneous connections | 1024 |  |
+| `-k` | lock down all paged memory. Note that there is a limit on how much memory you may lock. Trying to allocate more than that would fail, so be sure you set the limit correctly for the user you started the daemon with (not for `-u <username>` user; under sh this is done with 'ulimit -S -l NUM_KB'). |  |  |
+| `-v`, `-vv`, `-vvv` | verbose, very verbose, extremely verbose |  |  |
+| `-h` | 도움말 출력 후 종료 |  |  |
+| `-i` | memcached, libevent licence 출력 |  |  |
+| `-P <file>` | save PID in `<file>` |  | only used with `-d` option |
+| `-t <num>` | number of threads to use | 4 |  |
+| `-R` | Maximum number of requests per event, limits the number of requests process for a given connection to prevent starvation | 20 |  |
+| `-b` | Set the backlog queue limit | 1024 |  |
+| `-B` | Binding protocol - one of ascii, binary, or auto | auto |  |
+| `-e` | engine_config 옵션, `<key>=<value>;<key>=<value>` 형태로 직접 지정하거나, `config_file=</path>`로 파일 지정 가능 |  |  |
+
+## engine config 관련 옵션
+
+아래 옵션들을 사용하지 않더라도 -e 옵션을 활용해 engine 관련 설정을 지정할 수 있다.
+예) `-m 40 -M` 대신 `-e cache_size=40;eviction=false;`를 사용해도 동일한 동작 수행
+다른 옵션과 `-e` 옵션을 중복해서 사용하는 경우 `-e` 옵션이 더 우선 적용된다.
+또한 `-e <key>=<value1>;<key>=<value2>` 형태로 입력하는 경우 `key`의 값은 `value2`로 최종 적용된다.
+
+| 옵션 | 설명 | 기본값 | 기타 |
+| --- | --- | --- | --- |
+| `-m <num>` | 최대 메모리 | 64 | MB 단위 |
+| `-M` | 메모리 부족한 경우 (item 삭제 대신)에러 |  |  |
+| `-g` | sticky(gummed) memory limit | 0 | MB 단위 |
+| `-f <factor>` | chunk size growth factor | 1.25 |  |
+| `-n <bytes>` | minimum space allocated for key+value+flags | 48 |  |
+| `-D <char>` | Use `<char>` as the delimiter between key prefixes and IDs. This is used for per-prefix stats reporting. The default is ":" (colon). If this option is specified, stats collection is turned on automatically; if not, then it may be turned on by sending the "stats detail on" command to the server. (+ `detail_enabled = 1`) |  |  |
+| `-L` | Try to use large memory pages (if available). Increasing the memory page size could reduce the number of TLB misses and improve the performance. In order to get large pages from the OS, memcached will allocate the total item-cache in one large chunk. |  |  |
+| `-C` | Disable use of CAS |  |  |
+| `-I` | Override the size of each slab page. Adjusts max item size | 1mb | min: 1k, max: 128m |
+
+## 기타
+현재 engine 관련 설정은 `-e` 옵션을 활용한 config file 지정, 다른 구동 옵션을 활용한 설정, 환경변수에서 읽어오는 방법 등 다양한 방법을 사용하고 있다.
+현재 방법들 중 환경변수는 사용자 관점에서 관리하기가 어렵고, 구동 옵션에서는 엔진 관련 설정과 다른 설정이 명확히 드러나지 않는다는 문제가 있다.
+따라서 `-e config_file=/config_file1.conf` 형태로 파일을 이용하여 engine 설정을 입력하는 것이 좋다.

--- a/documentation/manuals/compilation_faq.md
+++ b/documentation/manuals/compilation_faq.md
@@ -1,0 +1,51 @@
+## Compile
+- 의존성 모듈 설치
+  - Install tools
+
+    ```
+    (CentOS) sudo yum install gcc gcc-c++ make autoconf automake libtool pkgconfig cppunit-devel perl-Test-Harness perl-Test-Simple
+    (Ubuntu) sudo apt-get install build-essential autoconf automake libtool libcppunit-dev
+    (OSX)    brew install autoconf automake libtool pkg-config cppunit
+    ```
+  - Install libevent
+
+    ```
+    $ wget https://github.com/downloads/libevent/libevent/libevent-2.0.21-stable.tar.gz
+    $ tar xfz libevent-2.0.21-stable.tar.gz
+    $ pushd libevent-2.0.21-stable
+    $ ./autogen.sh
+    $ ./configure --prefix=/path/to/arcus-directory
+    $ make
+    $ sudo make install
+    $ popd
+    ```
+  - Install [arcus-zookeeper](https://github.com/naver/arcus-zookeeper)
+
+## Test
+- 개별 테스트를 수행하는 방법
+
+  ```
+  perl t/${test_script_name}.t
+  ```
+- 여러 테스트가 동시 수행되어 used port로 실패하는 경우 재수행하거나 동시성을 1로 하여 수행.
+
+  ```
+  //run_test.pl 수정
+  my $opt = '--job 1'; # --job N : run N test jobs in parallel
+  ```
+- perl Test::More.pm 모듈이 없어서 실패하는 경우
+
+  ```
+  Can't locate Test/More.pm in @INC (@INC contains: /usr/local/lib64/perl5 /usr/local/share/perl5 /usr/lib64/perl5/vendor_perl
+  /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5 .) at -e line 1.
+  ```
+  위 에러를 보이게 되며, 테스트 스크립트에서 필요로 하는 perl 모듈인 Test::More.pm 이 시스템에 설치되어 있지 않아서 발생한다.
+  CPAN 을 이용해 Test::More.pm 모듈을 설치한다.
+  ```
+  # Install CPAN
+  (CentOS) sudo yum install cpan
+  (Ubuntu) sudo apt-get install libpath-tiny-perl
+
+  # Install Test::More
+  cpan Test::More
+  ```


### PR DESCRIPTION
마크다운 문서를 위한 폴더 구조를 정리합니다.
구조는 아래와 같이 설정해 보았습니다.
문서 경로: `/documentation`

- `documentation/`
  - README.md: arcus cache server에 대한 기본 설명
  - SUMMARY.md: Gitbook에서 보여질 목차 정보
  - 그 외 ARCUS 캐시 서버의 기본 컨셉 및 데이터 모델 등에 관한 문서
- `documentation/ascii-protocol`
  ascii protocol 관련 문서
- `documentation/manuals`
  운영과 관련된 문서(설치/실행 등)

```
documentation/
├── README.md
├── SUMMARY.md
├── collection-items.md
├── item-attributes.md
├── ascii-protocol
│   ├── 00-arcus-ascii-protocol.md
│   ├── 01-key-value.md
│   ├── 02-list-collection.md
│   ├── 03-set-collection.md
│   ├── 04-map-collection.md
│   ├── 05-btree-collection.md
│   ├── 06-pipelining.md
│   ├── 07-item-attribute.md
│   ├── 08-scan.md
│   ├── 09-administration.md
│   └── appendix.md
└── manuals
    ├── commandline_arguments.md
    └── compilation_faq.md
```
위를 바탕으로 생성되는 웹 페이지는 다음과 같습니다.
https://jam2in.gitbook.io/arcus-memcached/v/namsic-1/
![image](https://github.com/naver/arcus-memcached/assets/28771800/476693de-4c3f-4502-86d6-7e5cd74953e4)

