### PR TITLE
DOC: Cleanup doc smget documentation

### DIFF
--- a/docs/ascii-protocol/ch08-command-btree-collection.md
+++ b/docs/ascii-protocol/ch08-command-btree-collection.md
@@ -396,44 +396,20 @@ elements를 sort merge 형태로 조회하면서 count 개의 elements를 가져
 즉, 여러 b+tree들을 하나의 large b+tree로 구성되어 있다고 보고,
 이에 대한 element 조회 기능과 동일하다.
 
-smget 동작은 조회 범위와 어떤 b+tree의 trim 영역과의 겹침에 대한 처리로,
-아래 두 가지 동작 모드가 있다.
+- smget 조회를 수행할 수 없는 아래 상태의 b+tree key들을 missed keys로 분류하고 이들의 elements는 smget 결과에 반영할 수 없다.
+따라서, 응용에서는 missed keys에 대해 백엔드 저장소인 DB에서 elements를 조회하여 최종 smget 결과에 반영해야 한다.
+  - 캐시에 존재하지 않는 key
+  - 조회가 현재 허용되지 않는 key (`UNREADABLE` 상태)
+  - 조회 조건을 만족하는 첫 번째 element가 trim되어 있는 key (`OUT_OF_RANGE` 상태)
+- smget 조회 조건을 만족하는 elements를 조회하였지만 b+tree trim으로 추가의 element 조회가 불가능한 key를 trimmed keys로 분류한다.
+따라서, 응용에서는 trimmed keys에 대하여 백엔드 저장소인 DB에서 trim된 elements를 조회하여 최종 smget 결과에 반영해야 한다.
+- 중복 bkey를 허용하여 조회하는 duplcate 조회와 중복 bkey를 제거하고 unique bkey만을 조회하는 unique 조회를 지원한다.
 
-1) 기존 smget 동작 (1.8.X 이하 버전에서 동작하던 방식)
-   - smget 조회 조건을 만족하는 첫번째 element가 trim된 b+tree가 하나라도 존재하면 OUT_OF_RANGE 응답을 보낸다.
-     이 경우, 응용은 모든 key에 대해 백엔드 저장소인 DB에서 elements 조회한 후에
-     응용에서 sort-merge 작업을 수행하여야 한다.
-   - OUT_OF_RANGE가 없는 상황에서 smget을 수행하면서
-     조회 조건을 만족하는 두번째 이후의 element가 trim된 b+tree를 만나게 되면,
-     그 지점까지 조회한 elements를 최종 elements 결과로 하고
-     smget 수행 상태는 TRIMMED로 하여 응답을 보낸다.
-     이 경우, 응용은 모든 key에 대해 백엔드 저장소인 DB에서 trim 영역의 elements를 조회하여
-     smget 결과에 반영하여야 한다.
-
-2) 신규 smget 동작 (1.9.0 이후 버전에서 추가된 방식)
-   - 기존의 OUT_OF_RANGE에 해당하는 b+tree를 missed keys로 분류하고
-     나머지 b+tree들에 대해 smget을 계속 수행한다.
-     따라서, 응용에서는 missed keys에 한해서만
-     백엔드 저장소인 DB에서 elements를 조회하여 최종 smget 결과에 반영할 수 있다.
-   - smget 조회 조건을 만족하는 두번째 이후의 element가 trim된 b+tree가 존재하더라도,
-     그 지점에서 smget을 중지하는 것이 아니라, 그러한 b+tree를 trimmed keys로 분류하고
-     원하는 개수의 elements를 찾을 때까지 smget을 계속 진행한다.
-     따라서, 응용에서는 trimmed keys에 한하여
-     백엔드 저장소인 DB에서 trim된 elements를 조회하여 최종 smget 결과에 반영할 수 있다.
-   - bkey에 대한 unique 조회 기능을 지원한다.
-     중복 bkey를 허용하여 조회하는 duplcate 조회 외에
-     중복 bkey를 제거하고 unique bkey만을 조회하는 unique 조회를 지원한다.
-   - 조회 조건에 offset 기능을 제거한다.
-
-기존 smget 연산을 사용하더라도, offset 값은 항상 0으로 사용하길 권고한다.
-양수의 offset을 사용하는 smget에서 missed keys가 존재하고
-missed keys에 대한 DB 조회가 offset으로 skip된 element를 가지는 경우,
-응용에서 정확한 offset 처리가 불가능해지기 때문이다.
 이전의 조회 결과에 이어서 추가로 조회하고자 하는 경우,
 이전에 조회된 bkey 값을 바탕으로 bkey range를 재조정하여 사용할 수 있다.
 
 ```
-bop smget <lenkeys> <numkeys> <bkey or "bkey range"> [<eflag_filter>] <count> [duplicate|unique]\r\n
+bop smget <lenkeys> <numkeys> <bkey or "bkey range"> [<eflag_filter>] <count> duplicate|unique\r\n
 <"space separated keys">\r\n
 * <eflag_filter> : <fwhere> [<bitwop> <foperand>] <compop> <fvalue>
 ```
