### PR TITLE
INTERNAL: Move a cmdlog_in_use variable

### DIFF
--- a/cmdlog.h
+++ b/cmdlog.h
@@ -21,10 +21,12 @@
 
 #define COMMAND_LOGGING
 
+extern bool cmdlog_in_use;
+
 void cmdlog_init(int port, EXTENSION_LOGGER_DESCRIPTOR *logger);
 void cmdlog_final(void);
 int cmdlog_start(char *file_path, bool *already_started);
 void cmdlog_stop(bool *already_stopped);
 char *cmdlog_stats(void);
-bool cmdlog_write(char client_ip[], char *command);
+void cmdlog_write(char client_ip[], char *command);
 #endif

--- a/memcached.c
+++ b/memcached.c
@@ -121,10 +121,6 @@ topkeys_t *default_topkeys = NULL;
 static char *arcus_zk_cfg = NULL;
 #endif
 
-#ifdef COMMAND_LOGGING
-static bool cmdlog_in_use = false;
-#endif
-
 #ifdef DETECT_LONG_QUERY
 static bool lqdetect_in_use = false;
 #endif
@@ -9957,10 +9953,8 @@ static void process_cmdlog_command(conn *c, token_t *tokens, const size_t ntoken
         }
         if (ret == 0) {
             out_string(c, "\tcommand logging started.\n");
-            cmdlog_in_use = true;
         } else {
             out_string(c, "\tcommand logging failed to start.\n");
-            cmdlog_in_use = false;
         }
     } else if (ntokens > 2 && strcmp(type, "stop") == 0) {
         cmdlog_stop(&already_check);
@@ -9968,7 +9962,6 @@ static void process_cmdlog_command(conn *c, token_t *tokens, const size_t ntoken
             out_string(c, "\tcommand logging already stopped.\n");
         } else {
             out_string(c, "\tcommand logging stopped.\n");
-            cmdlog_in_use = false;
         }
     } else if (ntokens > 2 && strcmp(type, "stats") == 0) {
         char *str = cmdlog_stats();
@@ -13116,9 +13109,7 @@ static void process_command_ascii(conn *c, char *command, int cmdlen)
 
 #ifdef COMMAND_LOGGING
     if (cmdlog_in_use) {
-        if (cmdlog_write(c->client_ip, command) == false) {
-            cmdlog_in_use = false;
-        }
+        cmdlog_write(c->client_ip, command);
     }
 #endif
 


### PR DESCRIPTION
### 🔗 Related Issue
- jam2in/arcus-works#526

### ⌨️ What I did
- cmdlog_in_use 변수를 cmdlog 모듈로 이동합니다. 

### 🤔 Others
- 간단하게 이동만 시켰습니다.
- 이외에도 내부에 두고 API로 노출시키는 방향도 있습니다.