### PR TITLE
INTERNAL: Prevent overflow when convert string to 32bit int

### DIFF
--- a/util.c
+++ b/util.c
@@ -74,7 +74,7 @@ bool safe_strtoul(const char *str, uint32_t *out) {
     errno = 0;
 
     l = strtoul(str, &endptr, 10);
-    if (errno == ERANGE) {
+    if (errno == ERANGE || l > UINT32_MAX) {
         return false;
     }
 
@@ -100,7 +100,7 @@ bool safe_strtol(const char *str, int32_t *out) {
     *out = 0;
     char *endptr;
     long l = strtol(str, &endptr, 10);
-    if (errno == ERANGE)
+    if (errno == ERANGE || l < INT32_MIN || l > INT32_MAX)
         return false;
     if (isspace(*endptr) || (*endptr == '\0' && endptr != str)) {
         *out = l;


### PR DESCRIPTION
- jam2in/arcus-works#475

문자열을 32bit 정수 자료형 변환 과정이 3단계(`string` -> `long(64bit)` -> `int(32bit)`)로 이루어짐으로써
overflow 발생 시 undefined value로 변환되는 현상을 수정합니다.

해당 현상 발생시 return false를 하도록 수정했습니다.