### PR TITLE
INTERNAL: Compare core version and engine version when create_instance()

### DIFF
--- a/engine_loader.c
+++ b/engine_loader.c
@@ -53,8 +53,19 @@ bool load_engine(const char *soname,
     ENGINE_ERROR_CODE error = (*my_create.create)(1, get_server_api, &engine);
 
     if (error != ENGINE_SUCCESS || engine == NULL) {
-        logger->log(EXTENSION_LOG_WARNING, NULL,
-                "Failed to create instance. Error code: %d\n", error);
+        switch (error) {
+            case ENGINE_EBADTYPE:
+                logger->log(EXTENSION_LOG_WARNING, NULL,
+                    "Do not match core and engine version\n");
+                break;
+            case ENGINE_ENOMEM:
+                logger->log(EXTENSION_LOG_WARNING, NULL,
+                    "Failed to allocate memory\n");
+                break;
+            default:
+                logger->log(EXTENSION_LOG_WARNING, NULL,
+                    "Failed to create instance. Error code: %d\n", error);
+        }
         dlclose(handle);
         return false;
     }

--- a/engines/default/default_engine.c
+++ b/engines/default/default_engine.c
@@ -1939,6 +1939,9 @@ create_instance(uint64_t interface, GET_SERVER_API get_server_api,
     if (interface != 1 || api == NULL) {
         return ENGINE_ENOTSUP;
     }
+    if (strcmp(api->core->server_version(), VERSION) != 0) {
+        return ENGINE_EBADTYPE;
+    }
 
     struct default_engine *engine = malloc(sizeof(*engine));
     if (engine == NULL) {

--- a/engines/demo/demo_engine.c
+++ b/engines/demo/demo_engine.c
@@ -783,6 +783,9 @@ create_instance(uint64_t interface, GET_SERVER_API get_server_api,
     if (interface != 1 || api == NULL) {
         return ENGINE_ENOTSUP;
     }
+    if (strcmp(api->core->server_version(), VERSION) != 0) {
+        return ENGINE_EBADTYPE;
+    }
 
     struct demo_engine *engine = malloc(sizeof(*engine));
     if (engine == NULL) {


### PR DESCRIPTION
- jam2in/arcus-works#450

core 버전과 default_engine.so 버전이 서로 다른 경우 구동에 실패하도록 합니다.

실패 시 아래와 같은 메시지 출력됩니다.
```
memcached: engines/default/default_engine.c:1941: create_instance: Assertion `__extension__ ({ size_t __s1_len, __s2_len; (__builtin_constant_p (api->core->server_version()) && __builtin_constant_p ("1.13.4-53") && (__s1_len = strlen (api->core->server_version()), __s2_len = strlen ("1.13.4-53"), (!((size_t)(const void *)((api->core->server_version()) + 1) - (size_t)(const void *)(api->core->server_version()) == 1) || __s1_len >= 4) && (!((size_t)(const void *)(("1.13.4-53") + 1) - (size_t)(const void *)("1.13.4-53") == 1) || __s2_len >= 4)) ? __builtin_strcmp (api->core->server_version(), "1.13.4-53") : (__builtin_constant_p (api->core->server_version()) && ((size_t)(const void *)((api->core->server_version()) + 1) - (size_t)(const void *)(api->core->server_version()) == 1) && (__s1_len = strlen (api->core->server_version()), __s1_len < 4) ? (__builtin_constant_p ("1.13.4-53") && ((size_t)(const void *)(("1.13.4-53") + 1) - (size_t)(const void *)("1.13.4-53") == 1) ? __builtin_strcmp (api->core->server_version(), "1.13.4-53") : (__extension__ ({ const unsigned char *__s2 = (const unsigned char *) (const char *) ("1.13.4-53"); int __result = (((const unsigned char *) (const char *) (api->core->server_version()))[0] - __s2[0]); if (__s1_len > 0 && __result == 0) { __result = (((const unsigned char *) (const char *) (api->core->server_version()))[1] - __s2[1]); if (__s1_len > 1 && __result == 0) { __result = (((const unsigned char *) (const char *) (api->core->server_version()))[2] - __s2[2]); if (__s1_len > 2 && __result == 0) __result = (((const unsigned char *) (const char *) (api->core->server_version()))[3] - __s2[3]); } } __result; }))) : (__builtin_constant_p ("1.13.4-53") && ((size_t)(const void *)(("1.13.4-53") + 1) - (size_t)(const void *)("1.13.4-53") == 1) && (__s2_len = strlen ("1.13.4-53"), __s2_len < 4) ? (__builtin_constant_p (api->core->server_version()) && ((size_t)(const void *)((api->core->server_version()) + 1) - (size_t)(const void *)(api->core->server_version()) == 1) ? __builtin_strcmp (api->core->server_version(), "1.13.4-53") : (__extension__ ({ const unsigned char *__s1 = (const unsigned char *) (const char *) (api->core->server_version()); register int __result = __s1[0] - ((const unsigned char *) (const char *) ("1.13.4-53"))[0]; if (__s2_len > 0 && __result == 0) { __result = (__s1[1] - ((const unsigned char *) (const char *) ("1.13.4-53"))[1]); if (__s2_len > 1 && __result == 0) { __result = (__s1[2] - ((const unsigned char *) (const char *) ("1.13.4-53"))[2]); if (__s2_len > 2 && __result == 0) __result = (__s1[3] - ((const unsigned char *) (const char *) ("1.13.4-53"))[3]); } } __result; }))) : __builtin_strcmp (api->core->server_version(), "1.13.4-53")))); }) == 0' failed.
Aborted (core dumped)
```