### PR TITLE
FEATURE: Add shutdown command

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -85,6 +85,7 @@ void UNLOCK_SETTING(void) {
     pthread_mutex_unlock(&setting_lock);
 }
 
+static pthread_mutex_t shutdown_lock = PTHREAD_MUTEX_INITIALIZER;
 volatile sig_atomic_t memcached_shutdown=0;
 
 /*
@@ -14545,7 +14546,11 @@ static void remove_pidfile(const char *pid_file)
 
 static void shutdown_server(void)
 {
-    memcached_shutdown = 1;
+    pthread_mutex_lock(&shutdown_lock);
+    if (memcached_shutdown == 0) {
+        memcached_shutdown = 1;
+    }
+    pthread_mutex_unlock(&shutdown_lock);
 }
 
 static void sigterm_handler(int sig)
@@ -15828,7 +15833,9 @@ int main (int argc, char **argv)
     mc_logger->log(EXTENSION_LOG_INFO, NULL, "Listen sockets closed.\n");
 
     /* 4) shutdown all threads */
+    pthread_mutex_lock(&shutdown_lock);
     memcached_shutdown = 2;
+    pthread_mutex_unlock(&shutdown_lock);
     threads_shutdown();
     release_independent_stats(default_thread_stats);
     if (default_topkeys) {


### PR DESCRIPTION
### 🔗 Related Issue
- jam2in/arcus-works#519

### ⌨️ What I did
`shutdown`명령을 추가합니다. 명령 추가 후 캐시 서버의 종료 동작은 크게 3가지로 구분됩니다.
- shutdown api 호출(SIGNAL, hb fail, …)
  - 즉시 종료 로직을 수행합니다. (기존 종료 로직과 동일)

- `shutdown`
  - main event loop를 종료한 후 최대 2초간 대기합니다.
  - 클라이언트 연결 수가 일정 시간(200ms) 감소하지 않으면 2초까지 대기하지 않고 즉시 종료합니다.

- `shutdown <seconds>`
  - main event loop를 종료한 후 주어진 시간만큼 대기합니다.
  - 클라이언트 연결 수가 감소하지 않아도 고정 시간만큼 대기한 뒤 종료합니다.

종료 동작은 가장 마지막에 호출된 함수 기준으로 동작합니다.
- `shutdown 30` 수행하여 종료 예약된 상태에서 SIGTERM 수신하는 경우 즉시 종료
- `shutdown 30` 수행하고 20초 뒤 `shutdown 60` 명령 수행하면,
두 번째 `shutdown` 명령 수신 시점으로부터 60초 대기 후 종료