### PR TITLE
DOC: Fix odd letters

### DIFF
--- a/docs/ascii-protocol/ch01-arcus-basic-concept.md
+++ b/docs/ascii-protocol/ch01-arcus-basic-concept.md
@@ -11,10 +11,10 @@ ARCUS Cache Server의 key-value 모델은 아래의 기본 제약 사항을 가�
 - 기존 key-value 모델의 제약 사항
   - Key의 최대 크기는 16000 character이다. (arcus-memcached 1.11 이후 버전)
     - 기존 버전에서 key 최대 크기는 250 character이다.
-  - Value의 최대 크기는 1MB(trailing 문자인 “\r\n” 포함한 길이) 이다.
+  - Value의 최대 크기는 1MB(trailing 문자인 "\r\n" 포함한 길이) 이다.
 - Collection 제약 사항
   - 하나의 collection에 들어갈 수 있는 최대 element 개수는 50,000개이다.
-  - Collection의 각 element가 가지는 value의 최대 크기는 16KB(trailing 문자인 “\r\n” 포함한 길이)이며 이는 설정으로 변경 가능하다.
+  - Collection의 각 element가 가지는 value의 최대 크기는 16KB(trailing 문자인 "\r\n" 포함한 길이)이며 이는 설정으로 변경 가능하다.
 
 ## Cache Key
 

--- a/docs/ascii-protocol/ch02-collection-items.md
+++ b/docs/ascii-protocol/ch02-collection-items.md
@@ -71,7 +71,7 @@ B+tree collection에서 사용가능한 bkey 데이터 유형은 아래 두 가�
 
 - hexadecimal
 
-  “0x”로 시작하는 짝수 개의 hexadecimal 문자열로 표현하며, 대소문자 모두 사용 가능하다.
+  "0x"로 시작하는 짝수 개의 hexadecimal 문자열로 표현하며, 대소문자 모두 사용 가능하다.
   ARCUS cache server는 두 hexadecimal 문자를 1 byte로 저장하며,
   1 ~ 31 길이의 variable length byte array로 저장한다.
 
@@ -117,7 +117,7 @@ eflag_filter: <fwhere> [<bitwop> <foperand>] <compop> <fvalue>
   - 생략 가능하며, eflag에 대한 bitwise 연산을 지정한다.
   - bitwise 연산이 지정되면 이 연산의 결과가 compare 연산의 대상이 되며,
     생략된다면 eflag 값 자체가 compare 연산의 대상이 된다.
-  - \<bitwop\>는 “&”(bitwise and), “|”(bitwise or), “^”(bitwise xor) 중의 하나로 bitwise 연산을 지정한다.
+  - \<bitwop\>는 "&"(bitwise and), "|"(bitwise or), "^"(bitwise xor) 중의 하나로 bitwise 연산을 지정한다.
   - \<foperand\>는 bitwise 연산을 취할 operand로 hexadecimal로 표현한다.
     \<foperand\>의 길이는 compare 연산을 취한 \<fvalue\>의 길이와 동일하여야 한다.
 - \<compop\> \<fvalue\>
@@ -133,7 +133,7 @@ eflag_filter: <fwhere> [<bitwop> <foperand>] <compop> <fvalue>
 하지만 응용이 필요하다면, 하나의 b+tree에 소속된 elements 이더라도
 eflag가 생략될 수도 있고 서로 다른 길이의 eflag를 가질 수도 있다.
 이 경우, 아래와 같이 eflag filtering이 애매모호해 질 수 있다.
-이 상황에서는 filter 조건의 비교 연산이 “NE”이면 true로 판별하고, 그 외의 비교 연산이면 false로 판별한다.
+이 상황에서는 filter 조건의 비교 연산이 "NE"이면 true로 판별하고, 그 외의 비교 연산이면 false로 판별한다.
 
 - eflag가 없는 element에 eflag_filter 조건이 주어질 수 있다.
 - eflag가 있지만 eflag_filter 조건에서 명시된 offset과 length의 데이터를 가지지 않을 수 있다.
@@ -156,7 +156,7 @@ eflag_update: [<fwhere> <bitwop>] <fvalue>
   - \<fwhere>은 eflag에서 부분 변경할 데이터의 시작 offset을 바이트 단위로 나타내며,
     이 경우, 부분 변경할 데이터의 length는 뒤에 명시되는 \<fvalue\>의 length로 결정된다.
   - \<bitwop\>는 부분 변경할 데이터에 대한 취할 bitwise 연산으로,