@@ -446,45 +422,13 @@ Bkey range는 "bkey1..bkey2" 형식으로 표현한다.
 - \<eflag_filter\> - eflag filter 조건.
 [Collection 기본 개념](ch02-collection-items.md)에서 eflag filter 참조 바란다.
 - \<count\> - 조회할 element 개수
-- [duplicate|unique] - smget 동작 방식을 지정한다.
-  - 생략되면, 예전 smget 동작을 수행한다.
-  - 지정되면, 신규 smget 동작을 수행한다. duplicate는 중복 bkey를 허용하고, unique는 중복 bkey를 제거한다.
+- `duplicate|unique` - duplicate는 중복 bkey를 허용하고, unique는 중복 bkey를 제거한다.
 
 bop smget 명령은 O(small N) 수행 원칙을 위하여 다음의 제약 사항을 가진다.
 - key list에 지정 가능한 최대 key 수는 10000이다.
 - count의 최솟값은 1, 최댓값은 2000이다.
 
-기존 smget 동작에서 성공 시의 response string은 다음과 같다.
-
-```
-VALUE <ecount>\r\n
-<key> <flags> <bkey> [<eflag>] <bytes> <data>\r\n
-<key> <flags> <bkey> [<eflag>] <bytes> <data>\r\n
-<key> <flags> <bkey> [<eflag>] <bytes> <data>\r\n
-...
-MISSED_KEYS <kcount>\r\n
-<key>\r\n
-<key>\r\n
-…
-END|DUPLICATED|TRIMMED|DUPLICATRED_TRIMMED\r\n
-```
-
-위 response string에 대한 설명은 다음과 같다.
-
-- VALUE 부분: 조회한 elements를 나타낸다.
-  - Element 정보는 조회한 element가 속한 b+tree의 key string과 flags 정보
-    그리고 그 element의 bkey, optional eflag, data로 구성된다.
-  - Element 정보는 bkey 기준으로 정렬되며,
-    동일 bkey를 가진 elements는 key string 기준으로 정렬된다.
-- MISSED_KEYS 부분: smget 조회에 참여하지 못한 key list와 그 원인을 나타낸다.
-  - \<key\>는 smget에 참여하지 못한 key string이다.
-- 마지막 라인은 smget response string의 마지막을 나타낸다.
-  - END: 조회 결과에 중복 bkey가 없음
-  - DUPLICATED: 조회 결과에 중복 bkey가 있음.
-  - TRIMMED: 조회 범위가 trim 영역과 겹치는 b+tree를 발견한 상태이다.
-  - DUPLICATED_TRIMMED: DUPLICATED와 TRIMMED 의미를 모두 가진다.
-
-신규 smget 동작에서 성공 시의 response string은 다음과 같다.
+성공 시의 response string은 다음과 같다.
 
 ```
 ELEMENTS <ecount>\r\n


### PR DESCRIPTION
- jam2in/arcus-works#472

bop smget 문서를 정리합니다.
https://github.com/namsic/arcus-memcached/blob/works%23472/doc-smget/docs/ascii-protocol/ch08-command-btree-collection.md#bop-smget

- old 인터페이스 관련 내용 제거
- 구조 및 표현 전반적으로 재작성
