### PR TITLE
FIX: Create an installation path and then convert to the absolute path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 /depcomp
 /deps/*
 !/deps/*.tar.gz
+!/deps/install.sh
 /doc/doxy
 /doc/doxy-api
 /doc/engine-interface.txt

--- a/deps/install.sh
+++ b/deps/install.sh
@@ -42,6 +42,7 @@ build_and_install() {
 
 ## If the path was not given, ask for prior consent about installation to system path.
 if [ -n "$1" ]; then
+    set -- $(mkdir -p $1 && cd $1 && pwd)
     prefix="--prefix=$1"
 else
     echo "There is no argument given for the installation path."


### PR DESCRIPTION
install.sh 실행 시 상대경로를 받을 경우에도 정상적으로 구동할 수 있게끔 변경합니다.

상대경로의 경우 절대경로 변환 과정에서 해당 디렉토리가 존재하지 않을 시 실패하는
현상을 막기 위해 설치경로에 대하여 미리 디렉토리를 생성시켰습니다.