-    “&”(bitwise and), “|”(bitwise or), “^”(bitwise xor) 중의 하나로 지정할 수 있다.
+    "&"(bitwise and), "|"(bitwise or), "^"(bitwise xor) 중의 하나로 지정할 수 있다.
 - \<fvalue\>
   - 변경할 new value를 나타낸다.
   - 앞서 기술한 \<fwhere\>과 \<bitwop\>가 생략되면, eflag의 전체 데이터를 \<fvalue\>로 변경한다.

--- a/docs/ascii-protocol/ch03-item-attributes.md
+++ b/docs/ascii-protocol/ch03-item-attributes.md
@@ -23,15 +23,15 @@ ARCUS Cache Server는 collection 기능 지원으로 인해,
 |-----------------------------------------------------------------------------------------------------------------|
 | maxcount       | collection  | maximum # of elements | 4 bytes unsigned integer       | 4000                    |
 |-----------------------------------------------------------------------------------------------------------------|
-| overflowaction | collection  | overflow action       | “error”: all collections       | list: "tail_trim"       |
-|                |             |                       | “head_trim”: list              | set: "error"            |
-|                |             |                       | “tail_trim”: list              | map: "error"            |
-|                |             |                       | “smallest_trim”: b+tree        | b+tree: "smallest_trim" |
-|                |             |                       | “largest_trim”: b+tree         |                         |
-|                |             |                       | “smallest_silent_trim”: b+tree |                         |
-|                |             |                       | “largest_silent_trim”: b+tree  |                         |
+| overflowaction | collection  | overflow action       | "error": all collections       | list: "tail_trim"       |
+|                |             |                       | "head_trim": list              | set: "error"            |
+|                |             |                       | "tail_trim": list              | map: "error"            |
+|                |             |                       | "smallest_trim": b+tree        | b+tree: "smallest_trim" |
+|                |             |                       | "largest_trim": b+tree         |                         |
+|                |             |                       | "smallest_silent_trim": b+tree |                         |
+|                |             |                       | "largest_silent_trim": b+tree  |                         |
 |-----------------------------------------------------------------------------------------------------------------|
-| readable       | collection  | readable/unreadable   | “on”, “off”                    | "on"                    |
+| readable       | collection  | readable/unreadable   | "on", "off"                    | "on"                    |
 |-----------------------------------------------------------------------------------------------------------------|
 | maxbkeyrange   | b+tree only | maximum bkey range    | 8 bytes unsigned integer or    | 0                       |
 |                |             |                       | hexadecimal (max 31 bytes)     |                         |

