### PR TITLE
INTERNAL: Add nc command to docker image to use ready command on startup.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ CMD [\
 # for arcus-operator
 FROM base
 RUN yum update -y
-RUN yum install -y bind-utils
+RUN yum install -y bind-utils nc
 RUN yum clean all -y
 ENV MEMCACHED_DIR /arcus-memcached
 ENV PATH ${PATH}:${MEMCACHED_DIR}


### PR DESCRIPTION
arcus-operator에서 startupProbe로 활용하기 위한 nc 명령어를 도커 이미지에 추가합니다.