### PR TITLE
DOC: Clean whitespace

### DIFF
--- a/doc/ap01-arcus-telnet-interface.md
+++ b/doc/ap01-arcus-telnet-interface.md
@@ -14,7 +14,7 @@ $ telnet {memcached-ip} {memcached-port}
 ## Telnet 연결
 
 Localhost에 11211 포트 번호로 memcached가 구동되어 있다고 가정한다.
-telnet 명령으로 해당 memcached에 연결하기 위해, 
+telnet 명령으로 해당 memcached에 연결하기 위해,
 OS prompt 상에서 아래의 명령을 수행한다.
 
 ```

--- a/doc/ch01-arcus-basic-concept.md
+++ b/doc/ch01-arcus-basic-concept.md
@@ -43,7 +43,7 @@ ARCUS Cache Server는 simple key-value 외에 collection 지원으로 다양한 
 - collection item
   - list item - 데이터들의 linked list을 value로 가지는 item
   - set item - 유일한 데이터들의 집합을 value로 가지는 item
-  - map item - \<field, value\>쌍으로 구성된 데이터 집합을 value로 가지는 item 
+  - map item - \<field, value\>쌍으로 구성된 데이터 집합을 value로 가지는 item
   - b+tree item - b+tree key 기반으로 정렬된 데이터 집합을 value로 가지는 item
 
 ## Expiration, Eviction, and Sticky
@@ -60,7 +60,7 @@ ARCUS Cache Server는 "out of memory" 오류를 내거나 LRU 기반의 eviction
 default로는 LRU 기반의 eviction 방식을 사용한다.
 
 특정 응용에서는 어떤 item이 expire & evict 대상이 되지 않기를 원하는 경우도 있다.
-ARCUS Cache Server는 이러한 item을 sticky item이라 하며, 
+ARCUS Cache Server는 이러한 item을 sticky item이라 하며,
 expiration time을 -1로 지정하면, sticky item으로 지원한다.
 Sticky item의 삭제는 전적으로 응용에 의해 관리되어야 함을 주의해야 한다.
 
@@ -90,7 +90,7 @@ Slab allocator는 메모리 크기 별로 메모리 공간을 나누어 관리�
   - 최소 크기의 slab 크기를 결정한다.
 - \-f \<factor\> : chunk size growth factor (default: 1.25)
   - Slab class 별로 slab 크기의 증가 정도를 지정하며, 1.0보다 큰 값으로 지정해야 한다.
-  
+
 ### Small Memory Allocator
 
 Collection 지원으로 인해 작은 메모리 공간의 할당과 반환 요청이 많아졌다.

--- a/doc/ch02-collection-items.md
+++ b/doc/ch02-collection-items.md
@@ -11,7 +11,7 @@ Collection 유형과 그 구조 및 특징은 아래와 같다.
   특정 위치에 있는 element를 접근할 수 있다.
   많은 element를 가진 list에서 중간 위치의 임의 element 접근 시에 성능 이슈가 있으므로,
   list를 queue 개념으로 사용하길 권한다.
-  
+
 **Set** - unordered set of unique value
 
 > Set 자료 구조는 membership checking에 적합하다.
@@ -34,7 +34,7 @@ Collection 유형과 그 구조 및 특징은 아래와 같다.
   Elements 수에 비례하여 동적으로 depth를 조정하는 b+tree 구조를 사용하여 메모리 사용을 최소화한다.
   그 외에, b+tree의 nonleaf node는 각 하위 node 중심의 sub-tree에 저장된 element 개수 정보를
   담고 있도록 해서, 특정 element의 position 조회 및 position 기반의 element 조회 기능도 제공한다.
-  
+
 Collection item은 \<key, "collection meta info"\> 구조를 가진다.
 Collection meta info는 collection 유형에 따른 속성 정보를 가지며,
 해당 collection의 elements에 신속히 접근하기 정보를 가진다.
@@ -53,7 +53,7 @@ Collection 유형에 따른 element 구조는 아래와 같다.
 
   map에서 각 element를 구분하기 위한 field를 필수적으로 가지며,
   field는 중복을 허용하지 않는다.
-  
+
 - b+tree element : \<bkey(b+tree key), eflag(element flag), data\>
 
   b+tree에서 elements를 어떤 기준으로 정렬하기 위한 bkey를 필수적으로 가지며,
@@ -68,13 +68,13 @@ B+tree collection에서 사용가능한 bkey 데이터 유형은 아래 두 가�
 
   0 ~ 18446744073709551615 범위의 값을 지정할 수 있다.
   이 유형이 성능 및 메모리 공간 관점에서 hexadecimal 유형보다 유리하므로, 이 유형의 bkey 사용을 권장한다.
-  
+
 - hexadecimal
- 
+
   “0x”로 시작하는 짝수 개의 hexadecimal 문자열로 표현하며, 대소문자 모두 사용 가능하다.
   ARCUS cache server는 두 hexadecimal 문자를 1 byte로 저장하며,
   1 ~ 31 길이의 variable length byte array로 저장한다.
-  
+
   hexadecimal 표현이 올바른 경우의 저장 바이트 수와 잘못된 경우의 이유는 아래와 같다.
 
   hexadecimal value | storage bytes | incorrect reason
@@ -85,7 +85,7 @@ B+tree collection에서 사용가능한 bkey 데이터 유형은 아래 두 가�
   0x34F40           |               | 홀수 개의 hexadecimal 문자열
   0x34F40G          |               | 'G'가 hexadecimal 문자가 아님
 
-bkey의 대소 비교는 8 bytes unsigned integer 유형의 값이면 두 integer 값의 단순한 비교 연산으로 수행하며, 
+bkey의 대소 비교는 8 bytes unsigned integer 유형의 값이면 두 integer 값의 단순한 비교 연산으로 수행하며,
 hexadecimal 유형의 값이면 아래와 같은 lexicographical order로 두 값을 비교한다.
 
 - 두 hexadecimal의 첫째 바이트부터 차례로 바이트 단위로 대소를 비교하여, 차이나면 대소 비교를 종료한다.
@@ -96,7 +96,7 @@ hexadecimal 유형의 값이면 아래와 같은 lexicographical order로 두 �
 
 eflag는 현재 b+tree element에만 존재하는 필드이다.
 eflag 데이터 유형은 hexadecimal 유형만 가능하며,
-bkey의 hexadecimal 표현과 저장 방식을 그대로 따른다. 
+bkey의 hexadecimal 표현과 저장 방식을 그대로 따른다.
 
 ## EFlag Filter
 
@@ -108,7 +108,7 @@ eflag에 대한 filter 조건은 아래와 같이 표현하며,
 eflag_filter: <fwhere> [<bitwop> <foperand>] <compop> <fvalue>
 ```
 
