### PR TITLE
INTERNAL: Set shutdown_time in shutdown_server and check in clock_handler

### DIFF
--- a/arcus_zk.c
+++ b/arcus_zk.c
@@ -1414,7 +1414,7 @@ static int arcus_check_domain_name(char *ensemble_list)
 }
 #endif
 
-void arcus_zk_init(char *ensemble_list, int zk_to,
+void arcus_zk_init(char *ensemble_list, int zk_to, int zk_sd,
                    EXTENSION_LOGGER_DESCRIPTOR *logger,
                    int verbose, size_t maxbytes, int port,
 #ifdef PROXY_SUPPORT
@@ -1458,6 +1458,9 @@ void arcus_zk_init(char *ensemble_list, int zk_to,
          */
         if (zk_to >= MIN_ZK_TO && zk_to <= MAX_ZK_TO) {
             arcus_conf.zk_timeout = zk_to*1000; // msec conversion
+        }
+        if (zk_sd >= 0) {
+            arcus_conf.shutdown_delay = zk_sd;
         }
     }
 

--- a/arcus_zk.c
+++ b/arcus_zk.c
@@ -147,6 +147,7 @@ typedef struct {
     int     port;               // memcached port number
     bool    zk_failstop;        // memcached automatic failstop on/off
     int     zk_timeout;         // Zookeeper session timeout
+    int     shutdown_delay;     // Graceful shutdown waits for some time after znode removal (unit: s)
     bool    auto_scrub;         // automactic scrub_stale
     char   *znode_name;         // Ephemeral ZK node name for this mc identification
     int     znode_ver;          // Ephemeral ZK node version
@@ -176,6 +177,7 @@ arcus_zk_config arcus_conf = {
     .hostip         = NULL,
     .zk_failstop    = true,
     .zk_timeout     = DEFAULT_ZK_TO,
+    .shutdown_delay = -1,
     .auto_scrub     = true,
     .znode_name     = NULL,
     .znode_ver      = -1,
@@ -1831,6 +1833,8 @@ void arcus_zk_get_confs(arcus_zk_confs *confs)
 {
     confs->zk_libversion = zoo_version_str();
     confs->zk_timeout = arcus_conf.zk_timeout;
+    confs->shutdown_delay = arcus_conf.shutdown_delay < 0
+        ? (arcus_conf.zk_timeout / 1000) : arcus_conf.shutdown_delay;
     confs->zk_failstop = arcus_conf.zk_failstop;
 }
 

--- a/arcus_zk.h
+++ b/arcus_zk.h
@@ -28,6 +28,7 @@ typedef struct {
     const char  *zk_libversion; // Zookeeper client version
     uint32_t    zk_timeout;     // Zookeeper session timeout (unit: ms)
     bool        zk_failstop;    // memcached automatic failstop
+    int         shutdown_delay; // Graceful shutdown waits for some time after znode removal (unit: s)
 } arcus_zk_confs;
 
 typedef struct {

--- a/arcus_zk.h
+++ b/arcus_zk.h
@@ -45,7 +45,7 @@ typedef struct {
 
 extern volatile sig_atomic_t arcus_zk_shutdown;
 
-void arcus_zk_init(char *ensemble_list, int zk_to,
+void arcus_zk_init(char *ensemble_list, int zk_to, int zk_sd,
                    EXTENSION_LOGGER_DESCRIPTOR *logger,
                    int verbose, size_t maxbytes, int port,
 #ifdef PROXY_SUPPORT

--- a/memcached.c
+++ b/memcached.c
@@ -15106,6 +15106,7 @@ int main (int argc, char **argv)
 
 #ifdef ENABLE_ZK_INTEGRATION
     int  arcus_zk_to=0;
+    int  arcus_zk_sd=-1;
 #ifdef PROXY_SUPPORT
     char *arcus_proxy_cfg = NULL;
 #endif
@@ -15164,6 +15165,7 @@ int main (int argc, char **argv)
 #ifdef ENABLE_ZK_INTEGRATION
           "z:"  /* Arcus Zookeeper */
           "o:"  /* Arcus Zookeeper session timeout option (sec) */
+          "Z:"  /* Arcus Zookeeper shutdown delay (sec) */
 #ifdef PROXY_SUPPORT
           "x:"  /* Proxy server ip:port */
 #endif
@@ -15399,6 +15401,9 @@ int main (int argc, char **argv)
             break;
         case 'o': /* Arcus Zookeeper session timeout */
             arcus_zk_to = atoi(optarg); // this value is in seconds
+            break;
+        case 'Z': /* Arcus Zookeeper shutdown delay */
+            arcus_zk_sd = atoi(optarg); // this value is in seconds
             break;
 #ifdef PROXY_SUPPORT
         case 'x': /* configure for proxy server */
@@ -15805,7 +15810,7 @@ int main (int argc, char **argv)
             exit(EXIT_FAILURE);
         }
         /* init zk module */
-        arcus_zk_init(arcus_zk_cfg, arcus_zk_to, mc_logger,
+        arcus_zk_init(arcus_zk_cfg, arcus_zk_to, arcus_zk_sd, mc_logger,
                       settings.verbose, settings.maxbytes, settings.port,
 #ifdef PROXY_SUPPORT
                       arcus_proxy_cfg,

--- a/memcached.c
+++ b/memcached.c
@@ -14557,6 +14557,9 @@ static void shutdown_server(void)
     if (arcus_zk_cfg) {
         arcus_zk_shutdown = 1;
         arcus_zk_final("graceful shutdown");
+        arcus_zk_confs zk_confs;
+        arcus_zk_get_confs(&zk_confs);
+        shutdown_delay = zk_confs.shutdown_delay;
     }
 #endif
     shutdown_time = current_time + shutdown_delay;


### PR DESCRIPTION
### 🔗 Related Issue
- jam2in/arcus-works#519

### ⌨️ What I did
- graceful shutdown 시 zk 연결을 우선 종료합니다.
- zk 연결 종료 후 일정 시간이 흐른 후 shutdown 로직을 수행합니다.

## 🤔 Others
- 작업 과정에서는 진행 편의 및 리뷰를 위해 commit을 단계별로 분리 예정

`INTERNAL: Use shutdown_time checked by clock_handler()`
1. shutdown api가 불리면, `arcus_zk_final()` 수행 후 종료 시간(`shutdown_time`)을 설정
2. `clock_handler()`가 `shutdown_time`과 `current_time` 비교하여 `memcached_shutdown` flag 설정

`INTERNAL: Add shutdown_delay to arcus_zk_confs`
1. zk config에 shutdown_delay 항목 추가
2. default delay는 zk의 session timeout이 되도록

`INTERNAL: Add 'Z' option for set zookeeper shutdown delay`
1. 구동 옵션 추가
2. `arcus_zk_init()` 호출 시 인자로 넘겨 shutdown_delay 설정