### PR TITLE
FIX: Check dependencies in the prefix path before the default path

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -342,7 +342,7 @@ AC_CACHE_CHECK([for libevent directory], ac_cv_libevent_dir, [
   saved_LDFLAGS="$LDFLAGS"
   saved_CPPFLAGS="$CPPFLAGS"
   le_found=no
-  for ledir in $trylibeventdir "" $prefix /usr/local ; do
+  for ledir in $trylibeventdir $prefix "" /usr/local ; do
     LDFLAGS="$saved_LDFLAGS"
     LIBS="$saved_LIBS -levent"
 
@@ -434,7 +434,7 @@ if test "x$enable_zk_integration" = "xyes"; then
     saved_LDFLAGS="$LDFLAGS"
     saved_CPPFLAGS="$CPPFLAGS"
     zk_found=no
-    for zkdir in $tryzookeeperdir "" $prefix /usr/local ; do
+    for zkdir in $tryzookeeperdir $prefix "" /usr/local ; do
       LDFLAGS="$saved_LDFLAGS"
       LIBS="$saved_LIBS -lzookeeper_mt"
 


### PR DESCRIPTION
- jam2in/arcus-works#448

libevent와 zookeeper 경로 탐색 시 prefix를 우선 확인하도록 합니다.