-- \<fwhere\> 
+- \<fwhere\>
   - eflag 값에서 bitwise/compare 연산을 취할 시작 offset을 바이트 단위로 나타낸다.
     bitwise/compare 연산을 취할 데이터의 length는 \<fvalue\>의 length로 한다.
     예를 들어, eflag 전체 데이터를 선택한다면, \<fwhere\>는 0이어야 하고
@@ -120,15 +120,15 @@ eflag_filter: <fwhere> [<bitwop> <foperand>] <compop> <fvalue>
   - \<bitwop\>는 “&”(bitwise and), “|”(bitwise or), “^”(bitwise xor) 중의 하나로 bitwise 연산을 지정한다.
   - \<foperand\>는 bitwise 연산을 취할 operand로 hexadecimal로 표현한다.
     \<foperand\>의 길이는 compare 연산을 취한 \<fvalue\>의 길이와 동일하여야 한다.
-- \<compop\> \<fvalue\>  
+- \<compop\> \<fvalue\>
   - eflag에 대한 compare 연산을 지정한다.
   - \<compop\>는 "EQ", "NE", "LT", "LE", "GT", "GE" 중의 하나로 compare 연산을 지정하며,
     \<fvalue\>는 compare 연산을 취할 대상 값으로 마찬가지로 hexadecimal로 표현한다.
-  - IN 또는 NOT IN 조건을 명시할 수도 있다. 
+  - IN 또는 NOT IN 조건을 명시할 수도 있다.
     IN 조건은 "EQ" 연산과 comma separated hexadecimal values로 명시하면 되고,
     NOT IN 조건은 "NE" 연산과 comma separated hexadecimal values로 명시하면 된다.
     이 경우, comma로 구분된 hexadecimal values의 최대 수는 100 개까지만 지원한다.
-  
+
 하나의 b+tree의 element에는 동일 길이의 element flag를 사용하길 권장한다.
 하지만 응용이 필요하다면, 하나의 b+tree에 소속된 elements 이더라도
 eflag가 생략될 수도 있고 서로 다른 길이의 eflag를 가질 수도 있다.
@@ -138,7 +138,7 @@ eflag가 생략될 수도 있고 서로 다른 길이의 eflag를 가질 수도 
 - eflag가 없는 element에 eflag_filter 조건이 주어질 수 있다.
 - eflag가 있지만 eflag_filter 조건에서 명시된 offset과 length의 데이터를 가지지 않을 수 있다.
   예를 들어, eflag가 4 bytes인 상황에서
-  (1) eflag_filter 조건의 offset은 5인 경우이거나 
+  (1) eflag_filter 조건의 offset은 5인 경우이거나
   (2) eflag_filter 조건의 offset은 3이고 length는 4인 경우가 있을 수 있다.
 
 ## EFlag Update
