### PR TITLE
INTERNAL: Add Makefile.docker

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -1,0 +1,7 @@
+VERSION ?= develop
+
+build:
+	- docker buildx create --name project-v3-builder
+	docker buildx use project-v3-builder
+	- docker buildx build --push --platform=linux/arm64,linux/amd64 --tag jam2in/arcus-memcached:${VERSION} --progress tty .
+	- docker buildx rm project-v3-builder

--- a/t/whitespace.t
+++ b/t/whitespace.t
@@ -8,6 +8,7 @@ BEGIN {
 
     my @exempted = qw(Makefile.am win32/Makefile.mingw m4/c99-backport.m4);
     push(@exempted, glob("*/Makefile.am"));
+    push(@exempted, glob("Makefile.docker"));
     push(@exempted, glob("ChangeLog*"));
     push(@exempted, glob("README.md*"));
     push(@exempted, glob("CONTRIBUTING.md*"));


### PR DESCRIPTION
- jam2in/arcus-docker#22

@uhm0311 의견에 따라 Makefile.docker를 추가합니다. 아래와 같이 사용할 수 있습니다.
```sh
# build && push multi-platform docker image
make -f Makefile.docker                 # jam2in/arcus-memcached:develop
make -f Makefile.docker VERSION=1.13.4  # jam2in/arcus-memcached:1.13.4
```

### 기타
- `memcached/memcached`
  - [devtools](https://github.com/memcached/memcached/tree/master/devtools)에 dockerfile 위치
  - repository root에 각 Dockerfile을 사용하는 [docker-compose](https://github.com/memcached/memcached/blob/master/docker-compose.yml) 위치(테스트 용도로 추측)
  - 이미지 생성을 위한 별도의 스크립트나 Makefile은 없음
- `redis/redis`
  - Dockerfile, docker image build 관련 파일 없음