--- a/docs/ascii-protocol/ch04-command-key-value.md
+++ b/docs/ascii-protocol/ch04-command-key-value.md
@@ -47,7 +47,7 @@ mget <lenkeys> <numkeys>\r\n
 mgets <lenkeys> <numkeys>\r\n
 <"space separated keys">\r\n
 ```
-- \<”space separated keys”\> - key list로, 스페이스(' ')로 구분한다.
+- \<"space separated keys"\> - key list로, 스페이스(' ')로 구분한다.
 - \<lenkeys\>과 \<numkeys> - key list 문자열의 길이와 key 개수를 나타낸다.
 
 retrieval 명령이 정상 수행되었을 경우, Response string은 아래와 같이 구성된다.

--- a/docs/ascii-protocol/ch05-command-list-collection.md
+++ b/docs/ascii-protocol/ch05-command-list-collection.md
@@ -32,8 +32,8 @@ Response string과 그 의미는 아래와 같다.
 | "CREATED"                              | 성공
 | "EXISTS"                               | 동일 key string을 가진 item이 이미 존재
 | "NOT_SUPPORTED"                        | 지원하지 않음
-| “CLIENT_ERROR bad command line format” | protocol syntax 틀림
-| “SERVER_ERROR out of memory”           | 메모리 부족
+| "CLIENT_ERROR bad command line format" | protocol syntax 틀림
+| "SERVER_ERROR out of memory"           | 메모리 부족
 
 ## lop insert
 
@@ -63,16 +63,16 @@ Response string과 그 의미는 아래와 같다.
 | Response String                          | 설명                     |
 |------------------------------------------|------------------------ |
 | "STORED"                                 | 성공 (element만 삽입)
-| “CREATED_STORED”                         | 성공 (collection 생성하고 element 삽입)
-| “NOT_FOUND”                              | key miss
-| “TYPE_MISMATCH”                          | 해당 item이 list collection이 아님
-| “OVERFLOWED”                             | overflow 발생
-| “OUT_OF_RANGE”                           | 삽입 위치가 list의 현재 element index 범위를 넘어섬. 예를 들어, 10개 element가 있는 상태에서 삽입 위치가 20인 경우임
+| "CREATED_STORED"                         | 성공 (collection 생성하고 element 삽입)
+| "NOT_FOUND"                              | key miss
+| "TYPE_MISMATCH"                          | 해당 item이 list collection이 아님
+| "OVERFLOWED"                             | overflow 발생
+| "OUT_OF_RANGE"                           | 삽입 위치가 list의 현재 element index 범위를 넘어섬. 예를 들어, 10개 element가 있는 상태에서 삽입 위치가 20인 경우임
 | "NOT_SUPPORTED"                          | 지원하지 않음
-| “CLIENT_ERROR bad command line format”   | protocol syntax 틀림
-| “CLIENT_ERROR too large value”           | 삽입할 데이터가 element value의 최대 크기보다 큼
-| “CLIENT_ERROR bad data chunk”            | 삽입할 데이터 길이가 \<bytes\>와 다르거나 "\r\n"으로 끝나지 않음
-| “SERVER_ERROR out of memory”             | 메모리 부족
+| "CLIENT_ERROR bad command line format"   | protocol syntax 틀림
+| "CLIENT_ERROR too large value"           | 삽입할 데이터가 element value의 최대 크기보다 큼
+| "CLIENT_ERROR bad data chunk"            | 삽입할 데이터 길이가 \<bytes\>와 다르거나 "\r\n"으로 끝나지 않음
+| "SERVER_ERROR out of memory"             | 메모리 부족
 
 ## lop delete
 
@@ -100,12 +100,12 @@ Response string과 그 의미는 아래와 같다.
 | Response String                          | 설명                     |
 |------------------------------------------|------------------------ |
 | "DELETED"                                | 성공 (element만 삭제)
-| “DELETED_DROPPED”                        | 성공 (element 삭제하고 list를 drop한 상태)
-| “NOT_FOUND”                              | key miss
-| “NOT_FOUND_ELEMENT”                      | element miss (single index or index range에 해당하는 element가 없음)
-| “TYPE_MISMATCH”                          | 해당 item이 list collection이 아님
+| "DELETED_DROPPED"                        | 성공 (element 삭제하고 list를 drop한 상태)
+| "NOT_FOUND"                              | key miss
+| "NOT_FOUND_ELEMENT"                      | element miss (single index or index range에 해당하는 element가 없음)
+| "TYPE_MISMATCH"                          | 해당 item이 list collection이 아님
 | "NOT_SUPPORTED"                          | 지원하지 않음
-| “CLIENT_ERROR bad command line format”   | protocol syntax 틀림
+| "CLIENT_ERROR bad command line format"   | protocol syntax 틀림
 
 ## lop get
 
@@ -139,13 +139,13 @@ END|DELETED|DELETED_DROPPED\r\n
 
 | Response String                                        | 설명                     |
 |--------------------------------------------------------|------------------------ |
-| “NOT_FOUND”                                            | key miss
-| “NOT_FOUND_ELEMENT”                                    | element miss (index or index range에 해당하는 element가 없음)
-| “TYPE_MISMATCH”                                        | 해당 item이 list collection이 아님
-| “UNREADABLE”                                           | 해당 item이 unreadable item임
+| "NOT_FOUND"                                            | key miss
+| "NOT_FOUND_ELEMENT"                                    | element miss (index or index range에 해당하는 element가 없음)
+| "TYPE_MISMATCH"                                        | 해당 item이 list collection이 아님
+| "UNREADABLE"                                           | 해당 item이 unreadable item임
 | "NOT_SUPPORTED"                                        | 지원하지 않음
-| “CLIENT_ERROR bad command line format”                 | protocol syntax 틀림
-| "SERVER_ERROR out of memory [writing get response]”    | 메모리 부족
+| "CLIENT_ERROR bad command line format"                 | protocol syntax 틀림
+| "SERVER_ERROR out of memory [writing get response]"    | 메모리 부족
 
 <!-- reference list -->
 [item-attribute]: ch03-item-attributes.md "Chapter 3. Item Attribute 설명"

--- a/docs/ascii-protocol/ch06-command-set-collection.md
+++ b/docs/ascii-protocol/ch06-command-set-collection.md
@@ -98,7 +98,7 @@ Response string과 그 의미는 아래와 같다.
 | "NOT_SUPPORTED"                         | 지원하지 않음
 | "CLIENT_ERROR bad command line format"  | protocol syntax 틀림
 | "CLIENT_ERROR too large value"          | 삭제할 데이터가 element value의 최대 크기보다 큼
-| "CLIENT_ERROR bad data chunk"           | 삭제할 데이터의 길이가 \<bytes\>와 다르거나 “\r\n”으로 끝나지 않음
+| "CLIENT_ERROR bad data chunk"           | 삭제할 데이터의 길이가 \<bytes\>와 다르거나 "\r\n"으로 끝나지 않음
 
 ## sop get
 
@@ -165,4 +165,4 @@ Response string과 그 의미는 아래와 같다.
 | "NOT_SUPPORTED"                          | 지원하지 않음
 | "CLIENT_ERROR bad command line format"   | protocol syntax 틀림
 | "CLIENT_ERROR too large value"           | 주어진 데이터가 element value의 최대 크기보다 큼
-| "CLIENT_ERROR bad data chunk"            | 주어진 데이터의 길이가 \<bytes\>와 다르거나 “\r\n”으로 끝나지 않음
+| "CLIENT_ERROR bad data chunk"            | 주어진 데이터의 길이가 \<bytes\>와 다르거나 "\r\n"으로 끝나지 않음

--- a/docs/ascii-protocol/ch08-command-btree-collection.md
+++ b/docs/ascii-protocol/ch08-command-btree-collection.md
@@ -324,11 +324,11 @@ Increment/decrement 수행 후의 데이터 값이다.
 
 ```
 bop mget <lenkeys> <numkeys> <bkey or "bkey range"> [<eflag_filter>] [<offset>] <count>\r\n
