### PR TITLE
INTERNAL: Do not extern arcus_zk_shutdown

### DIFF
--- a/arcus_zk.h
+++ b/arcus_zk.h
@@ -42,8 +42,6 @@ typedef struct {
 
 /* Interface between memcached.c and arcus_zk.c */
 
-extern volatile sig_atomic_t arcus_zk_shutdown;
-
 void arcus_zk_init(char *ensemble_list, int zk_to,
                    EXTENSION_LOGGER_DESCRIPTOR *logger,
                    int verbose, size_t maxbytes, int port,

--- a/memcached.c
+++ b/memcached.c
@@ -14546,12 +14546,6 @@ static void remove_pidfile(const char *pid_file)
 static void shutdown_server(void)
 {
     memcached_shutdown = 1;
-
-#ifdef ENABLE_ZK_INTEGRATION
-    if (arcus_zk_cfg) {
-        arcus_zk_shutdown = 1;
-    }
-#endif
 }
 
 static void sigterm_handler(int sig)


### PR DESCRIPTION
### 🔗 Related Issue
- jam2in/arcus-works#519
- jam2in/arcus-works#536

### ⌨️ What I did
- `arcus_zk_shutdown` flag를 `static`으로 변경합니다.

- zk_final, hb_final 시점을 앞당깁니다.
  - 기존: main thread event loop 종료 후
  - 변경: shutdown api 호출 시점

- `arcus_zk_final()` 함수 안에서 `arcus_zk_shutdown` 값을 변경합니다.
  - 기존: sm thread 종료(`arcus_zk_shutdown = 1`)와 zk 연결 종료(`arcus_zk_final()`)를 구분
  변경: `arcus_zk_final()` 호출하면 두 동작을 이어서 수행