@@ -163,8 +163,7 @@ eflag_update: [<fwhere> <bitwop>] <fvalue>
     부분 변경을 위한 \<fwhere\>과 \<bitwop\>가 지정되면
     \<fvalue\>는 eflag 부분 데이터에 대해 bitwise 연산을 취할 operand로 사용되며,
     bitwise 연산의 결과가 eflag의 new value로 변경된다.
-  
+
 
 기존 eflag 값을 delete하여 eflag가 없는 상태로 변경할 수 있다.
 이를 위해서는 \<fwhere\>과 \<bitwop\>를 생략하고 \<fvalue\> 값으로 0을 주면 된다.
-

--- a/doc/ch03-item-attributes.md
+++ b/doc/ch03-item-attributes.md
@@ -48,7 +48,7 @@ Item 속성들 중 정확한 이해를 돕기 위해 추가 설명이 필요한 
 
 Flags는 item의 data-specific 정보를 저장하기 위한 목적으로 사용된다.
 예를 들어, ARCUS java client는 어떤 java object를 Cache Server에 저장할 경우,
-그 java object의 type에 따라 serialization(or marshalling)하여 저장할 data를 만들고, 
+그 java object의 type에 따라 serialization(or marshalling)하여 저장할 data를 만들고,
 그 java object의 type 정보를 flags 값으로 하여 ARCUS Cache Server에 요청하여 저장한다.
 Data 조회 시에는 ARCUS Cache Server로 부터 data와 함께 flags 정보를 함께 얻어와서,
 해당 java object의 type에 따라 그 data를 de-serialization(or de-marshalling)하여 java object를 생성한다.
@@ -61,7 +61,7 @@ ARCUS Cache Server는 expire 되지 않고 메모리 부족 상황에서도 evic
 Sticky item 또한 expiretime 속성으로 지정한다.
 
 - -1 : sticky item으로 설정
-- 0	: never expired item으로 설정, 그러나 메모리 부족 시에 evict될 수 있다.
+- 0 : never expired item으로 설정, 그러나 메모리 부족 시에 evict될 수 있다.
 - X <= (60 * 60 * 24 * 30) : 30일 이하의 값이면, "현재 시간 + X(초)"로 expiration time이 설정된다.
 - X > (60 * 60 * 24 * 30) : 30일 초과의 값이면, X를 unix time으로 인식하여 expiration time을 설정한다.
 X가 현재 시간보다 작으면 그 즉시 expire되므로 주의하여야 한다.
@@ -86,7 +86,7 @@ Collection의 maxcount를 초과하여 element 추가하면 overflow가 발생�
 - "error"
   - 모든 collection 유형에 설정 가능한 속성이다.
   - set과 map collection의 default overflow action이다.
-  - 새로운 element 추가를 허용하지 않고 overflow 오류를 리턴한다. 
+  - 새로운 element 추가를 허용하지 않고 overflow 오류를 리턴한다.
 - "head_trim", "tail_trim"
   - list collection에만 설정 가능한 overflow action이다.
   - list collection의 default overflow action은 "tail_trim"이다.
@@ -117,14 +117,14 @@ ARCUS Cache Server는 다수 element를 가진 collection을 atomic하게 생성
 incomplete 친구 정보가 응용에게 노출되게 된다.
 이러한 문제를 방지하기 위해 collection 생성에 대해 read atomicity를 제공하는 기능이 필요하며,
 이 기능의 구현을 위해 readable 속성을 제공한다.
-  
+
 처음 empty collection 생성 시에 readable 속성을 off 상태로 설정해서
 그 collection에 대한 조회 요청은 UNREADABLE 오류를 발생시키게 하고,
 그 collection에 모든 element들을 추가한 후에 마지막으로 readable 속성을 다시 on 상태로 변경함으로써
 complete collection이 응용에 의해 조회될 수 있게 할 수 있다.
 
 ## maxbkeyrange 속성
-  
+
 B+tree only 속성으로 smallest bkey와 largest bkey의 최대 범위를 규정한다.
 B+tree에 설정된 maxbkeyrange를 위배시키는 새로운 bkey를 가진 element를 삽입하는 경우,
 b+tree의 overflow action 정책에 따라 오류를 내거나
@@ -142,7 +142,7 @@ maxbkeyrange는 2일치에 해당하는 값인 172880(2 * 24 * 60 * 60)으로 �
 이러한 지정으로, 새로운 data가 추가될 때마다 b+tree에서 2일치가 지난 data는
 maxbkeyrange와 overflowaction에 의해 자동으로 제거된다.
 만약, 이런 기능이 없다면, 응용에서 오래된(2일이 지난) data를 직접 제거하는 작업을 수행해야 한다.
-  
+
 maxbkeyrange 설정은 bkey의 데이터 유형에 맞게 설정하여야 하며,
 maxbkeyrange 설정이 생략되거나 명시적으로 0을 줄 경우의 default 값은
 bkey 데이터 유형에 무관하게 unlimited maxbkeyrange를 의미한다.

