### PR TITLE
INTERNAL: Fix the invalid allowable range of run options

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -15180,10 +15180,9 @@ int main (int argc, char **argv)
         case 'm':
             cache_memory_limit = atoi(optarg);
             settings.maxbytes = (size_t)cache_memory_limit * 1024 * 1024;
-            if (cache_memory_limit < 0 || settings.maxbytes < settings.sticky_limit) {
+            if (cache_memory_limit <= 0) {
                 mc_logger->log(EXTENSION_LOG_WARNING, NULL,
-                    "The value of memory limit must be"
-                    " greater than 0 and sticky_limit.\n");
+                    "The value of memory limit must be greater than 0.\n");
                 return 1;
             }
             old_opts += sprintf(old_opts, "cache_size=%llu;",
@@ -15197,10 +15196,9 @@ int main (int argc, char **argv)
         case 'g':
             sticky_memory_limit = atoi(optarg);
             settings.sticky_limit = (size_t)sticky_memory_limit * 1024 * 1024;
-            if (sticky_memory_limit < 0 || settings.sticky_limit > settings.maxbytes) {
+            if (sticky_memory_limit <= 0) {
                 mc_logger->log(EXTENSION_LOG_WARNING, NULL,
-                    "The value of sticky(gummed) memory limit must be"
-                    " greater than 0 and less than memlimit.\n");
+                    "The value of sticky(gummed) memory limit must be greater than 0.\n");
                 return 1;
             }
             old_opts += sprintf(old_opts, "sticky_limit=%llu;",
@@ -15234,7 +15232,7 @@ int main (int argc, char **argv)
             break;
         case 'R':
             settings.reqs_per_event = atoi(optarg);
-            if (settings.reqs_per_event == 0) {
+            if (settings.reqs_per_event <= 0) {
                 mc_logger->log(EXTENSION_LOG_WARNING, NULL,
                     "Number of requests per event must be greater than 0\n");
                 return 1;
@@ -15257,7 +15255,7 @@ int main (int argc, char **argv)
            break;
         case 'n':
             settings.chunk_size = atoi(optarg);
-            if (settings.chunk_size == 0) {
+            if (settings.chunk_size <= 0) {
                 mc_logger->log(EXTENSION_LOG_WARNING, NULL,
                         "Chunk size must be greater than 0\n");
                 return 1;
@@ -15579,6 +15577,12 @@ int main (int argc, char **argv)
     }
     if (settings.udpport != 0) {
         nfiles += settings.num_threads * 2;
+    }
+
+    if (settings.maxbytes < settings.sticky_limit) {
+        mc_logger->log(EXTENSION_LOG_WARNING, NULL,
+            "The value of memory limit cannot be smaller than sticky_limit.\n");
+        return 1;
     }
 
     if (settings.maxconns <= nfiles) {


### PR DESCRIPTION
memcached 의 몇몇 구동옵션에서 허용되지 않는 수(음수)를 줄 수 있는 현상을 수정 또는 관련 로그 메시지를 수정합니다.

추가적으로 Memory Limit(maxbytes)옵션인 -m 옵션에서 0을 허용하고 있어,
slabs 모듈 확인 결과 할당 과정에서 아래의 로직을 확인할 수 있었습니다.
```c
if ((slabsp->mem_limit && slabsp->mem_malloced + len > slabsp->mem_limit && p->slabs >= p->rsvd_slabs) ||
    (grow_slab_list(id) == 0) ||
    ((ptr = memory_allocate((size_t)len)) == 0)) {

    MEMCACHED_SLABS_SLABCLASS_ALLOCATE_FAILED(id);
    return 0;
}
```
mem_limit(maxbytes)를 0으로 설정한 경우는 메모리에 대한 제한을 두지 않기 위한 용도인가요?

