### PR TITLE
FIX: Use a type of exptime as int64_t in binary protocol

### DIFF
--- a/include/memcached/protocol_binary.h
+++ b/include/memcached/protocol_binary.h
@@ -343,10 +343,10 @@ extern "C"
         struct {
             protocol_binary_request_header header;
             struct {
-                uint32_t expiration;
+                int64_t expiration;
             } body;
         } message;
-        uint8_t bytes[sizeof(protocol_binary_request_header) + 4];
+        uint8_t bytes[sizeof(protocol_binary_request_header) + 8];
     } protocol_binary_request_flush;
 
     typedef protocol_binary_request_flush protocol_binary_request_flush_prefix;
@@ -366,10 +366,10 @@ extern "C"
             protocol_binary_request_header header;
             struct {
                 uint32_t flags;
-                uint32_t expiration;
+                int64_t expiration;
             } body;
         } message;
-        uint8_t bytes[sizeof(protocol_binary_request_header) + 8];
+        uint8_t bytes[sizeof(protocol_binary_request_header) + 16];
     } protocol_binary_request_set;
     typedef protocol_binary_request_set protocol_binary_request_add;
     typedef protocol_binary_request_set protocol_binary_request_replace;
@@ -405,10 +405,10 @@ extern "C"
             struct {
                 uint64_t delta;
                 uint64_t initial;
-                uint32_t expiration;
+                int64_t expiration;
             } body;
         } message;
-        uint8_t bytes[sizeof(protocol_binary_request_header) + 20];
+        uint8_t bytes[sizeof(protocol_binary_request_header) + 24];
     } protocol_binary_request_incr;
     typedef protocol_binary_request_incr protocol_binary_request_decr;
 
@@ -531,7 +531,7 @@ extern "C"
             protocol_binary_request_header header;
             struct {
                 uint32_t flags;
-                int32_t  exptime;
+                int64_t  exptime;
                 int32_t  maxcount;
                 uint8_t  ovflaction;
                 uint8_t  readable;
@@ -539,7 +539,7 @@ extern "C"
                 uint8_t  reserved2;
             } body;
         } message;
-        uint8_t bytes[sizeof(protocol_binary_request_header) + 16];
+        uint8_t bytes[sizeof(protocol_binary_request_header) + 24];
     } protocol_binary_request_lop_create;
 
     typedef union {
@@ -548,7 +548,7 @@ extern "C"
             struct {
                 int32_t  index;
                 uint32_t flags;
-                int32_t  exptime;
+                int64_t  exptime;
                 int32_t  maxcount;
                 uint8_t  create;
                 uint8_t  reserved1;
@@ -556,7 +556,7 @@ extern "C"
                 uint8_t  reserved3;
             } body;
         } message;
-        uint8_t bytes[sizeof(protocol_binary_request_header) + 20];
+        uint8_t bytes[sizeof(protocol_binary_request_header) + 24];
     } protocol_binary_request_lop_insert;
 
     typedef union {
@@ -613,7 +613,7 @@ extern "C"
             protocol_binary_request_header header;
             struct {
                 uint32_t flags;
-                int32_t  exptime;
+                int64_t  exptime;
                 int32_t  maxcount;
                 uint8_t  ovflaction;
                 uint8_t  readable;
@@ -621,7 +621,7 @@ extern "C"
                 uint8_t  reserved2;
             } body;
         } message;
-        uint8_t bytes[sizeof(protocol_binary_request_header) + 16];
+        uint8_t bytes[sizeof(protocol_binary_request_header) + 24];
     } protocol_binary_request_sop_create;
 
     typedef union {
@@ -629,7 +629,7 @@ extern "C"
             protocol_binary_request_header header;
             struct {
                 uint32_t flags;
-                int32_t  exptime;
+                int64_t  exptime;
                 int32_t  maxcount;
                 uint8_t  create;
                 uint8_t  reserved1;
@@ -637,7 +637,7 @@ extern "C"
                 uint8_t  reserved3;
             } body;
         } message;
-        uint8_t bytes[sizeof(protocol_binary_request_header) + 16];
+        uint8_t bytes[sizeof(protocol_binary_request_header) + 24];
     } protocol_binary_request_sop_insert;
 
     typedef union {
@@ -703,7 +703,7 @@ extern "C"
             protocol_binary_request_header header;
             struct {
                 uint32_t flags;
-                int32_t  exptime;
+                int64_t  exptime;
                 int32_t  maxcount;
                 uint8_t  ovflaction;
                 uint8_t  readable;
@@ -711,7 +711,7 @@ extern "C"
                 uint8_t  reserved2;
             } body;
         } message;
