### PR TITLE
FEATURE: Add ready command

### DIFF
--- a/arcus_zk.c
+++ b/arcus_zk.c
@@ -1833,6 +1833,7 @@ void arcus_zk_get_confs(arcus_zk_confs *confs)
 void arcus_zk_get_stats(arcus_zk_stats *stats)
 {
     stats->zk_connected = (main_zk != NULL && main_zk->zh != NULL) ? true : false;
+    stats->zk_ready = arcus_conf.znode_created && !sm_info.mc_pause;
 #ifdef ENABLE_ZK_RECONFIG
     stats->zk_reconfig_needed = zk_reconfig.needed;
     stats->zk_reconfig_enabled = zk_reconfig.enabled;

--- a/arcus_zk.h
+++ b/arcus_zk.h
@@ -32,6 +32,7 @@ typedef struct {
 
 typedef struct {
     bool     zk_connected;  // ZooKeeper-memcached connection state
+    bool     zk_ready;      // cache-list znode created?
 #ifdef ENABLE_ZK_RECONFIG
     bool     zk_reconfig_needed;  // ZK dynamic reconfig is needed?
     bool     zk_reconfig_enabled; // ZK dynamic reconfig enabled in ZK?

--- a/memcached.c
+++ b/memcached.c
@@ -8174,6 +8174,7 @@ static void process_stats_zookeeper(ADD_STAT add_stats, void *c)
     APPEND_STAT("zk_timeout", "%u", zk_confs.zk_timeout);
     APPEND_STAT("zk_failstop", "%s", zk_confs.zk_failstop ? "on" : "off");
     APPEND_STAT("zk_connected", "%s", zk_stats.zk_connected ? "true" : "false");
+    APPEND_STAT("zk_ready", "%s", zk_stats.zk_ready ? "true" : "false");
 #ifdef ENABLE_ZK_RECONFIG
     APPEND_STAT("zk_reconfig_needed", "%s", zk_stats.zk_reconfig_needed ? "on" : "off");
     if (zk_stats.zk_reconfig_needed) {
@@ -13240,6 +13241,18 @@ static void process_command_ascii(conn *c, char *command, int cmdlen)
         process_lqdetect_command(c, tokens, ntokens);
     }
 #endif
+    else if ((ntokens == 2) && (strcmp(tokens[COMMAND_TOKEN].value, "ready") == 0))
+    {
+        char *response = "READY";
+#ifdef ENABLE_ZK_INTEGRATION
+        if (arcus_zk_cfg) {
+            arcus_zk_stats zk_stats;
+            arcus_zk_get_stats(&zk_stats);
+            if (!zk_stats.zk_ready) response = "NOT_READY";
+        }
+#endif
+        out_string(c, response);
+    }
     else /* no matching command */
     {
         if (settings.extensions.ascii != NULL) {


### PR DESCRIPTION
- jam2in/arcus-operator#49

### 변경사항
- `arcus_zk_stats` 구조체에 `bool zk_znode_created` 필드를 추가합니다.
  - `stats zookeeper` 결과에 `zk_znode_created`를 추가합니다.

- `ready` 명령을 추가합니다. 응답은 `READY` 또는 `NOT_READY` 입니다.
  해당 서버가 외부로부터 요청을 받아 처리할 수 있는 상태인지 확인합니다.
  - `--enable-zk-integration` flag 없이 컴파일 => 항상 `READY`

  - `--enable-zk-integration` flag 포함하여 컴파일
    - `arcus_zk_cfg`가 NULL인 경우(`-z` option 없이 구동된 경우) `READY`
    - cache_list znode 생성 여부에 따라 `READY` 또는 `NOT_READY`

### 기타
arcus_zk.c의 `azk_stat`은 현재 사용되지 않는 변수인 것 같습니다.
https://github.com/naver/arcus-memcached/blob/399c36896cdcf578a12accc0d9b94426c3485049/arcus_zk.c#L198-L199