### PR TITLE
INTERNAL: Use deps/install.sh in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,42 +1,15 @@
-ARG \
-    libevent_version="2.1.12-stable" \
-    zookeeper_version="3.5.9-p3" \
-    configure_options="--enable-zk-integration"
-
 FROM centos:7 AS builder
 RUN yum update -y
-RUN yum install -y gcc gcc-c++ make m4 perl autoconf automake libtool pkgconfig cppunit-devel ant which git
-ARG libevent_version zookeeper_version configure_options
-## Libevent
-WORKDIR /tmp
-ADD https://github.com/libevent/libevent/releases/download/release-${libevent_version}/libevent-${libevent_version}.tar.gz .
-RUN tar -zxf libevent-${libevent_version}.tar.gz
-WORKDIR libevent-${libevent_version}
-RUN ./configure --disable-openssl --prefix=/arcus
-RUN make && make install
-## ZooKeeper C client
-WORKDIR /tmp
-RUN git clone https://github.com/naver/arcus-zookeeper.git -b ${zookeeper_version}
-WORKDIR arcus-zookeeper
-RUN ant compile_jute
-WORKDIR zookeeper-client/zookeeper-client-c
-RUN autoreconf -if
-RUN ./configure --prefix=/arcus
-RUN make && make install
-## Memcached
-COPY . /tmp/arcus-memcached
-WORKDIR /tmp/arcus-memcached
+RUN yum install -y make libtool which git
+# Copy all files from the repository not included in .dockerignore to /src in the image.
+COPY . /src
+WORKDIR /src
+RUN ./deps/install.sh /arcus
 RUN ./config/autorun.sh
-RUN ./configure --prefix=/arcus --with-libevent=/arcus --with-zookeeper=/arcus ${configure_options}
+RUN ./configure --prefix=/arcus --enable-zk-integration
 RUN make && make install
 
 FROM centos:7 AS base
-ARG libevent_version zookeeper_version configure_options
-LABEL \
-    libevent="$libevent_version" \
-    zookeeper="$zookeeper_version" \
-    configure="$configure_options"
-#   document="https://github.com/naver/arcus-memcached"
 COPY --from=builder /arcus /arcus
 ENV PATH ${PATH}:/arcus/bin
 


### PR DESCRIPTION
- #696 
- 의존성 설치에 `deps/install.sh` 스크립트를 사용합니다.
- 최소한의 yum 패키지만 사용하도록 변경합니다.
- 소스 폴더 경로를 `/tmp`에서 `/src`로 변경했습니다.
- 이미지에 포함되는 LABEL을 제거했습니다.