-<”space separated keys”>\r\n
+<"space separated keys">\r\n
 * <eflag_filter> : <fwhere> [<bitwop> <foperand>] <compop> <fvalue>
 ```
 
-- \<”space separated keys”\> - 대상 b+tree들의 key list로, 스페이스(' ')로 구분한다.
+- \<"space separated keys"\> - 대상 b+tree들의 key list로, 스페이스(' ')로 구분한다.
      - 하위 호환성(1.10.X 이하 버전)을 위해 콤마(,)도 지원하지만 권장하지 않는다.
 - \<lenkeys\>과 \<numkeys> - key list 문자열의 길이와 key 개수를 나타낸다.
 - \<bkey or "bkey range"\> - 하나의 bkey 또는 bkey range 조회 조건. Bkey range는 "bkey1..bkey2" 형식으로 표현한다.
@@ -385,7 +385,7 @@ flags와 ecount를 포함하여 조회된 element 정보가 생략된다.
 |-------------------------------------------------------|------------------------ |
 | "NOT_SUPPORTED"                                       | 지원하지 않음
 | "CLIENT_ERROR bad command line format"                | protocol syntax 틀림
-| "CLIENT_ERROR bad data chunk"                         | space separated key list의 길이가 \<lenkeys\>와 다르거나 “\r\n”으로 끝나지 않음
+| "CLIENT_ERROR bad data chunk"                         | space separated key list의 길이가 \<lenkeys\>와 다르거나 "\r\n"으로 끝나지 않음
 | "CLIENT_ERROR bad value"                              | bop mget 명령의 제약 조건을 위배함.
 | "SERVER_ERROR out of memory [writing get response]"   | 메모리 부족
 
@@ -414,7 +414,7 @@ bop smget <lenkeys> <numkeys> <bkey or "bkey range"> [<eflag_filter>] <count> du
 * <eflag_filter> : <fwhere> [<bitwop> <foperand>] <compop> <fvalue>
 ```
 
-- \<”space separated keys”\> - 대상 b+tree들의 key list로, 스페이스(' ')로 구분한다.
+- \<"space separated keys"\> - 대상 b+tree들의 key list로, 스페이스(' ')로 구분한다.
      - 하위 호환성(1.10.X 이하 버전)을 위해 콤마(,)도 지원하지만 권장하지 않는다.
 - \<lenkeys\>과 \<numkeys> - key list 문자열의 길이와 key 개수를 나타낸다.
 - \<bkey or "bkey range"\> - 하나의 bkey 또는 bkey range 조회 조건.

