### PR TITLE
CLEANUP: Call shutdown_server() in sigterm_handler()

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -14524,6 +14524,17 @@ static void remove_pidfile(const char *pid_file)
     }
 }
 
+static void shutdown_server(void)
+{
+    memcached_shutdown = 1;
+
+#ifdef ENABLE_ZK_INTEGRATION
+    if (arcus_zk_cfg) {
+        arcus_zk_shutdown = 1;
+    }
+#endif
+}
+
 static void sigterm_handler(int sig)
 {
     assert(sig == SIGTERM || sig == SIGINT);
@@ -14533,13 +14544,7 @@ static void sigterm_handler(int sig)
                        "memcached shutdown by signal(%s)\n",
                        (sig == SIGINT ? "SIGINT" : "SIGTERM"));
     }
-    memcached_shutdown = 1;
-
-#ifdef ENABLE_ZK_INTEGRATION
-    if (arcus_zk_cfg) {
-        arcus_zk_shutdown = 1;
-    }
-#endif
+    shutdown_server();
 }
 
 static int install_sigterm_handler(void)
@@ -14813,20 +14818,6 @@ static bool is_my_key(const char *key, size_t nkey)
     return true;
 }
 #endif
-
-static void shutdown_server(void)
-{
-    if (settings.verbose) {
-        mc_logger->log(EXTENSION_LOG_INFO, NULL, "memcached shutdown by api\n");
-    }
-    memcached_shutdown = 1;
-
-#ifdef ENABLE_ZK_INTEGRATION
-    if (arcus_zk_cfg) {
-        arcus_zk_shutdown = 1;
-    }
-#endif
-}
 
 static EXTENSION_LOGGER_DESCRIPTOR* get_logger(void)
 {


### PR DESCRIPTION
### 🔗 Related Issue
- jam2in/arcus-works#519

### ⌨️ What I did
- `sigterm_handler()`에서 flag 직접 설정하는 대신 `shutdown_server()` 호출하도록 합니다.
- `shutdown_server()` 함수 위치가 `sigterm_handler()` 상단으로 이동됩니다.

### 🤔 Others
- 종료 전 대기 로직이 추가되는 경우, signal 수신 시의 동작이 flag만 설정하는 지금보다는 복잡해지게 될 것입니다.
이에 대한 사전 PR의 성격을 띄고 있습니다.
  - zk 연결 종료
  - shutdown 예약

- 꼭 위 이슈의 구현 방안과 연관짓지 않더라도, shutdown api 호출과 signal 수신 모두
graceful shutdown 수행해야 할 것이므로 하나의 구현을 공유하는 것이 나쁠 것 없다고 판단했습니다.