### PR TITLE
DOC: Add texts for dependencies installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,23 @@ Other Linux distributions have not been tested.
 
 **Dependencies**
 
-arcus-memcached has the following dependencies. Make sure to install them.
+Install tools for building by using package manager in linux system.
+  ```
+    (CentOS) sudo yum install gcc make which libtool
+    (Ubuntu) sudo apt-get install build-essential libtool
+  ```
+
+Also, arcus-memcached has the following library dependencies.
 - [libevent](http://libevent.org/) - An event notification library
 - [arcus-zookeeper](https://github.com/naver/arcus-zookeeper) - Zookeeper c library with Arcus modification
+
+To install them easily, run the command below from the git-cloned source code.
+```
+$ ./deps/install.sh [installation path]
+```
+If the installation path was not given, dependencies will be installed in the system path(/usr/local).
+
+Therefore, giving the installation path preferably is recommended.
 
 **Compile**
 


### PR DESCRIPTION
`readme.md`에 memcached build에 필요한 의존성 패키지 및 라이브러리 설치 방식에 대한 내용을 추가했습니다.
libevent와 zookeeper의 경우 install.sh를 사용한 방식으로 소개했습니다.

패키지 설치의 경우 해당 패키지가 모두 필요한지에 대해서는 검토가 필요한 것 같습니다.