### PR TITLE
INTERNAL: Add rfc1321 to EXTRA_DIST and add dist tarball to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 .dirstamp
 /.libs/
 /aclocal.m4
+/arcus-memcached-*.tar.gz
 /autom4te.cache
 /compile
 /config.guess

--- a/Makefile.am
+++ b/Makefile.am
@@ -251,7 +251,7 @@ default_engine_dtrace.lo: $(default_engine_la_OBJECTS)
 
 SUBDIRS = doc
 DIST_DIRS = scripts
-EXTRA_DIST = doc scripts t memcached.spec memcached_dtrace.d m4/version.m4
+EXTRA_DIST = doc scripts t memcached.spec memcached_dtrace.d m4/version.m4 rfc1321
 
 MOSTLYCLEANFILES = *.gcov *.gcno *.gcda *.tcov
 


### PR DESCRIPTION
- jam2in/arcus-works#457

- `make dist` 명령으로 생성되는 `arcus-memcached-<version>.tar.gz` 파일을 .gitignore에 추가합니다.
- `make dist` 명령으로 생성되는 tarball 파일에 rfc1321 폴더가 포함되도록 합니다.