### PR TITLE
TEST: Unset an environment variable for topkeys

### DIFF
--- a/t/topkeys.t
+++ b/t/topkeys.t
@@ -7,11 +7,15 @@ use lib "$Bin/lib";
 use MemcachedTest;
 
 my $engine = shift;
-my $server = get_memcached($engine);
-my $sock = $server->sock;
+my $server;
+my $sock;
 my $cmd;
 my $val;
 my $rst;
+
+delete $ENV{"MEMCACHED_TOP_KEYS"};
+$server = get_memcached($engine);
+$sock = $server->sock;
 
 $cmd = "stats topkeys"; $rst = "NOT_SUPPORTED";
 mem_cmd_is($sock, $cmd, "", $rst, "No topkeys without command line option.");


### PR DESCRIPTION
Topkey 테스트에서 환경변수가 이미 설정되어 있을 시 실패하던 문제를 수정합니다.