### PR TITLE
INTERNAL: Add an arcus_zk_initalized function

### DIFF
--- a/arcus_zk.c
+++ b/arcus_zk.c
@@ -1838,6 +1838,11 @@ void arcus_zk_get_stats(arcus_zk_stats *stats)
 #endif
 }
 
+bool arcus_zk_initalized(void)
+{
+    return main_zk != NULL;
+}
+
 #ifdef ENABLE_CLUSTER_AWARE
 int arcus_key_is_mine(const char *key, size_t nkey, bool *mine)
 {

--- a/arcus_zk.h
+++ b/arcus_zk.h
@@ -61,6 +61,7 @@ bool arcus_zk_get_failstop(void);
 void arcus_zk_get_confs(arcus_zk_confs *confs);
 void arcus_zk_get_stats(arcus_zk_stats *stats);
 
+bool arcus_zk_initalized(void);
 #ifdef ENABLE_CLUSTER_AWARE
 int  arcus_key_is_mine(const char *key, size_t nkey, bool *mine);
 #endif

--- a/memcached.c
+++ b/memcached.c
@@ -9246,7 +9246,7 @@ static void process_zkensemble_command(conn *c, token_t *tokens, const size_t nt
     char *subcommand = tokens[SUBCOMMAND_TOKEN].value;
     bool valid = false;
 
-    if (arcus_zk_cfg == NULL) {
+    if (!arcus_zk_initalized()) {
         out_string(c, "ERROR not using ZooKeeper");
         return;
     }
@@ -13271,7 +13271,7 @@ static void process_command_ascii(conn *c, char *command, int cmdlen)
     {
         char *response = "READY";
 #ifdef ENABLE_ZK_INTEGRATION
-        if (arcus_zk_cfg) {
+        if (arcus_zk_initalized()) {
             arcus_zk_stats zk_stats;
             arcus_zk_get_stats(&zk_stats);
             if (!zk_stats.zk_ready) response = "NOT_READY";
@@ -15418,7 +15418,7 @@ int main (int argc, char **argv)
         case 'z': /* configure for Arcus zookeeper cluster */
                   /* host_list in the form of
                      -z 10.0.0.1:2181,10.0.0.2:2181,10.0.0.3:2181 */
-            arcus_zk_cfg = strdup(optarg);
+            arcus_zk_cfg = optarg;
             break;
         case 'o': /* Arcus Zookeeper session timeout */
             arcus_zk_to = atoi(optarg); // this value is in seconds
@@ -15913,7 +15913,6 @@ int main (int argc, char **argv)
     /* 7) destroy cluster config structure */
     if (arcus_zk_cfg) {
         arcus_zk_destroy();
-        free(arcus_zk_cfg);
     }
 #endif
 


### PR DESCRIPTION
### 🔗 Related Issue
- jam2in/arcus-works#551

### ⌨️ What I did
- zk_integrated 판별을 memcached.c 가 아닌 arcus_zk 모듈을 통해 가능하게 끔 변경합니다.

### 🎯 To Do
- [x] zkensemble 명령어 테스트 진행 (모두 이전과 동일)
  - `-z` 옵션이 주어진 경우
  ```
  # Client
  zkensemble get
  0.0.0.0:50000 
  ```
  - `-z` 옵션이 주어지지 않은 경우
  ```
  zkensemble get
  ERROR not using ZooKeeper
  ```
  - mc_pause 상태
  ```
  # Server
  zk connection closed by mc_pause.
  Failed to get the ZooKeeper ensemble list. Invalid ZK handle.
  # Client
  zkensemble get
  ERROR failed to get the ensemble address
  zkensemble rejoin
  Successfully rejoined
  ```