### PR TITLE
TEST: Exclude all Makefiles from whitespace test

### DIFF
--- a/t/whitespace.t
+++ b/t/whitespace.t
@@ -8,7 +8,7 @@ BEGIN {
 
     my @exempted = qw(Makefile.am win32/Makefile.mingw m4/c99-backport.m4);
     push(@exempted, glob("*/Makefile.am"));
-    push(@exempted, glob("Makefile.docker"));
+    push(@exempted, glob("Makefile.*"));
     push(@exempted, glob("ChangeLog*"));
     push(@exempted, glob("README.md*"));
     push(@exempted, glob("CONTRIBUTING.md*"));


### PR DESCRIPTION
- jam2in/arcus-memcached-EE#1088

최상위 경로의 모든 Makefile을 whitespace test에서 제외하도록 합니다.
현재 EE에서 테스트 실패하는 상태입니다.