### PR TITLE
INTERNAL: Reduce add_iov() work for TCP connections

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -1206,6 +1206,9 @@ static int ensure_iov_space(conn *c)
  * connection.
  *
  * Returns 0 on success, -1 on out-of-memory.
+ * Note: This is a hot path for at least ASCII protocol. While there is
+ * redundant code in splitting TCP/UDP handling, any reduction in steps has a
+ * large impact for TCP connections.
  */
 
 static int add_iov(conn *c, const void *buf, int len)
@@ -1213,20 +1216,48 @@ static int add_iov(conn *c, const void *buf, int len)
     assert(c != NULL);
     struct msghdr *m;
     int leftover;
-    bool limit_to_mtu;
 
-    do {
+    if (IS_UDP(c->transport)) {
+        do {
+            m = &c->msglist[c->msgused - 1];
+
+            /*
+             * Limit UDP packets to UDP_MAX_PAYLOAD_SIZE bytes.
+             */
+
+            /* We may need to start a new msghdr if this one is full. */
+            if (m->msg_iovlen == IOV_MAX ||
+                (c->msgbytes >= UDP_MAX_PAYLOAD_SIZE)) {
+                add_msghdr(c);
+                m = &c->msglist[c->msgused - 1];
+            }
+
+            if (ensure_iov_space(c) != 0)
+                return -1;
+
+            /* If the fragment is too big to fit in the datagram, split it up */
+            if (len + c->msgbytes > UDP_MAX_PAYLOAD_SIZE) {
+                leftover = len + c->msgbytes - UDP_MAX_PAYLOAD_SIZE;
+                len -= leftover;
+            } else {
+                leftover = 0;
+            }
+
+            m = &c->msglist[c->msgused - 1];
+            m->msg_iov[m->msg_iovlen].iov_base = (void *)buf;
+            m->msg_iov[m->msg_iovlen].iov_len = len;
+
+            c->msgbytes += len;
+            c->iovused++;
+            m->msg_iovlen++;
+
+            buf = ((char *)buf) + len;
+            len = leftover;
+        } while (leftover > 0);
+    } else {
+        /* Optimized path for TCP connections */
         m = &c->msglist[c->msgused - 1];
-
-        /*
-         * Limit UDP packets, and the first payloads of TCP replies, to
-         * UDP_MAX_PAYLOAD_SIZE bytes.
-         */
-        limit_to_mtu = IS_UDP(c->transport) || (1 == c->msgused);
-
-        /* We may need to start a new msghdr if this one is full. */
-        if (m->msg_iovlen == IOV_MAX ||
-            (limit_to_mtu && c->msgbytes >= UDP_MAX_PAYLOAD_SIZE)) {
+        if (m->msg_iovlen == IOV_MAX) {
             add_msghdr(c);
             m = &c->msglist[c->msgused - 1];
         }
@@ -1234,26 +1265,12 @@ static int add_iov(conn *c, const void *buf, int len)
         if (ensure_iov_space(c) != 0)
             return -1;
 
-        /* If the fragment is too big to fit in the datagram, split it up */
-        if (limit_to_mtu && len + c->msgbytes > UDP_MAX_PAYLOAD_SIZE) {
-            leftover = len + c->msgbytes - UDP_MAX_PAYLOAD_SIZE;
-            len -= leftover;
-        } else {
-            leftover = 0;
-        }
-
-        m = &c->msglist[c->msgused - 1];
         m->msg_iov[m->msg_iovlen].iov_base = (void *)buf;
         m->msg_iov[m->msg_iovlen].iov_len = len;
-
         c->msgbytes += len;
         c->iovused++;
         m->msg_iovlen++;
-
-        buf = ((char *)buf) + len;
-        len = leftover;
-    } while (leftover > 0);
-
+    }
     return 0;
 }
 


### PR DESCRIPTION
> I keep putting off a major refactor on the (nearly 11 year old in its current state) frontend code. Now that my internal fiddling is starting to slow down it was worth a shot at some low hanging fruit. When doing the ascii response inlining work I noticed add_iov() taking up a lot of CPU. When reviewing my old notes and the original patch from Steven Grimm it's clear that the pipeline was optimized for (2006-era) UDP traffic. All the extra wrapped code ended up causing a lot of extra work for TCP sockets.
> - memcached/memcached#243
> - [312ae0d](https://github.com/memcached/memcached/pull/243/commits/312ae0d2382f970b556b64bc63a383f83954ab2d)

TCP 프로토콜에서 첫 payload에 대하여 msghdr를 나누었던 구현을 수정합니다.
memcached에서 반영되었던 commit을 그대로 복사했습니다.