### PR TITLE
INTERNAL: Show log when deps/install.sh fails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN yum install -y make libtool which git
 # Copy all files from the repository not included in .dockerignore to /src in the image.
 COPY . /src
 WORKDIR /src
-RUN ./deps/install.sh /arcus
+RUN ./deps/install.sh /arcus || (tail ./deps/install.log; exit 1)
 RUN ./config/autorun.sh
 RUN ./configure --prefix=/arcus --enable-zk-integration
 RUN make && make install


### PR DESCRIPTION
docker image build 과정에서 deps/install.sh 실패하는 경우,

`deps/install.sh`의 출력에는 에러 원인이 나타나지 않고 빌드 결과물도 남지 않으므로 `deps/install.log`를 확인하는 것도 어렵습니다.

실패 시 로그의 마지막 부분을 출력하여 빌드 실패 원인 파악에 도움이 되도록 합니다.