### PR TITLE
INTERNAL: Fix a clang static analyzer issue about getpeername failure

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -722,6 +722,8 @@ conn *conn_new(const int sfd, STATE_FUNC init_state,
     /* save client ip address in connection object */
     struct sockaddr_in addr;
     socklen_t addrlen = sizeof(addr);
+    /* even if getpeername is successful, there is no guarantee of initialization */
+    memset(&addr, 0, sizeof(addr));
     if (getpeername(c->sfd, (struct sockaddr*)&addr, &addrlen) != 0) {
         if (init_state == conn_new_cmd) {
             mc_logger->log(EXTENSION_LOG_WARNING, c,
@@ -13619,7 +13621,6 @@ bool conn_listening(conn *c)
 
     if (curr_conns >= settings.maxconns) {
         /* Allow admin connection even if # of connections is over maxconns */
-        getpeername(sfd, (struct sockaddr*)&addr, &addrlen);
         struct sockaddr_in *sin = (struct sockaddr_in *)&addr;
         if (strcmp(inet_ntoa(sin->sin_addr), ADMIN_CLIENT_IP) != 0 ||
             curr_conns >= settings.maxconns + ADMIN_MAX_CONNECTIONS)


### PR DESCRIPTION
### 🔗 Related Issue
- jam2in/arcus-works#562

### ⌨️ What I did
- clang static analyzer 에서 감지한 케이스 중 하나를 수정합니다.
  - getpeername 이 항상 주소값이 들어감을 보장해주지 않습니다.
```
memcached.c:732:38: warning: Passed-by-value struct argument contains uninitialized data (e.g., field: 's_addr') [core.CallAndMessage]
    snprintf(c->client_ip, 16, "%s", inet_ntoa(addr.sin_addr));
```
```
memcached.c:13620:20: warning: Passed-by-value struct argument contains uninitialized data (e.g., field: 's_addr') [core.CallAndMessage]
        if (strcmp(inet_ntoa(sin->sin_addr), ADMIN_CLIENT_IP) != 0 ||
```

- conn_new 에서는 memset을 통해 addr 변수를 초기화했습니다.
  - 아래와 같이 처리했으나 여전히 warning이 발생하여 memset을 사용했습니다.
  ```c
  if (getpeername(c->sfd, (struct sockaddr*)&addr, &addrlen) != 0) {
     /* Fail Handler */
  } else {
      snprintf(c->client_ip, 16, "%s", inet_ntoa(addr.sin_addr));
  }
- conn_listening에서는 socket accept 과정에서 addr 값이 할당되므로 getpeername 을 제거했습니다.

