### PR TITLE
CLEANUP: Use default_version variable in version.pl

### DIFF
--- a/config/version.pl
+++ b/config/version.pl
@@ -11,9 +11,10 @@ chomp $version;
 #my $version = '1.4.2-30-gf966dba';
 #my $version = '1.4.3-rc1';
 #my $version = '1.4.3';
+my $default_version = '1.13.5-unknown';
 
 unless ($version =~ m/^\d+\.\d+\.\d+/) {
-    write_file('m4/version.m4', "m4_define([VERSION_NUMBER], [1.13.5-unknown])\n");
+    write_file('m4/version.m4', "m4_define([VERSION_NUMBER], [$default_version])\n");
     exit;
 }
 


### PR DESCRIPTION
- jam2in/arcus-memcached-EE#1092

`git describe` 명령을 통해 버전 정보를 얻어오는 데 실패한 경우 사용할 버전 문자열을 별도의 변수로 분리합니다.