### PR TITLE
INTERNAL: Fix a sprintf error and remove a needless condition

### DIFF
--- a/cmdlog.c
+++ b/cmdlog.c
@@ -402,10 +402,6 @@ void cmdlog_write(char client_ip[], char* command)
     int inputlen;
     int nwritten;
 
-    if (! cmdlog_in_use) {
-        return;
-    }
-
     gettimeofday(&val, NULL);
     ptm = localtime(&val.tv_sec);
 

--- a/memcached.c
+++ b/memcached.c
@@ -1509,7 +1509,7 @@ static void pipe_response_done(conn *c, bool end_of_pipelining)
             str = "PIPE_ERROR bad error\r\n";
             len = 22;
         }
-        sprintf(c->pipe_resbuf + c->pipe_reslen, str);
+        sprintf(c->pipe_resbuf + c->pipe_reslen, "%s", str);
         c->pipe_reslen += len;
         c->pipe_errlen += len;
 


### PR DESCRIPTION
### ⌨️ What I did
- 컴파일 과정에서 발생한 에러를 수정합니다.
- 불필요한 cmdlog 조건문을 제거합니다.