-        uint8_t bytes[sizeof(protocol_binary_request_header) + 16];
+        uint8_t bytes[sizeof(protocol_binary_request_header) + 20];
     } protocol_binary_request_bop_create;
 
     typedef union {
@@ -723,7 +723,7 @@ extern "C"
                 uint8_t  eflag[MAX_EFLAG_LENG];
                 uint8_t  neflag;
                 uint32_t flags;
-                int32_t  exptime;
+                int64_t  exptime;
                 int32_t  maxcount;
                 uint8_t  create;
                 uint8_t  reserved1;
@@ -732,7 +732,7 @@ extern "C"
             } body;
         } message;
         uint8_t bytes[sizeof(protocol_binary_request_header) +
-                      MAX_BKEY_LENG+1 + MAX_EFLAG_LENG+1 + 16];
+                      MAX_BKEY_LENG+1 + MAX_EFLAG_LENG+1 + 24];
     } protocol_binary_request_bop_insert;
 
     typedef union {

--- a/memcached.c
+++ b/memcached.c
@@ -3633,7 +3633,7 @@ static void complete_incr_bin(conn *c)
     /* fix byteorder in the request */
     req->message.body.delta = ntohll(req->message.body.delta);
     req->message.body.initial = ntohll(req->message.body.initial);
-    req->message.body.expiration = ntohl(req->message.body.expiration);
+    req->message.body.expiration = ntohll(req->message.body.expiration);
     char *key = binary_get_key(c);
     size_t nkey = c->binary_header.request.keylen;
     bool incr = (c->cmd == PROTOCOL_BINARY_CMD_INCREMENT ||
@@ -3658,7 +3658,7 @@ static void complete_incr_bin(conn *c)
     ENGINE_ERROR_CODE ret;
     ret = mc_engine.v1->arithmetic(mc_engine.v0,
                                    c, key, nkey, incr,
-                                   req->message.body.expiration != 0xffffffff,
+                                   req->message.body.expiration != 0xffffffffffffffff,
                                    req->message.body.delta,
                                    req->message.body.initial,
                                    0, /* flags */
@@ -4387,7 +4387,7 @@ static void process_bin_lop_create(conn *c)
 
     /* fix byteorder in the request */
     protocol_binary_request_lop_create* req = binary_get_request(c);
-    req->message.body.exptime  = ntohl(req->message.body.exptime);
+    req->message.body.exptime  = ntohll(req->message.body.exptime);
     req->message.body.maxcount = ntohl(req->message.body.maxcount);
 
     if (settings.verbose > 1) {
@@ -4395,7 +4395,7 @@ static void process_bin_lop_create(conn *c)
         for (int ii = 0; ii < nkey; ++ii) {
             fprintf(stderr, "%c", key[ii]);
         }
-        fprintf(stderr, " flags(%u) exptime(%d) maxcount(%d) ovflaction(%s) readable(%d)\n",
+        fprintf(stderr, " flags(%u) exptime(%"PRId64") maxcount(%d) ovflaction(%s) readable(%d)\n",
                 req->message.body.flags, req->message.body.exptime, req->message.body.maxcount,
                 get_ovflaction_str(req->message.body.ovflaction), req->message.body.readable);
     }
@@ -4463,7 +4463,7 @@ static void process_bin_lop_prepare_nread(conn *c)
     protocol_binary_request_lop_insert* req = binary_get_request(c);
     req->message.body.index = ntohl(req->message.body.index);
     if (req->message.body.create) {
-        req->message.body.exptime  = ntohl(req->message.body.exptime);
+        req->message.body.exptime  = ntohll(req->message.body.exptime);
         req->message.body.maxcount = ntohl(req->message.body.maxcount);
     }
 
@@ -4780,7 +4780,7 @@ static void process_bin_sop_create(conn *c)
 
     /* fix byteorder in the request */
     protocol_binary_request_sop_create* req = binary_get_request(c);
-    req->message.body.exptime  = ntohl(req->message.body.exptime);
+    req->message.body.exptime  = ntohll(req->message.body.exptime);
     req->message.body.maxcount = ntohl(req->message.body.maxcount);
 
     if (settings.verbose > 1) {
@@ -4788,7 +4788,7 @@ static void process_bin_sop_create(conn *c)
         for (int ii = 0; ii < nkey; ++ii) {
             fprintf(stderr, "%c", key[ii]);
         }
-        fprintf(stderr, " flags(%u) exptime(%d) maxcount(%d) ovflaction(%s) readable(%d)\n",
+        fprintf(stderr, " flags(%u) exptime(%"PRId64") maxcount(%d) ovflaction(%s) readable(%d)\n",
                 req->message.body.flags, req->message.body.exptime, req->message.body.maxcount,
                 "error", req->message.body.readable);
     }
@@ -4888,7 +4888,7 @@ static void process_bin_sop_prepare_nread(conn *c)
         if (c->cmd == PROTOCOL_BINARY_CMD_SOP_INSERT) {
             protocol_binary_request_sop_insert* req = binary_get_request(c);
             if (req->message.body.create) {
-                req->message.body.exptime  = ntohl(req->message.body.exptime);
+                req->message.body.exptime  = ntohll(req->message.body.exptime);
                 req->message.body.maxcount = ntohl(req->message.body.maxcount);
             }
             c->coll_op     = OPERATION_SOP_INSERT;
@@ -5233,7 +5233,7 @@ static void process_bin_bop_create(conn *c)
 
     /* fix byteorder in the request */
     protocol_binary_request_bop_create* req = binary_get_request(c);
-    req->message.body.exptime  = ntohl(req->message.body.exptime);
+    req->message.body.exptime  = ntohll(req->message.body.exptime);
     req->message.body.maxcount = ntohl(req->message.body.maxcount);
 
     if (settings.verbose > 1) {
@@ -5241,7 +5241,7 @@ static void process_bin_bop_create(conn *c)
         for (int ii = 0; ii < nkey; ++ii) {
             fprintf(stderr, "%c", key[ii]);
         }
-        fprintf(stderr, " flags(%u) exptime(%d) maxcount(%d) ovflaction(%s) readable(%d)\n",
+        fprintf(stderr, " flags(%u) exptime(%"PRId64") maxcount(%d) ovflaction(%s) readable(%d)\n",
                 req->message.body.flags, req->message.body.exptime, req->message.body.maxcount,
                 get_ovflaction_str(req->message.body.ovflaction), req->message.body.readable);
     }
@@ -5317,7 +5317,7 @@ static void process_bin_bop_prepare_nread(conn *c)
         //*(uint64_t*)req->message.body.bkey = ntohll(*(uint64_t*)req->message.body.bkey);
     }
     if (req->message.body.create) {
-        req->message.body.exptime  = ntohl(req->message.body.exptime);
+        req->message.body.exptime  = ntohll(req->message.body.exptime);
         req->message.body.maxcount = ntohl(req->message.body.maxcount);
     }
 
@@ -6754,7 +6754,6 @@ static void dispatch_bin_command(conn *c)
         handle_binary_protocol_error(c);
         return;
     }
-
     switch (c->cmd) {
     case PROTOCOL_BINARY_CMD_SETQ:
         c->cmd = PROTOCOL_BINARY_CMD_SET;
@@ -6829,14 +6828,14 @@ static void dispatch_bin_command(conn *c)
         }
         break;
     case PROTOCOL_BINARY_CMD_FLUSH:
-        if (keylen == 0 && bodylen == extlen && (extlen == 0 || extlen == 4)) {
+        if (keylen == 0 && bodylen == extlen && (extlen == 0 || extlen == 8)) {
             bin_read_key(c, bin_read_flush_exptime, extlen);
         } else {
             protocol_error = 1;
         }
         break;
     case PROTOCOL_BINARY_CMD_FLUSH_PREFIX:
-        if (keylen > 0 && bodylen == extlen && (extlen == 0 || extlen == 4)) {
+        if (keylen > 0 && bodylen == extlen && (extlen == 0 || extlen == 8)) {
             bin_read_key(c, bin_read_flush_prefix_exptime, extlen);
         } else {
             protocol_error = 1;
@@ -6852,8 +6851,8 @@ static void dispatch_bin_command(conn *c)
     case PROTOCOL_BINARY_CMD_SET: /* FALLTHROUGH */
     case PROTOCOL_BINARY_CMD_ADD: /* FALLTHROUGH */
     case PROTOCOL_BINARY_CMD_REPLACE:
-        if (extlen == 8 && keylen != 0 && bodylen >= (keylen + 8)) {
-            bin_read_key(c, bin_reading_set_header, 8);
+        if (extlen == 16 && keylen != 0 && bodylen >= (keylen + 16)) {
+            bin_read_key(c, bin_reading_set_header, 16);
         } else {
             protocol_error = 1;
         }
@@ -6877,8 +6876,8 @@ static void dispatch_bin_command(conn *c)
         break;
     case PROTOCOL_BINARY_CMD_INCREMENT:
     case PROTOCOL_BINARY_CMD_DECREMENT:
-        if (keylen > 0 && extlen == 20 && bodylen == (keylen + extlen)) {
-            bin_read_key(c, bin_reading_incr_header, 20);
+        if (keylen > 0 && extlen == 24 && bodylen == (keylen + extlen)) {
+            bin_read_key(c, bin_reading_incr_header, 24);
         } else {
             protocol_error = 1;
         }
@@ -6924,15 +6923,15 @@ static void dispatch_bin_command(conn *c)
         }
         break;
     case PROTOCOL_BINARY_CMD_LOP_CREATE:
-        if (keylen > 0 && extlen == 16 && bodylen == (keylen + extlen)) {
-            bin_read_key(c, bin_reading_lop_create, 16);
+        if (keylen > 0 && extlen == 24 && bodylen == (keylen + extlen)) {
+            bin_read_key(c, bin_reading_lop_create, 24);
         } else {
             protocol_error = 1;
         }
         break;
     case PROTOCOL_BINARY_CMD_LOP_INSERT:
-        if (keylen > 0 && extlen == 20 && bodylen > (keylen + extlen)) {
-            bin_read_key(c, bin_reading_lop_prepare_nread, 20);
+        if (keylen > 0 && extlen == 24 && bodylen > (keylen + extlen)) {
+            bin_read_key(c, bin_reading_lop_prepare_nread, 24);
         } else {
             protocol_error = 1;
         }
@@ -6952,15 +6951,15 @@ static void dispatch_bin_command(conn *c)
         }
         break;
     case PROTOCOL_BINARY_CMD_SOP_CREATE:
-        if (keylen > 0 && extlen == 16 && bodylen == (keylen + extlen)) {
-            bin_read_key(c, bin_reading_sop_create, 16);
+        if (keylen > 0 && extlen == 24 && bodylen == (keylen + extlen)) {
+            bin_read_key(c, bin_reading_sop_create, 24);
         } else {
             protocol_error = 1;
         }
         break;
     case PROTOCOL_BINARY_CMD_SOP_INSERT:
-        if (keylen > 0 && extlen == 16 && bodylen > (keylen + extlen)) {
-            bin_read_key(c, bin_reading_sop_prepare_nread, 16);
+        if (keylen > 0 && extlen == 24 && bodylen > (keylen + extlen)) {
+            bin_read_key(c, bin_reading_sop_prepare_nread, 24);
         } else {
             protocol_error = 1;
         }
@@ -6987,8 +6986,8 @@ static void dispatch_bin_command(conn *c)
         }
         break;
     case PROTOCOL_BINARY_CMD_BOP_CREATE:
-        if (keylen > 0 && extlen == 16 && bodylen == (keylen + extlen)) {
-            bin_read_key(c, bin_reading_bop_create, 16);
+        if (keylen > 0 && extlen == 20 && bodylen == (keylen + extlen)) {
+            bin_read_key(c, bin_reading_bop_create, 20);
         } else {
             protocol_error = 1;
         }
@@ -7243,11 +7242,11 @@ static void process_bin_append_prepend(conn *c)
 static void process_bin_flush(conn *c)
 {
     protocol_binary_request_flush* req = binary_get_request(c);
-    time_t exptime = 0;
+    int64_t exptime = 0;
     ENGINE_ERROR_CODE ret = ENGINE_SUCCESS;
 
     if (c->binary_header.request.extlen == sizeof(req->message.body)) {
-        exptime = ntohl(req->message.body.expiration);
+        exptime = ntohll(req->message.body.expiration);
         if (exptime < 0) {
             ret = ENGINE_EINVAL;
         }

--- a/t/binary.t
+++ b/t/binary.t
@@ -55,7 +55,7 @@ use constant CMD_PREPENDQ   => 0x1A;
 # the same format, since they _could_ differ in the future.
 use constant REQ_PKT_FMT      => "CCnCCnNNNN";
 use constant RES_PKT_FMT      => "CCnCCnNNNN";
-use constant INCRDECR_PKT_FMT => "NNNNN";
+use constant INCRDECR_PKT_FMT => "NNNNQ>";
 use constant MIN_RECV_BYTES   => length(pack(RES_PKT_FMT));
 use constant REQ_MAGIC        => 0x80;
 use constant RES_MAGIC        => 0x81;
@@ -255,7 +255,7 @@ $mc->silent_mutation(::CMD_ADDQ, 'silentadd', 'silentaddval');
 # diag "Silent replace.";
 {
     my $key = "silentreplace";
-    my $extra = pack "NN", 829, 0;
+    my $extra = pack "NQ>N", 829, 0;
     $empty->($key);
     # $mc->send_silent(::CMD_REPLACEQ, $key, 'somevalue', 7278552, $extra, 0);
     # $empty->($key);
@@ -415,7 +415,7 @@ $mc->silent_mutation(::CMD_ADDQ, 'silentadd', 'silentaddval');
         my $k = "test_key_$i";
         my $v = 'x' x $i;
         # diag "Trying $i $k";
-        my $extra = pack "NN", 82, 0;
+        my $extra = pack "NQ>N", 82, 0;
         my $data = $mc->build_command(::CMD_SETQ, $k, $v, 0, $extra, 0);
         $data .= $mc->build_command(::CMD_SETQ, "alt_$k", "blah", 0, $extra, 0);
         if (length($data) > 2024) {
@@ -539,7 +539,7 @@ sub silent_mutation {
     my ($cmd, $key, $value) = @_;
 
     $empty->($key);
-    my $extra = pack "NN", 82, 0;
+    my $extra = pack "NQ>N", 82, 0;
     $mc->send_silent($cmd, $key, $value, 7278552, $extra, 0);
     $check->($key, 82, $value);
 }
@@ -707,7 +707,7 @@ sub flush {
 sub add {
     my $self = shift;
     my ($key, $val, $flags, $expire) = @_;
-    my $extra_header = pack "NN", $flags, $expire;
+    my $extra_header = pack "NQ>N", $flags, $expire;
     my $cas = 0;
     return $self->_do_command(::CMD_ADD, $key, $val, $extra_header, $cas);
 }
@@ -715,7 +715,7 @@ sub add {
 sub set {
     my $self = shift;
     my ($key, $val, $flags, $expire, $cas) = @_;
-    my $extra_header = pack "NN", $flags, $expire;
+    my $extra_header = pack "NQ>N", $flags, $expire;
     return $self->_do_command(::CMD_SET, $key, $val, $extra_header, $cas);
 }
 
@@ -728,7 +728,7 @@ sub _append_prepend {
 sub replace {
     my $self = shift;
     my ($key, $val, $flags, $expire) = @_;
-    my $extra_header = pack "NN", $flags, $expire;
+    my $extra_header = pack "NQ>N", $flags, $expire;
     my $cas = 0;
     return $self->_do_command(::CMD_REPLACE, $key, $val, $extra_header, $cas);
 }

--- a/t/udp.t
+++ b/t/udp.t
@@ -23,7 +23,7 @@ use constant CMD_APPEND       => 0x0E;
 use constant CMD_PREPEND      => 0x0F;
 use constant REQ_PKT_FMT      => "CCnCCnNNNN";
 use constant RES_PKT_FMT      => "CCnCCnNNNN";
-use constant INCRDECR_PKT_FMT => "NNNNN";
+use constant INCRDECR_PKT_FMT => "NNNNQ>";
 use constant MIN_RECV_BYTES   => length(pack(RES_PKT_FMT));
 
 
@@ -80,7 +80,7 @@ sub udp_set_test {
         $req = "set $key $flags $exp $val_len\r\n$value\r\n";
     } elsif ($protocol == ::IS_BINARY) {
         my $key_len = length($key);
-        my $extra = pack "NN",$flags,$exp;
+        my $extra = pack "NQ>N",$flags,$exp;
         my $extra_len = length($extra);
         my $total_len = $val_len + $extra_len + $key_len;
         $req = pack(::REQ_PKT_FMT, ::BIN_REQ_MAGIC, ::CMD_SET, $key_len, $extra_len, 0, 0, $total_len, 0, 0, 0);


### PR DESCRIPTION
- #711 

바이너리 프로토콜에서의 exptime에 대한 64bit 정수형 변환 PR입니다.
64bit 정수형으로 변환됨에 따라 변화된 구조체 크기에 맞추어 byte 및 extra 크기를 조정했습니다.
소스에서는 아래를 변경했습니다.
- memcached.c
- protocol_binary.h

또한 테스트(testapp, binary, udp test)에서도 변환된 크기로 바이너리 헤더를 보내게끔 수정했습니다.