--- a/doc/ch04-command-key-value.md
+++ b/doc/ch04-command-key-value.md
@@ -1,6 +1,6 @@
 # Chapter 4. Simple Key-Value 명령
 
-ARCUS Cache Server는 memcached 1.4의 key-value 명령을 그대로 지원하며, 
+ARCUS Cache Server는 memcached 1.4의 key-value 명령을 그대로 지원하며,
 이에 추가하여 incr/decr 명령은 그 기능을 확장 지원한다.
 
 Simple key-value 명령들의 요약은 아래와 같다.

--- a/doc/ch05-command-list-collection.md
+++ b/doc/ch05-command-list-collection.md
@@ -57,7 +57,7 @@ lop insert <key> <index> <bytes> [create <attributes>] [noreply|pipe]\r\n<data>\
 pipe 사용은 [Command Pipelining](ch09-command-pipelining.md)을 참조 바란다.
 - \<data\> - 삽입할 데이터 (최대 크기는 [기본제약사항](ch01-arcus-basic-concept.md#기본-제약-사항)을 참고)
 
- 
+
 Response string과 그 의미는 아래와 같다.
 
 | Response String                          | 설명                     |
@@ -139,13 +139,13 @@ END|DELETED|DELETED_DROPPED\r\n
 
 | Response String                                        | 설명                     |
 |--------------------------------------------------------|------------------------ |
-| “NOT_FOUND”	                                           | key miss
-| “NOT_FOUND_ELEMENT”	                                   | element miss (index or index range에 해당하는 element가 없음)
-| “TYPE_MISMATCH”	                                       | 해당 item이 list collection이 아님
+| “NOT_FOUND”                                            | key miss
+| “NOT_FOUND_ELEMENT”                                    | element miss (index or index range에 해당하는 element가 없음)
+| “TYPE_MISMATCH”                                        | 해당 item이 list collection이 아님
 | “UNREADABLE”                                           | 해당 item이 unreadable item임
 | "NOT_SUPPORTED"                                        | 지원하지 않음
 | “CLIENT_ERROR bad command line format”                 | protocol syntax 틀림
-| "SERVER_ERROR out of memory [writing get response]”	   | 메모리 부족
+| "SERVER_ERROR out of memory [writing get response]”    | 메모리 부족
 
 <!-- reference list -->
 [item-attribute]: ch03-item-attributes.md "Chapter 3. Item Attribute 설명"

--- a/doc/ch06-command-set-collection.md
+++ b/doc/ch06-command-set-collection.md
@@ -5,7 +5,7 @@ Set collection에 관한 명령은 아래와 같다.
 - [Set collection 생성: sop create](ch06-command-set-collection.md#sop-create-set-collection-생성)
 - Set collection 삭제: delete (기존 key-value item의 삭제 명령을 그대로 사용)
 
-Set element에 관한 명령은 아래와 같다. 
+Set element에 관한 명령은 아래와 같다.
 
 - [Set element 삽입: sop insert](ch06-command-set-collection.md#sop-insert-set-element-삽입)
 - [Set element 삭제: sop delete](ch06-command-set-collection.md#sop-delete-set-element-삭제)
@@ -114,7 +114,7 @@ sop get <key> <count> [delete|drop]\r\n
 그리고 delete로 인해 empty set이 될 경우 그 set을 drop할 것인지를 지정한다.
 
 성공 시의 response string은 아래와 같다.
-VALUE 라인의 \<count\>는 조회된 element 개수를 의미한다. 
+VALUE 라인의 \<count\>는 조회된 element 개수를 의미한다.
 마지막 라인은 END, DELETED, DELETED_DROPPED 중의 하나를 가지며
 각각 element 조회만 수행한 상태, element 조회하고 삭제한 상태,
 element 조회 및 삭제하고 set을 drop한 상태를 의미한다.
@@ -132,13 +132,13 @@ END|DELETED|DELETED_DROPPED\r\n
 
 | Response String                                      | 설명                    |
 |------------------------------------------------------|------------------------ |
-| "NOT_FOUND"	                                         | key miss
-| "NOT_FOUND_ELEMENT"	                                 | element miss (element가 존재하지 않는 상태임)
-| "TYPE_MISMATCH"	                                     | 해당 item이 set collection이 아님
+| "NOT_FOUND"                                          | key miss
+| "NOT_FOUND_ELEMENT"                                  | element miss (element가 존재하지 않는 상태임)
+| "TYPE_MISMATCH"                                      | 해당 item이 set collection이 아님
 | "UNREADABLE"                                         | 해당 item이 unreadable item임
 | "NOT_SUPPORTED"                                      | 지원하지 않음
 | "CLIENT_ERROR bad command line format"               | protocol syntax 틀림
-| "SERVER_ERROR out of memory [writing get response]"	 | 메모리 부족
+| "SERVER_ERROR out of memory [writing get response]"  | 메모리 부족
 
 ## sop exist (Set Element 존재유무 검사)
 
@@ -159,12 +159,10 @@ Response string과 그 의미는 아래와 같다.
 |------------------------------------------|------------------------ |
 | "EXIST"                                  | 성공 (주어진 데이터가 set에 존재)
 | "NOT_EXIST"                              | 성공 (주어진 데이터가 set에 존재하지 않음)
-| "NOT_FOUND"	                             | key miss
-| "TYPE_MISMATCH"	                         | 해당 item이 set collection이 아님
+| "NOT_FOUND"                              | key miss
+| "TYPE_MISMATCH"                          | 해당 item이 set collection이 아님
 | "UNREADABLE"                             | 해당 item이 unreadable item임
 | "NOT_SUPPORTED"                          | 지원하지 않음
 | "CLIENT_ERROR bad command line format"   | protocol syntax 틀림
 | "CLIENT_ERROR too large value"           | 주어진 데이터가 element value의 최대 크기보다 큼
 | "CLIENT_ERROR bad data chunk"            | 주어진 데이터의 길이가 \<bytes\>와 다르거나 “\r\n”으로 끝나지 않음
- 
-

--- a/doc/ch07-command-map-collection.md
+++ b/doc/ch07-command-map-collection.md
@@ -5,7 +5,7 @@ Map collection에 관한 명령은 아래와 같다.
 - [Map collection 생성: mop create](ch07-command-map-collection.md#mop-create-map-collection-생성)
 - Map collection 삭제: delete (기존 key-value item의 삭제 명령을 그대로 사용)
 
-Map element에 관한 명령은 아래와 같다. 
+Map element에 관한 명령은 아래와 같다.
 
 - [Map element 삽입: mop insert](ch07-command-map-collection.md#mop-insert-map-element-삽입)
 - [Map element 변경: mop update](ch07-command-map-collection.md#mop-update-map-element-변경)
@@ -149,7 +149,7 @@ mop get <key> <lenfields> <numfields> [delete|drop]\r\n
 그리고 delete로 인해 empty map이 될 경우 그 map을 drop할 것인지를 지정한다.
 
 성공 시의 response string은 아래와 같다.
-VALUE 라인의 \<count\>는 조회된 field 개수를 의미한다. 
+VALUE 라인의 \<count\>는 조회된 field 개수를 의미한다.
 마지막 라인은 END, DELETED, DELETED_DROPPED 중의 하나를 가지며
 각각 field 조회만 수행한 상태, field 조회하고 삭제한 상태,
 field 조회 및 삭제하고 map을 drop한 상태를 의미한다.
@@ -173,5 +173,4 @@ END|DELETED|DELETED_DROPPED\r\n
 | "UNREADABLE"                                         | 해당 item이 unreadable item임
 | "NOT_SUPPORTED"                                      | 지원하지 않음
 | "CLIENT_ERROR bad command line format"               | protocol syntax 틀림
-| "SERVER_ERROR out of memory [writing get response]"	 | 메모리 부족
-
+| "SERVER_ERROR out of memory [writing get response]" | 메모리 부족

--- a/doc/ch08-command-btree-collection.md
+++ b/doc/ch08-command-btree-collection.md
@@ -385,7 +385,7 @@ flags와 ecount를 포함하여 조회된 element 정보가 생략된다.
 |-------------------------------------------------------|------------------------ |
 | "NOT_SUPPORTED"                                       | 지원하지 않음
 | "CLIENT_ERROR bad command line format"                | protocol syntax 틀림
-| "CLIENT_ERROR bad data chunk"	                        | space separated key list의 길이가 \<lenkeys\>와 다르거나 “\r\n”으로 끝나지 않음
+| "CLIENT_ERROR bad data chunk"                         | space separated key list의 길이가 \<lenkeys\>와 다르거나 “\r\n”으로 끝나지 않음
 | "CLIENT_ERROR bad value"                              | bop mget 명령의 제약 조건을 위배함.
 | "SERVER_ERROR out of memory [writing get response]"   | 메모리 부족
 
@@ -536,7 +536,7 @@ smget 수행의 실패 시의 response string은 다음과 같다.
 | "OUT_OF_RANGE"                                       | 기존 smget 동작에서만 발생할 수 있는 실패 response string이다.
 | "NOT_SUPPORTED"                                      | 지원하지 않음
 | "CLIENT_ERROR bad command line format"               | protocol syntax 틀림
-| "CLIENT_ERROR bad data chunk"	                       | 주어진 key 리스트에 중복 key가 존재하거나 주어진 key 리스트의 길이가 \<lenkeys\> 길이와 다르거나 "\r\n"으로 끝나지 않음.
+| "CLIENT_ERROR bad data chunk"                        | 주어진 key 리스트에 중복 key가 존재하거나 주어진 key 리스트의 길이가 \<lenkeys\> 길이와 다르거나 "\r\n"으로 끝나지 않음.
 | "CLIENT_ERROR bad value"                             | 앞서 기술한 smget 연산의 제약 조건을 위배
 | "SERVER_ERROR out of memory [writing get response"   | 메모리 부족
 
@@ -664,4 +664,3 @@ END\r\n
 | "NOT_SUPPORTED"                                     | 지원하지 않음
 | "CLIENT_ERROR bad command line format"              | protocol syntax 틀림
 | "SERVER_ERROR out of memory [writing get response]" | 메모리 부족
-

--- a/doc/ch09-command-pipelining.md
+++ b/doc/ch09-command-pipelining.md
@@ -17,11 +17,11 @@ Command pipelining 가능한 명령은 아래와 같으며, 단순 response stri
 * sop 명령들 - sop insert/delete/exist
 * mop 명령들 - mop insert/delete/update
 * bop 명령들 - bop insert/upsert/delete/update/incr/decr
- 
+
 Command pipelining 수행 예로,
 특정 list의 tail 쪽으로 10개 elements를 추가하고자 한다면,
 아래와 같이 lop insert 명령을 연속하여 cache server로 보내면 된다.
-첫 번째 명령부터 마지막 바로 이전 명령까지는 모두 “pipe” 인자를 사용하여 연결하여야 하고, 
+첫 번째 명령부터 마지막 바로 이전 명령까지는 모두 “pipe” 인자를 사용하여 연결하여야 하고,
 마지막 명령에서는 “pipe” 인자를 생략함으로써 pipelining의 끝임을 표현하여야 한다.
 
 ```
@@ -54,7 +54,7 @@ RESPONSE 라인에서 \<count\>는 전체 결과 수를 나타내고,
 마지막 라인은 pipelining 수행 상태를 나타내며, 아래 중의 하나를 가진다.
 
 - "END" - pipelining 연산이 정상 수행됨
-- “PIPE_ERROR command overflow”	- pipelining 가능한 최대 commands 수인 500개를 초과하였다.
+- “PIPE_ERROR command overflow” - pipelining 가능한 최대 commands 수인 500개를 초과하였다.
   이 경우, 500개까지의 command들만 하나의 command pipelining으로 처리되고 하나의 response stream으로 리턴된다.
   그 이후의 commands들은 처리되지 않는다.
 - “PIPE_ERROR memory overflow” - ARCUS cache server 내부에서 pipelining 처리를 위한

--- a/doc/ch10-command-item-attribute.md
+++ b/doc/ch10-command-item-attribute.md
@@ -59,5 +59,3 @@ setattr <key> <name>=<value> [<name>=<value> ...]\r\n
 | "ATTR_ERROR not found"                  | 인자로 지정한 attribute가 존재하지 않거나 해당 item 유형에서 지원되지 않는 attribute임.
 | "ATTR_ERROR bad value"                  | 해당 attribute에 대해 새로 변경하고자 하는 value가 allowed value가 아님.
 | "CLIENT_ERROR bad command line format"  | protocol syntax 틀림
-
-

--- a/doc/ch12-command-administration.md
+++ b/doc/ch12-command-administration.md
@@ -17,7 +17,7 @@ ARCUS Cache Server는 items을 invalidate 시키기 위한 두 가지 flush 명�
 - flush_all : 모든 items을 flush
 - flush_prefix: 특정 prefix의 items들만 flush
 
-Flush 작업은 items을 invalidate시키더라도 그 items이 차지한 메모리 공간을 즉각 반환하지 않는다. 
+Flush 작업은 items을 invalidate시키더라도 그 items이 차지한 메모리 공간을 즉각 반환하지 않는다.
 대신, ARCUS Cache Server의 global 정보로 flush 수행 시점 정보를 기록해 둠으로써,
 그 시점 이전에 존재했던 items은 invalidated items이라는 것을 알 수 있게 한다.
 따라서, item 접근할 때마다 invalidated item인지를 확인하여야 하는 부담이 있지만,
@@ -47,7 +47,7 @@ Response string과 그 의미는 아래와 같다.
 |-----------------------------------------|------------------------ |
 | "OK"                                    | 성공
 | "NOT_FOUND"                             | prefix miss (flush_prefix 명령인 경우만 해당)
-| "CLIENT_ERROR bad command line format"	| protocol syntax 틀림
+| "CLIENT_ERROR bad command line format"  | protocol syntax 틀림
 
 ## Scrub 명령
 
@@ -288,7 +288,7 @@ END
   - \<collection_name\>_\<command_name\>_elem_hits: 콜렉션 명령의 key hit 그리고 element hit 횟수
   - \<collection_name\>_\<command_name\>_none_hits: 콜렉션 명령의 key hit 그러나 element miss 횟수
 
-다음은 그 외의 개별 통계이다. 
+다음은 그 외의 개별 통계이다.
 
 | stats                 | 설명                                                         |
 | --------------------- | ------------------------------------------------------------ |
@@ -540,14 +540,14 @@ PREFIX <null> get 2 hit 2 set 2 del 0
        bcs 0 bis 0 bih 0 bus 0 buh 0 bds 0 bdh 0 bps 0 bph 0 bms 0 bmh 0 bgs 0 bgh 0 bns 0 bnh 0
        pfs 0 pfh 0 pgs 0 pgh 0
        gas 0 sas 0
-PREFIX a get 5 hit 5 set 5 del 0 
+PREFIX a get 5 hit 5 set 5 del 0
        lcs 0 lis 0 lih 0 lds 0 ldh 0 lgs 0 lgh 0
        scs 0 sis 0 sih 0 sds 0 sdh 0 sgs 0 sgh 0 ses 0 seh 0
        mcs 0 mis 0 mih 0 mus 0 muh 0 mds 0 mdh 0 mgs 0 mgh 0
        bcs 0 bis 0 bih 0 bus 0 buh 0 bds 0 bdh 0 bps 0 bph 0 bms 0 bmh 0 bgs 0 bgh 0 bns 0 bnh 0
        pfs 0 pfh 0 pgs 0 pgh 0
        gas 0 sas 0
-PREFIX b get 2 hit 2 set 2 del 0 
+PREFIX b get 2 hit 2 set 2 del 0
        lcs 0 lis 0 lih 0 lds 0 ldh 0 lgs 0 lgh 0
        scs 0 sis 0 sih 0 sds 0 sdh 0 sgs 0 sgh 0 ses 0 seh 0
        mcs 0 mis 0 mih 0 mus 0 muh 0 mds 0 mdh 0 mgs 0 mgh 0
@@ -645,8 +645,8 @@ slab class 별 LRU에 달려있는 item들의 cache key들을 dump하기 위하�
 stats cachedump <slab_clsid> <limit> [ forward | backward [sticky] ]\r\n
 ```
 
-- \<slab_clsid\>	- dump 대상 LRU를 지정하기 위한 slab class id이다.
-- \<limit\>	- dump하고자 하는 item 개수로서 0 ~ 200 범위에서 지정이 가능하다.
+- \<slab_clsid\> - dump 대상 LRU를 지정하기 위한 slab class id이다.
+- \<limit\> - dump하고자 하는 item 개수로서 0 ~ 200 범위에서 지정이 가능하다.
 0이면 default로 50개로 지정되며, 200 초과이면 200개만 dump한다.
 해당 LRU의 head 또는 tail에서 시작하여 limit 개 item들의 cache key들을 dump한다.
 - forward or backward - LRU의 head 또는 tail 중에 어디에서 dump를 시작할 것인지를 지정한다.
@@ -689,19 +689,19 @@ STAT current_command_log_filesize_bytes 65555
 END
 ```
 
-- use_persistence - 현재 Persistence 모드가 on인지 off인지 나타낸다.   
-- data_path - 스냅샷 파일이 생성되는 경로를 나타낸다.   
-- logs_path - 명령 로그 파일이 생성되는 경로를 나타낸다.   
-- async_logging - 명령 로깅의 동작 모드로 동기 로깅 모드면 false, 비동기 로깅 모드면 true로 나타낸다.   
-- chkpt_interval_pct_snapshot - 체크포인트 수행 주기 설정으로, 스냅샷 파일 크기에 대비하여 명령 로그 파일의 추가 증가된 크기 비율을 나타낸다.   
-- chkpt_interval_min_logsize - 체크포인트 수행 주기 설정으로, 체크포인트를 수행할 명령 로그 파일의 최소 크기를 나타낸다.   
-- recovery_elapsed_time_sec - ARCUS 인스턴스 재구동 후, 데이터를 복구하는데 걸리는 시간을 나타낸다. (unit : seconds)   
-- last_chkpt_in_progress - 현재 체크포인트의 수행 여부를 나타낸다.   
-- last_chkpt_failure_count - 이전 체크포인트가 수행되거나 성공될 때까지 몇 번 실패한 것인지를 나타낸다.   
-- last_chkpt_start_time - 이전 체크포인트가 조건이 충족되어 시작한 시간을 나타낸다. (unit : absolute timestamp)   
-- last_chkpt_elapsed_time_sec - 이전 체크포인트 수행하는데 걸린 시간을 나타낸다. (unit : seconds)   
-- last_chkpt_snapshot_filesize_bytes - 이전 체크포인트 스냅샷 파일 크기를 나타낸다. (unit : bytes)   
-- current_command_log_filesize_bytes - 현재 명령 로그 파일 크기를 나타낸다. (unit : bytes)   
+- use_persistence - 현재 Persistence 모드가 on인지 off인지 나타낸다.
+- data_path - 스냅샷 파일이 생성되는 경로를 나타낸다.
+- logs_path - 명령 로그 파일이 생성되는 경로를 나타낸다.
+- async_logging - 명령 로깅의 동작 모드로 동기 로깅 모드면 false, 비동기 로깅 모드면 true로 나타낸다.
+- chkpt_interval_pct_snapshot - 체크포인트 수행 주기 설정으로, 스냅샷 파일 크기에 대비하여 명령 로그 파일의 추가 증가된 크기 비율을 나타낸다.
+- chkpt_interval_min_logsize - 체크포인트 수행 주기 설정으로, 체크포인트를 수행할 명령 로그 파일의 최소 크기를 나타낸다.
+- recovery_elapsed_time_sec - ARCUS 인스턴스 재구동 후, 데이터를 복구하는데 걸리는 시간을 나타낸다. (unit : seconds)
+- last_chkpt_in_progress - 현재 체크포인트의 수행 여부를 나타낸다.
+- last_chkpt_failure_count - 이전 체크포인트가 수행되거나 성공될 때까지 몇 번 실패한 것인지를 나타낸다.
+- last_chkpt_start_time - 이전 체크포인트가 조건이 충족되어 시작한 시간을 나타낸다. (unit : absolute timestamp)
+- last_chkpt_elapsed_time_sec - 이전 체크포인트 수행하는데 걸린 시간을 나타낸다. (unit : seconds)
+- last_chkpt_snapshot_filesize_bytes - 이전 체크포인트 스냅샷 파일 크기를 나타낸다. (unit : bytes)
+- current_command_log_filesize_bytes - 현재 명령 로그 파일 크기를 나타낸다. (unit : bytes)
 
 ## Config 명령
 
@@ -861,7 +861,7 @@ The log file name: /Users/temp/command_11211_20160126_192729_{n}.log //path/file
 
 ARCUS Cache Server에서 collection item에 대한 요청 중에는 그 처리 시간이 오래 걸리는 요청이 존재한다.
 이를 detect하기 위한 기능으로 lqdetect 명령을 제공한다.
-start 명령을 시작으로 detection이 종료될 때 까지 long query 가능성이 있는 command에 대하여, 
+start 명령을 시작으로 detection이 종료될 때 까지 long query 가능성이 있는 command에 대하여,
 그 command 처리에서 접근한 elements 수가 특정 기준 이상인 command를 추출,
 command 별로 detect된 명령어 20개를 샘플로 저장한다.
 long query 대상이 되는 모든 command에 대해 20개의 샘플 저장이 완료되면 자동 종료한다.
@@ -925,7 +925,7 @@ stats 명령은 가장 최근 수행된(수행 중인) long query detection의 �
 ```
 Long query detection stats : running              //stopped by causes(request or overflow) | running
 The last running time : 20160126_175629 ~ 0_0     //bgndate_bgntime ~ enddate_endtime
-The number of total long query commands : 1152    //detected_commands 
+The number of total long query commands : 1152    //detected_commands
 The detection threshold : 43                      //threshold
 ```
 
@@ -972,7 +972,7 @@ DUMP SUMMARY: { prefix=<prefix>, count=<count>, total=<total> elapsed=<elapsed> 
 위의 결과에서 각 의미는 아래와 같다.
 - key dump 결과 부분
   - \<type\>은 item type으로 1 character로 표시한다.
-     - "K" : kv 
+     - "K" : kv
      - "L" : list
      - "S" : set
      - "M" : map

--- a/doc/compilation_faq.md
+++ b/doc/compilation_faq.md
@@ -8,7 +8,7 @@
     (OSX)    brew install autoconf automake libtool pkg-config cppunit
     ```
   - Install libevent
-  
+
     ```
     $ wget https://github.com/downloads/libevent/libevent/libevent-2.0.21-stable.tar.gz
     $ tar xfz libevent-2.0.21-stable.tar.gz
@@ -45,7 +45,7 @@
   # Install CPAN
   (CentOS) sudo yum install cpan
   (Ubuntu) sudo apt-get install libpath-tiny-perl
-  
+
   # Install Test::More
   cpan Test::More
   ```

--- a/t/whitespace.t
+++ b/t/whitespace.t
@@ -11,7 +11,6 @@ BEGIN {
     push(@exempted, glob("ChangeLog*"));
     push(@exempted, glob("README.md*"));
     push(@exempted, glob("CONTRIBUTING.md*"));
-    push(@exempted, glob("doc/*.md"));
     push(@exempted, glob("doc/*.xml"));
     push(@exempted, glob("doc/xml2rfc/*.xsl"));
     push(@exempted, glob("m4/*backport*m4"));


### PR DESCRIPTION
- #697 

- `t/whitespace.t` 예외 대상에서 `doc/*.md`를 제외합니다.
(== 마크다운 문서를 whitespace 테스트 대상에 포함시킵니다.)

- 기존 문서를 whitespace 테스트에 통과하도록 변경합니다.