### PR TITLE
CLEANUP: Move event callback functions to mc_util files

### DIFF
--- a/mc_util.c
+++ b/mc_util.c
@@ -628,11 +628,12 @@ ENGINE_ERROR_CODE tokenize_sblocks(mblck_list_t *blist, int keylen, int keycnt,
  */
 
 /* event handlers structure */
-static struct engine_event_handler {
+struct engine_event_handler {
     EVENT_CALLBACK cb;
     const void *cb_data;
     struct engine_event_handler *next;
-} *engine_event_handlers[MAX_ENGINE_EVENT_TYPE + 1];
+};
+static struct engine_event_handler *engine_event_handlers[MAX_ENGINE_EVENT_TYPE + 1];
 
 /*
  * Register a callback.

--- a/mc_util.h
+++ b/mc_util.h
@@ -17,6 +17,7 @@
 #ifndef MC_UTIL_H
 #define MC_UTIL_H
 
+#include <memcached/engine.h>
 #include <memcached/extension.h>
 
 /* length of string representing 4 bytes integer is 10 */
@@ -94,5 +95,12 @@ ENGINE_ERROR_CODE tokenize_mblocks(mblck_list_t *blist, int keylen, int keycnt,
 ENGINE_ERROR_CODE tokenize_sblocks(mblck_list_t *blist, int keylen, int keycnt,
                                    int maxklen, bool must_backward_compatible,
                                    token_t *tokens);
+
+/* event callback functions */
+void register_callback(ENGINE_HANDLE *eh,
+                       ENGINE_EVENT_TYPE type,
+                       EVENT_CALLBACK cb, const void *cb_data);
+void perform_callbacks(ENGINE_EVENT_TYPE type,
+                       const void *data, const void *c);
 
 #endif

--- a/mc_util.h
+++ b/mc_util.h
@@ -17,7 +17,7 @@
 #ifndef MC_UTIL_H
 #define MC_UTIL_H
 
-#include <memcached/engine.h>
+#include <memcached/callback.h>
 #include <memcached/extension.h>
 
 /* length of string representing 4 bytes integer is 10 */

--- a/memcached.c
+++ b/memcached.c
@@ -114,8 +114,6 @@ static struct event_base *main_base;
 struct thread_stats *default_thread_stats;
 topkeys_t *default_topkeys = NULL;
 
-static struct engine_event_handler *engine_event_handlers[MAX_ENGINE_EVENT_TYPE + 1];
-
 #ifdef ENABLE_ZK_INTEGRATION
 static char *arcus_zk_cfg = NULL;
 #endif
@@ -440,31 +438,6 @@ void safe_close(int sfd)
             mc_stats.curr_conns--;
             UNLOCK_STATS();
         }
-    }
-}
-
-// Register a callback.
-static void register_callback(ENGINE_HANDLE *eh,
-                              ENGINE_EVENT_TYPE type,
-                              EVENT_CALLBACK cb, const void *cb_data)
-{
-    struct engine_event_handler *h =
-        calloc(sizeof(struct engine_event_handler), 1);
-
-    assert(h);
-    h->cb = cb;
-    h->cb_data = cb_data;
-    h->next = engine_event_handlers[type];
-    engine_event_handlers[type] = h;
-}
-
-// Perform all callbacks of a given type for the given connection.
-static void perform_callbacks(ENGINE_EVENT_TYPE type,
-                              const void *data, const void *c)
-{
-    for (struct engine_event_handler *h = engine_event_handlers[type];
-         h; h = h->next) {
-        h->cb(c, type, data, h->cb_data);
     }
 }
 

--- a/memcached.h
+++ b/memcached.h
@@ -250,12 +250,6 @@ struct settings {
     } extensions;
 };
 
-struct engine_event_handler {
-    EVENT_CALLBACK cb;
-    const void *cb_data;
-    struct engine_event_handler *next;
-};
-
 extern struct settings settings;
 extern EXTENSION_LOGGER_DESCRIPTOR *mc_logger;
 


### PR DESCRIPTION
- jam2in/arcus-works#442
- jam2in/arcus-works#497
- #688
- #701 

기존 내용은 노션 및 이슈에 정리되었으므로 지웠습니다.

event callbacks 함수를 `mc_util` 파일로 이동시킵니다.