### PR TITLE
INTERNAL: Remove CMD on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,6 @@ ENTRYPOINT ["memcached",\
  "-u", "root",\
  "-D", ":",\
  "-r"]
-CMD [\
- "-v",\
- "-p", "11211",\
- "-m", "100",\
- "-c", "100"]
 
 # for arcus-operator
 FROM base


### PR DESCRIPTION
@oliviarla 

docker image에 아무 옵션도 설정하지 않았을 때 Dockerfile의 CMD에 의해 추가되는 구동 옵션이
캐시 서버에 아무 옵션도 설정하지 않고 구동했을 때의 default 설정값과 서로 달라 혼란을 야기합니다.

따라서 docker image의 기본 옵션을 제거합니다.