### PR TITLE
DOC: Use English headers for stable links

### DIFF
--- a/doc/ch01-arcus-basic-concept.md
+++ b/doc/ch01-arcus-basic-concept.md
@@ -4,7 +4,7 @@ ARCUS Cache Server는 하나의 데이터만을 value로 가지는 simple key-va
 여러 데이터를 구조화된 형태로 저장하는 collection을 하나의 value로 가지는
 확장된 key-value 데이터 모델을 제공한다.
 
-## 기본 제약 사항
+## Basic constraints
 
 ARCUS Cache Server의 key-value 모델은 아래의 기본 제약 사항을 가진다.
 
@@ -130,4 +130,4 @@ stale 데이터 노출 관점
 - Automatic scrub 작업은 모든 캐시 데이터를 순차 접근하여 stale 여부를 검사하므로, 일정 시간이 소요된다.
 하지만, Automatic scrub 작업의 완료 전에 새로 추가된 캐시 노드가 다운되는 경우는 극히 드물다.
 
-참고로 명시적으로 수행할 수 있는 `scrub stale` 명령을 제공하고 있다. [Scrub 명령](ch12-command-administration.md#scrub-명령)
+참고로 명시적으로 수행할 수 있는 `scrub stale` 명령을 제공하고 있다. [Scrub 명령](ch12-command-administration.md#scrub)

--- a/doc/ch05-command-list-collection.md
+++ b/doc/ch05-command-list-collection.md
@@ -2,16 +2,16 @@
 
 List collection에 관한 명령은 아래와 같다.
 
-- [List collection 생성: lop create](ch05-command-list-collection.md#lop-create-list-collection-생성)
+- [List collection 생성: lop create](#lop-create)
 - List collection 삭제: delete (기존 key-value item의 삭제 명령을 그대로 사용)
 
 List element에 관한 명령은 아래와 같다.
 
-- [List element 삽입: lop insert](ch05-command-list-collection.md#lop-insert-list-element-삽입)
-- [List element 삭제: lop delete](ch05-command-list-collection.md#lop-delete-list-element-삭제)
-- [List element 조회: lop get](ch05-command-list-collection.md#lop-get-list-element-조회)
+- [List element 삽입: lop insert](#lop-insert)
+- [List element 삭제: lop delete](#lop-delete)
+- [List element 조회: lop get](#lop-get)
 
-## lop create (List Collection 생성)
+## lop create
 
 List collection을 empty 상태로 생성한다.
 
@@ -35,7 +35,7 @@ Response string과 그 의미는 아래와 같다.
 | “CLIENT_ERROR bad command line format” | protocol syntax 틀림
 | “SERVER_ERROR out of memory”           | 메모리 부족
 
-## lop insert (List Element 삽입)
+## lop insert
 
 List collection에 하나의 element를 삽입한다.
 List collection을 생성하면서 하나의 element를 삽입할 수도 있다.
@@ -55,7 +55,7 @@ lop insert <key> <index> <bytes> [create <attributes>] [noreply|pipe]\r\n<data>\
   - unreadable - 명시하면, readable 속성은 off로 설정됩니다.
 - noreply or pipe - 명시하면, response string을 전달받지 않는다.
 pipe 사용은 [Command Pipelining](ch09-command-pipelining.md)을 참조 바란다.
-- \<data\> - 삽입할 데이터 (최대 크기는 [기본제약사항](ch01-arcus-basic-concept.md#기본-제약-사항)을 참고)
+- \<data\> - 삽입할 데이터 (최대 크기는 [기본제약사항](ch01-arcus-basic-concept.md#basic-constraints)을 참고)
 
 
 Response string과 그 의미는 아래와 같다.
@@ -74,7 +74,7 @@ Response string과 그 의미는 아래와 같다.
 | “CLIENT_ERROR bad data chunk”            | 삽입할 데이터 길이가 \<bytes\>와 다르거나 "\r\n"으로 끝나지 않음
 | “SERVER_ERROR out of memory”             | 메모리 부족
 
-## lop delete (List Element 삭제)
+## lop delete
 
 List collection에 하나의 index 또는 index range에 해당하는 elements를 삭제한다.
 
@@ -107,7 +107,7 @@ Response string과 그 의미는 아래와 같다.
 | "NOT_SUPPORTED"                          | 지원하지 않음
 | “CLIENT_ERROR bad command line format”   | protocol syntax 틀림
 
-## lop get (List Element 조회)
+## lop get
 
 List collection에 하나의 index 또는 index range에 해당하는 elements를 조회한다.
 

--- a/doc/ch06-command-set-collection.md
+++ b/doc/ch06-command-set-collection.md
@@ -2,17 +2,17 @@
 
 Set collection에 관한 명령은 아래와 같다.
 
-- [Set collection 생성: sop create](ch06-command-set-collection.md#sop-create-set-collection-생성)
+- [Set collection 생성: sop create](#sop-create)
 - Set collection 삭제: delete (기존 key-value item의 삭제 명령을 그대로 사용)
 
 Set element에 관한 명령은 아래와 같다.
 
-- [Set element 삽입: sop insert](ch06-command-set-collection.md#sop-insert-set-element-삽입)
-- [Set element 삭제: sop delete](ch06-command-set-collection.md#sop-delete-set-element-삭제)
-- [Set element 조회: sop get](ch06-command-set-collection.md#sop-get-set-element-조회)
-- [Set element 존재유무 검사: sop exist](ch06-command-set-collection.md#sop-exist-set-element-존재유무-검사)
+- [Set element 삽입: sop insert](#sop-insert)
+- [Set element 삭제: sop delete](#sop-delete)
+- [Set element 조회: sop get](#sop-get)
+- [Set element 존재유무 검사: sop exist](#sop-exist)
 
-## sop create (Set Collection 생성)
+## sop create
 
 Set collection을 empty 상태로 생성한다.
 
@@ -36,7 +36,7 @@ Response string과 그 의미는 아래와 같다.
 | "CLIENT_ERROR bad command line format"   | protocol syntax 틀림
 | "SERVER_ERROR out of memory"             | 메모리 부족
 
-## sop insert (Set Element 삽입)
+## sop insert
 
 Set collection에 하나의 element를 삽입한다.
 Set collection을 생성하면서 하나의 element를 삽입할 수도 있다.
@@ -53,7 +53,7 @@ sop insert <key> <bytes> [create <attributes>] [noreply|pipe]\r\n<data>\r\n
   - unreadable - 명시하면, readable 속성은 off로 설정됩니다.
 - noreply or pipe - 명시하면, response string을 전달받지 않는다.
 pipe 사용은 [Command Pipelining](ch09-command-pipelining.md)을 참조 바란다.
-- \<data\> - 삽입할 데이터 (최대 크기는 [기본제약사항](ch01-arcus-basic-concept.md#기본-제약-사항)을 참고)
+- \<data\> - 삽입할 데이터 (최대 크기는 [기본제약사항](ch01-arcus-basic-concept.md#basic-constraints)을 참고)
 
 Response string과 그 의미는 아래와 같다.
 
@@ -71,7 +71,7 @@ Response string과 그 의미는 아래와 같다.
 | "CLIENT_ERROR bad data chunk"            | 삽입할 데이터 길이가 \<bytes\>와 다르거나 "\r\n"으로 끝나지 않음
 | "SERVER_ERROR out of memory"             | 메모리 부족
 
-## sop delete (Set Element 삭제)
+## sop delete
 
 Set collection에서 하나의 element를 삭제한다.
 
@@ -100,7 +100,7 @@ Response string과 그 의미는 아래와 같다.
 | "CLIENT_ERROR too large value"          | 삭제할 데이터가 element value의 최대 크기보다 큼
 | "CLIENT_ERROR bad data chunk"           | 삭제할 데이터의 길이가 \<bytes\>와 다르거나 “\r\n”으로 끝나지 않음
 
-## sop get (Set Element 조회)
+## sop get
 
 Set collection에서 N 개의 elements를 조회한다.
 
@@ -140,7 +140,7 @@ END|DELETED|DELETED_DROPPED\r\n
 | "CLIENT_ERROR bad command line format"               | protocol syntax 틀림
 | "SERVER_ERROR out of memory [writing get response]"  | 메모리 부족
 
-## sop exist (Set Element 존재유무 검사)
+## sop exist
 
 Set collection에 특정 element의 존재 유무를 검사한다.
 

--- a/doc/ch07-command-map-collection.md
+++ b/doc/ch07-command-map-collection.md
@@ -2,17 +2,17 @@
 
 Map collection에 관한 명령은 아래와 같다.
 
-- [Map collection 생성: mop create](ch07-command-map-collection.md#mop-create-map-collection-생성)
+- [Map collection 생성: mop create](#mop-create)
 - Map collection 삭제: delete (기존 key-value item의 삭제 명령을 그대로 사용)
 
 Map element에 관한 명령은 아래와 같다.
 
-- [Map element 삽입: mop insert](ch07-command-map-collection.md#mop-insert-map-element-삽입)
-- [Map element 변경: mop update](ch07-command-map-collection.md#mop-update-map-element-변경)
-- [Map element 삭제: mop delete](ch07-command-map-collection.md#mop-delete-map-element-삭제)
-- [Map element 조회: mop get](ch07-command-map-collection.md#mop-get-map-field-element-조회)
+- [Map element 삽입: mop insert](#mop-insert)
+- [Map element 변경: mop update](#mop-update)
+- [Map element 삭제: mop delete](#mop-delete)
+- [Map element 조회: mop get](#mop-get)
 
-## mop create (Map Collection 생성)
+## mop create
 
 Map collection을 empty 상태로 생성한다.
 
@@ -36,7 +36,7 @@ Response string과 그 의미는 아래와 같다.
 | "CLIENT_ERROR bad command line format" | protocol syntax 틀림
 | "SERVER_ERROR out of memory"           | 메모리 부족
 
-## mop insert (Map Element 삽입)
+## mop insert
 
 Map collection에 하나의 field, element를 삽입한다.
 Map collection을 생성하면서 \<field, value\>로 구성된 하나의 element를 삽입할 수도 있다.
@@ -54,7 +54,7 @@ mop insert <key> <field> <bytes> [create <attributes>] [noreply|pipe]\r\n<data>\
   - unreadable - 명시하면, readable 속성은 off로 설정됩니다.
 - noreply or pipe - 명시하면, response string을 전달받지 않는다.
 pipe 사용은 [Command Pipelining](ch09-command-pipelining.md)을 참조 바란다.
-- \<data\> - 삽입할 데이터 (최대 크기는 [기본제약사항](ch01-arcus-basic-concept.md#기본-제약-사항)을 참고)
+- \<data\> - 삽입할 데이터 (최대 크기는 [기본제약사항](ch01-arcus-basic-concept.md#basic-constraints)을 참고)
 
 Response string과 그 의미는 아래와 같다.
 
@@ -73,7 +73,7 @@ Response string과 그 의미는 아래와 같다.
 | "CLIENT_ERROR invalid prefix name"      | 유효하지(존재하지) 않는 prefix 명
 | "SERVER_ERROR out of memory"            | 메모리 부족
 
-## mop update (Map Element 변경)
+## mop update
 
 Map collection에서 하나의 field에 대해 element 변경을 수행한다.
 현재 다수 field에 대한 변경연산은 제공하지 않는다.
@@ -103,7 +103,7 @@ Response string과 그 의미는 아래와 같다.
 | "CLIENT_ERROR bad data chunk"            | 삽입할 데이터 길이가 \<bytes\>와 다르거나 "\r\n"으로 끝나지 않음
 | "SERVER_ERROR out of memory"             | 메모리 부족
 
-## mop delete (Map Element 삭제)
+## mop delete
 
 Map collection에서 하나 이상의 field 이름을 주어, 그에 해당하는 element를 삭제한다.
 
@@ -132,7 +132,7 @@ Response string과 그 의미는 아래와 같다.
 | "NOT_SUPPORTED"                         | 지원하지 않음
 | "CLIENT_ERROR bad command line format"  | protocol syntax 틀림
 
-## mop get (Map Field, Element 조회)
+## mop get
 
 Map collection에서 하나 이상의 field 이름을 주어, 그에 해당하는 element를 조회한다.
 

--- a/doc/ch08-command-btree-collection.md
+++ b/doc/ch08-command-btree-collection.md
@@ -2,22 +2,22 @@
 
 B+tree collection에 관한 명령은 아래와 같다.
 
-- [B+tree collection 생성: bop create](ch08-command-btree-collection.md#bop-create-btree-collection-%EC%83%9D%EC%84%B1)
+- [B+tree collection 생성: bop create](#bop-create)
 - B+tree collection 삭제: delete (기존 key-value item의 삭제 명령을 그대로 사용)
 
 B+tree element에 관한 기본 명령은 아래와 같다.
 
-- [B+tree element 삽입/대체: bop insert/upsert](ch08-command-btree-collection.md#bop-insertupsert-btree-element-삽입대체)
-- [B+tree element 변경: bop update](ch08-command-btree-collection.md#bop-update-btree-element-%EB%B3%80%EA%B2%BD)
-- [B+tree element 삭제: bop delete](ch08-command-btree-collection.md#bop-delete-btree-element-삭제)
-- [B+tree element 조회: bop get](ch08-command-btree-collection.md#bop-get-btree-element-조회)
-- [B+tree element 개수 계산: bop count](ch08-command-btree-collection.md#bop-count-btree-element-개수-계산)
-- [B+tree element 값의 증감: bop incr/decr](ch08-command-btree-collection.md#bop-incrdecr-btree-element-값의-증감)
+- [B+tree element 삽입/대체: bop insert/upsert](#bop-insertupsert)
+- [B+tree element 변경: bop update](#bop-update)
+- [B+tree element 삭제: bop delete](#bop-delete)
+- [B+tree element 조회: bop get](#bop-get)
+- [B+tree element 개수 계산: bop count](#bop-count)
+- [B+tree element 값의 증감: bop incr/decr](#bop-incrdecr)
 
 ARCUS cache server는 다수의 b+tree들에 대한 조회 기능을 특별히 제공하며, 이들은 아래와 같다.
 
-- [하나의 명령으로 여러 b+tree들에 대한 조회를 한번에 수행하는 기능:  bop mget](ch08-command-btree-collection.md#bop-mget-btree-multiple-get)
-- [여러 b+tree들에서 조회 조건을 만족하는 elements를 sort merge하여 최종 결과를 얻는 기능: bop smget](ch08-command-btree-collection.md#bop-smget-btree-sort-merge-get)
+- [하나의 명령으로 여러 b+tree들에 대한 조회를 한번에 수행하는 기능:  bop mget](#bop-mget)
+- [여러 b+tree들에서 조회 조건을 만족하는 elements를 sort merge하여 최종 결과를 얻는 기능: bop smget](#bop-smget)
 
 ARCUS cache server는 bkey 기반의 element 조회 기능 외에도 b+tree position 기반의 element 조회 기능을 제공한다.
 B+tree에서 특정 element의 position이란 b+teee에서의 그 element의 위치 정보로서,
@@ -27,16 +27,16 @@ B+tree position은 0-based index로 표현한다.
 
 ARCUS cache server에서 제공하는 b+tree position 관련 명령은 다음과 같다.
 
-- [B+tree에서 특정 bkey의 position을 조회하는 기능 : bop position](ch08-command-btree-collection.md#bop-position-btree-position-조회)
-- [B+tree에서 하나의 position 또는 position range에 해당하는 element를 조회하는 기능 : bop gbp(get by position)](ch08-command-btree-collection.md#bop-gbp-btree-get-by-position)
-- [B+tree에서 특정 bkey의 position과 element 그리고 그 위치 앞뒤의 element를 함께 조회하는 기능: bop pwg(position with get)](ch08-command-btree-collection.md#bop-pwg-btree-find-position-with-get-version-180)
+- [B+tree에서 특정 bkey의 position을 조회하는 기능 : bop position](#bop-position)
+- [B+tree에서 하나의 position 또는 position range에 해당하는 element를 조회하는 기능 : bop gbp(get by position)](#bop-gbp)
+- [B+tree에서 특정 bkey의 position과 element 그리고 그 위치 앞뒤의 element를 함께 조회하는 기능: bop pwg(position with get)](#bop-pwg)
 
 B+tree position 기반의 조회가 필요한 예를 하나 들면, ranking 시스템이 있다.
 Ranking 시스템에서는 특정 score를 bkey로 하여 해당 elements를 저장하고,
 조회는 최고/최저 score 기준으로 몇번째 위치 또는 위치의 범위에 해당하는 element를 찾는 경우가 많다.
 
 
-## bop create (B+tree Collection 생성)
+## bop create
 
 B+tree collection을 empty 상태로 생성한다.
 
@@ -61,7 +61,7 @@ Response string과 그 의미는 아래와 같다.
 | "CLIENT_ERROR bad command line format"  | protocol syntax 틀림
 | "SERVER_ERROR out of memory"            | 메모리 부족
 
-## bop insert/upsert (B+Tree Element 삽입/대체)
+## bop insert/upsert
 
 B+tree collection에 하나의 element를 추가하는 명령으로
 (1) 하나의 element를 삽입하는 bop insert 명령과
@@ -78,7 +78,7 @@ bop upsert <key> <bkey> [<eflag>] <bytes> [create <attributes>] [noreply|pipe|ge
 - \<key\> - 대상 item의 key string
 - \<bkey\> - 삽입할 element의 bkey
 - \<eflag\> - 삽입할 element의 optional flag
-- \<bytes\>와 \<data\> - 삽입할 element의 데이터의 길이와 데이터 그 자체 (최대 크기는 [기본제약사항](ch01-arcus-basic-concept.md#기본-제약-사항)을 참고)
+- \<bytes\>와 \<data\> - 삽입할 element의 데이터의 길이와 데이터 그 자체 (최대 크기는 [기본제약사항](ch01-arcus-basic-concept.md#basic-constraints)을 참고)
 - create \<attributes\> - b+tree collection 없을 시에 b+tree 생성 요청.
 [Item Attribute 설명](ch03-item-attributes.md)을 참조 바란다.
   - unreadable - 명시하면, readable 속성은 off로 설정됩니다.
@@ -114,7 +114,7 @@ END\r\n
 | "CLIENT_ERROR bad data chunk"           | 삽입할 데이터의 길이가 \<bytes\>와 다르거나 "\r\n"으로 끝나지 않음
 | "SERVER_ERROR out of memory"            | 메모리 부족
 
-## bop update (B+Tree Element 변경)
+## bop update
 
 B+tree collection에서 하나의 element에 대해 eflag 변경 그리고/또는 data 변경을 수행한다.
 현재 다수 elements에 대한 변경 연산은 제공하지 않고 있다.
@@ -149,7 +149,7 @@ Response string과 그 의미는 아래와 같다.
 | "CLIENT_ERROR bad data chunk"           | 변경할 데이터의 길이가 \<bytes\>와 다르거나 "\r\n"으로 끝나지 않음
 | "SERVER_ERROR out of memory"            | 메모리 부족
 
-## bop delete (B+Tree Element 삭제)
+## bop delete
 
 b+tree collection에서 하나의 bkey 또는 bkey range 조건과 eflag filter 조건을 만족하는
 N 개의 elements를 삭제한다.
@@ -182,7 +182,7 @@ Response string과 그 의미는 아래와 같다.
 | "NOT_SUPPORTED"                         | 지원하지 않음
 | "CLIENT_ERROR bad command line format"  | protocol syntax 틀림
 
-## bop get (B+Tree Element 조회)
+## bop get
 
 B+tree collection에서 하나의 bkey 또는 bkey range 조건과 eflag filter 조건을 만족하는
 elements에서 offset 개를 skip한 후 count 개의 elements를 조회한다.
@@ -241,7 +241,7 @@ b+tree collection 내부에 trim 발생 여부를 유지하지 않아 TRIMMED와
 | "CLIENT_ERROR bad command line format"                | protocol syntax 틀림
 | "SERVER_ERROR out of memory [writing get response]"   | 메모리 부족
 
-## bop count (B+Tree Element 개수 계산)
+## bop count
 
 b+tree collection에서 하나의 bkey 또는 bkey range 조건과 eflag filter 조건을 만족하는
 elements 개수를 구한다.
@@ -274,7 +274,7 @@ COUNT=<count>
 | "NOT_SUPPORTED"                          | 지원하지 않음
 | "CLIENT_ERROR bad command line format"   | protocol syntax 틀림
 
-## bop incr/decr (B+Tree Element 값의 증감)
+## bop incr/decr
 
 B+tree collection 특정 하나의 element에 있는 데이터를 increment 또는 decrement하고,
 증감된 데이터를 반환한다.
@@ -316,7 +316,7 @@ Increment/decrement 수행 후의 데이터 값이다.
 | "CLIENT_ERROR bad command line format"                          | protocol syntax 틀림
 | "SERVER_ERROR out of memory [writing get response]"             | 메모리 부족
 
-## bop mget (B+Tree Multiple Get)
+## bop mget
 
 여러 b+tree들에 대해 동일 조회 조건(bkey range와 eflag filter)으로 element들을 한꺼번에 조회한다.
 여러 b+tree들에 대한 동일 조회 조건을 사용하므로, 대상 b+tree들은 동일 bkey 유형을 가져야 한다.
@@ -389,7 +389,7 @@ flags와 ecount를 포함하여 조회된 element 정보가 생략된다.
 | "CLIENT_ERROR bad value"                              | bop mget 명령의 제약 조건을 위배함.
 | "SERVER_ERROR out of memory [writing get response]"   | 메모리 부족
 
-## bop smget (B+Tree Sort Merge Get)
+## bop smget
 
 여러 b+tree들에서 bkey range 조건과 eflag filter 조건을 모두 만족하는
 elements를 sort merge 형태로 조회하면서 count 개의 elements를 가져온다.
@@ -541,7 +541,7 @@ smget 수행의 실패 시의 response string은 다음과 같다.
 | "SERVER_ERROR out of memory [writing get response"   | 메모리 부족
 
 
-## bop position (B+Tree Position 조회)
+## bop position
 
 b+tree collection에서 특정 element의 position을 조회한다.
 Element의 position이란 b+tree에서의 위치 정보로서,
@@ -575,7 +575,7 @@ POSITION=<position>\r\n
 | "NOT_SUPPORTED"                          | 지원하지 않음
 | "CLIENT_ERROR bad command line format"   | protocol syntax 틀림
 
-## bop gbp (B+Tree Get By Position)
+## bop gbp
 
 B+tree collection에서 position 기반으로 elements를 조회한다.
 
@@ -613,7 +613,8 @@ END\r\n
 | "CLIENT_ERROR bad command line format"               | protocol syntax 틀림
 | "SERVER_ERROR out of memory [writing get response]"  | 메모리 부족
 
-## bop pwg (B+Tree Find Position with Get [version 1.8.0])
+## bop pwg
+Available since 1.8.0
 
 B+tree collection에서 특정 bkey의 position을 조회하면서,
 그 bkey를 가진 element를 포함하여 앞뒤에(양방향) 위치한 element N개 씩을 한번에 조회한다.

--- a/doc/ch11-command-scan.md
+++ b/doc/ch11-command-scan.md
@@ -1,9 +1,9 @@
 # Chapter 11. Scan 명령
 
-- [SCAN KEY 명령](ch11-command-scan.md#scan-key-명령)
-- [SCAN PREFIX 명령](ch11-command-scan.md#scan-prefix-명령)
+- [SCAN KEY 명령](#scan-key)
+- [SCAN PREFIX 명령](#scan-prefix)
 
-## Scan key 명령
+## Scan key
 
 특정 조건을 만족하는 아이템들의 키 목록을 얻어올 수 있는 scan key 기능을 제공한다.
 scan key 기능은 제한된 시간(5ms) 내에서 아이템들을 스캔하고 응용에게 찾은 키 스트링 목록과
@@ -78,7 +78,7 @@ scan key 명령 실패 시에 response string 은 다음과 같다.
 | CLIENT_ERROR invalid cursor            | cursor 에 숫자가 아닌 값을 준 경우
 | CLIENT_ERROR bad command line format   | protocol syntax 틀림
 
-## Scan prefix 명령
+## Scan prefix
 
 특정 조건을 만족하는 Prefix 목록을 얻어올 수 있는 scan prefix 기능을 제공한다.
 scan prefix 기능은 제한된 시간(5ms) 내에서 Prefix들을 스캔하고 응용에게 찾은 Prefix 목록과

--- a/doc/ch12-command-administration.md
+++ b/doc/ch12-command-administration.md
@@ -1,16 +1,16 @@
 # Chapter 12. Admin & Monitoring 명령
 
-- [FLUSH 명령](ch12-command-administration.md#flush-명령)
-- [SCRUB 명령](ch12-command-administration.md#scrub-명령)
-- [STATS 명령](ch12-command-administration.md#stats-명령)
-- [CONFIG 명령](ch12-command-administration.md#config-명령)
-- [CMDLOG 명령](ch12-command-administration.md#command-logging-명령)
-- [LQDETECT 명령](ch12-command-administration.md#long-query-detect-명령)
-- [KEY DUMP 명령](ch12-command-administration.md#key-dump-명령)
-- [ZKENSEMBLE 명령](ch12-command-administration.md#zkensemble-명령)
-- [HELP 명령](ch12-command-administration.md#help-명령)
+- [FLUSH 명령](#flush)
+- [SCRUB 명령](#scrub)
+- [STATS 명령](#stats)
+- [CONFIG 명령](#config)
+- [CMDLOG 명령](#command-logging)
+- [LQDETECT 명령](#long-query-detect)
+- [KEY DUMP 명령](#key-dump)
+- [ZKENSEMBLE 명령](#zkensemble)
+- [HELP 명령](#help)
 
-## Flush 명령
+## Flush
 
 ARCUS Cache Server는 items을 invalidate 시키기 위한 두 가지 flush 명령을 제공한다.
 
@@ -49,7 +49,7 @@ Response string과 그 의미는 아래와 같다.
 | "NOT_FOUND"                             | prefix miss (flush_prefix 명령인 경우만 해당)
 | "CLIENT_ERROR bad command line format"  | protocol syntax 틀림
 
-## Scrub 명령
+## Scrub
 
 ARCUS Cache Server에는 유효하지 않으면서 메모리를 차지하고 있는 items이 존재할 수 있다.
 이 items은 아래 두 유형으로 구분된다.
@@ -95,7 +95,7 @@ ARCUS Cache Server 구동 시에 ascii_scrub.so 파일을 dynamic linking 하는
 구동 옵션을 주어야 scrub 명령을 사용할 수 있다.
 
 
-## Stats 명령
+## Stats
 
 ARCUS Cache Server의 각종 통계 정보를 조회하거나 그 통계 정보를 reset한다.
 
@@ -703,7 +703,7 @@ END
 - last_chkpt_snapshot_filesize_bytes - 이전 체크포인트 스냅샷 파일 크기를 나타낸다. (unit : bytes)
 - current_command_log_filesize_bytes - 현재 명령 로그 파일 크기를 나타낸다. (unit : bytes)
 
-## Config 명령
+## Config
 
 ARCUS Cache Server는 특정 configuration에 대해 동적으로 변경하거나 현재의 값을 조회하는 기능을 제공한다.
 동적으로 변경가능한 configuration들은 현재 아래만 지원한다.
@@ -809,7 +809,7 @@ ARCUS Cache Server에는 더 이상 유효하지 않은 아이템을 일괄 삭�
 config scrub_count [<scrub_count>]\r\n
 ```
 
-## Command Logging 명령
+## Command Logging
 
 ARCUS Cache Server에 입력되는 command를 logging 한다.
 start 명령을 시작으로 logging이 종료될 때 까지의 모든 command를 기록한다.
@@ -857,7 +857,7 @@ The number of log files : 1                                          //file_coun
 The log file name: /Users/temp/command_11211_20160126_192729_{n}.log //path/file_name
 ```
 
-## Long Query Detect 명령
+## Long Query Detect
 
 ARCUS Cache Server에서 collection item에 대한 요청 중에는 그 처리 시간이 오래 걸리는 요청이 존재한다.
 이를 detect하기 위한 기능으로 lqdetect 명령을 제공한다.
@@ -929,7 +929,7 @@ The number of total long query commands : 1152    //detected_commands
 The detection threshold : 43                      //threshold
 ```
 
-## Key dump 명령
+## Key dump
 
 ARCUS Cache Server의 key를 dump 한다.
 
@@ -992,7 +992,7 @@ DUMP SUMMARY: { prefix=<prefix>, count=<count>, total=<total> elapsed=<elapsed> 
   - \<total\>은 cache에 있는 전체 key 개수이다.
   - \<elapsed\>는 dump하는 데 소요된 시간(단위: 초) 이다.
 
-## ZKensemble 명령
+## ZKensemble
 
 ARCUS Cache Server가 연결되어 있는 ZooKeeper ensemble 설정에 대한 명령을 제공한다.
 
@@ -1011,7 +1011,7 @@ rejoin 명령은 ZK ensemble 과의 연결을 끊고 cache cloud에서 빠져 �
 - 운영자의 실수로 cache_list에 등록된 cache server의 ephemeral znode가 삭제된 경우
 
 
-## Help 명령
+## Help
 
 ARCUS Cache Server의 ASCII command syntax를 조회한다.
 


### PR DESCRIPTION
- #697

- 링크로 연결되는 헤더에 한글을 포함하지 않도록 합니다.
- 동일 문서 내에서 이동하는 경우 파일명을 생략하도록 합니다.
  - 기존 `[List collection 생성: lop create](ch05-command-list-collection.md#lop-create-list-collection-생성)`
  - 변경 `[List collection 생성: lop create](#lop-create)`

  gitbook에서는 문서 내에서 이동할 수 있는 헤더 별 링크를 기본 제공해 주는데,
  마크다운에서 직접 작성해 두는 것이 크게 의미가 없지 않은가 하는 생각도 듭니다.