--- a/docs/ascii-protocol/ch09-command-pipelining.md
+++ b/docs/ascii-protocol/ch09-command-pipelining.md
@@ -1,7 +1,7 @@
 # Chapter 9. Command Pipelining
 
 Command pipelining은
-“pipe” 키워드를 통해 여러 collection 명령들을 pipelining하여 cache server에 전달하고,
+"pipe" 키워드를 통해 여러 collection 명령들을 pipelining하여 cache server에 전달하고,
 cache server는 각 명령을 처리한 즉시 그 response를 client로 전달하는 것이 아니라
 그 response를 reply queue에 보관해 두었다가, 마지막 명령 처리 후에 reply queue에 보관해 둔 전체 response를
 한번에 client로 전달하는 기능이다.
@@ -21,8 +21,8 @@ Command pipelining 가능한 명령은 아래와 같으며, 단순 response stri
 Command pipelining 수행 예로,
 특정 list의 tail 쪽으로 10개 elements를 추가하고자 한다면,
 아래와 같이 lop insert 명령을 연속하여 cache server로 보내면 된다.
-첫 번째 명령부터 마지막 바로 이전 명령까지는 모두 “pipe” 인자를 사용하여 연결하여야 하고,
-마지막 명령에서는 “pipe” 인자를 생략함으로써 pipelining의 끝임을 표현하여야 한다.
+첫 번째 명령부터 마지막 바로 이전 명령까지는 모두 "pipe" 인자를 사용하여 연결하여야 하고,
+마지막 명령에서는 "pipe" 인자를 생략함으로써 pipelining의 끝임을 표현하여야 한다.
 
 ```
  lop insert lkey -1 6 pipe\r\ndatum0\r\n
@@ -54,17 +54,17 @@ RESPONSE 라인에서 \<count\>는 전체 결과 수를 나타내고,
 마지막 라인은 pipelining 수행 상태를 나타내며, 아래 중의 하나를 가진다.
 
 - "END" - pipelining 연산이 정상 수행됨
-- “PIPE_ERROR command overflow” - pipelining 가능한 최대 commands 수인 500개를 초과하였다.
+- "PIPE_ERROR command overflow" - pipelining 가능한 최대 commands 수인 500개를 초과하였다.
   이 경우, 500개까지의 command들만 하나의 command pipelining으로 처리되고 하나의 response stream으로 리턴된다.
   그 이후의 commands들은 처리되지 않는다.
-- “PIPE_ERROR memory overflow” - ARCUS cache server 내부에서 pipelining 처리를 위한
+- "PIPE_ERROR memory overflow" - ARCUS cache server 내부에서 pipelining 처리를 위한
   메모리 공간이 부족한 상태를 의미한다. ARCUS cache server는 500개 commands의 result를 담아둘 공간을
   미리 확보하여 수행하므로 이 오류가 발생할 가능성은 거의 없다.
   단, 의도하지 않은 이유에 의한 경우를 대비하여 이 오류를 추가해 둔 것이다.
   이 오류가 발생하면, 그 시점에 command pipelining을 중지하고 그 즉시 response stream을 client에 전달한다.
   이 경우의 response stream에는 가장 마지막에 수행된 command의 response string이 생략된다.
   그리고, 그 이후의 commands들은 처리되지 않는다.
-- “PIPE_ERROR bad error” - pipelining 으로 어떤 command를 수행 중
-  “CLIENT_ERROR”와 “SERVER_ERROR”로 시작하는 중요 오류가 발생한 경우이다.
+- "PIPE_ERROR bad error" - pipelining 으로 어떤 command를 수행 중
+  "CLIENT_ERROR"와 "SERVER_ERROR"로 시작하는 중요 오류가 발생한 경우이다.
   이 경우에도, 그 즉시 command pipelining을 중지하고 현재까지의 response stream을 client에 전달한다.
   그리고, 그 이후의 commands들은 처리되지 않는다.


### PR DESCRIPTION
### ⌨️ What I did
- Btree 문서 내 이상한 글자를 수정합니다.
  - `bop update` 의 ASCII 프로토콜 예시에서 data가 없어도 되는 것처럼 표현된 것을 수정했습니다.
  - `bop mget` 의 ASCII 프로토콜 예시에서 큰따옴표 대신 굽은 따옴표로 쓰여 있는 것을 수정했습니다.