### PR TITLE
FIX: Update max ntokens for bop smget(new) with offset

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -12567,7 +12567,7 @@ static void process_bop_command(conn *c, token_t *tokens, const size_t ntokens)
                           (c->coll_efilter.ncompval==0 ? NULL : &c->coll_efilter));
     }
 #if defined(SUPPORT_BOP_MGET) || defined(SUPPORT_BOP_SMGET)
-    else if ((ntokens >= 7 && ntokens <= 13) &&
+    else if ((ntokens >= 7 && ntokens <= 14) &&
              ((strcmp(subcommand, "mget") == 0  && (subcommid = (int)OPERATION_BOP_MGET)) ||
               (strcmp(subcommand, "smget") == 0 && (subcommid = (int)OPERATION_BOP_SMGET)) ))
     {


### PR DESCRIPTION
- jam2in/arcus-works#472
- jam2in/arcus-works#474

new smget interface에서 offset을 허용하지 않도록 합니다.
 
- `offset`과 `duplicate|unique`를 함께 지정하는 경우에 `CLIENT_ERROR bad command line format`를 반환합니다.
  ```
  bop smget <lenkeys> <numkeys> <bkey or "bkey range"> <offset> <count> <duplicate|unique>\r\n
  ```
  위와 같은 구조의 명령이 현재는 동작하지만, PR 적용 이후 에러를 반환하게 됩니다.
- new smget에서 offset을 사용하는 테스트 코드를 제거합니다.

### 기타
기존 코드의 조건문에 `#ifdef`를 끼워넣는 것은 복잡하고 잘 읽히지 않을 것 같아서
코드 중복을 감수하고 별도의 if-else 형태로 분리했습니다. 더 나은 구현 방안이 있다면 반영하겠습니다.