### PR TITLE
INTERNAL: Fix unmatched string formats

### DIFF
--- a/cmdlog.c
+++ b/cmdlog.c
@@ -380,8 +380,8 @@ char *cmdlog_stats(void)
         snprintf(str, CMDLOG_INPUT_SIZE,
                 "\t" "Command logging state : %s" "\n"
                 "\t" "The last running time : %d_%d ~ %d_%d" "\n"
-                "\t" "The number of entered commands : %d" "\n"
-                "\t" "The number of skipped commands : %d" "\n"
+                "\t" "The number of entered commands : %u" "\n"
+                "\t" "The number of skipped commands : %u" "\n"
                 "\t" "The number of log files : %d" "\n"
                 "\t" "The log file name: %s/command_%d_%d_%d_{n}.log" "\n",
                 (stats->state >= 0 && stats->state <= 4 ?

--- a/engines/default/cmdlogrec.c
+++ b/engines/default/cmdlogrec.c
@@ -242,7 +242,7 @@ static void lrec_attr_print(char *data, char *str)
     lrec_attr_info info;
     /* because lrec_attr_info is not aligned, set info with memcpy */
     memcpy(&info, data, sizeof(lrec_attr_info));
-    sprintf(str, "(flags=%u, exptime=%u, maxcount=%d, ovflaction=%u, readable=%u)",
+    sprintf(str, "(flags=%u, exptime=%u, maxcount=%d, ovflaction=%u, readable=%d)",
             info.flags, CONVERT_REL_EXPTIME(info.exptime), info.maxcount, info.ovflaction,
             (info.mflags & COLL_META_FLAG_READABLE ? 1 : 0));
 }
@@ -358,7 +358,7 @@ static void lrec_it_link_print(LogRec *logrec)
         sprintf(metastr, "cas=%"PRIu64, body->ptr.cas);
     } else {
         struct lrec_coll_meta *meta = (struct lrec_coll_meta*)&body->ptr.meta;
-        int leng = sprintf(metastr, "ovflact=%s | mflags=%u | mcnt=%u",
+        int leng = sprintf(metastr, "ovflact=%s | mflags=%u | mcnt=%d",
                            get_coll_ovflact_text(meta->ovflact), meta->mflags, meta->mcnt);
 
         if (cm->ittype == ITEM_TYPE_BTREE && meta->maxbkrlen != BKEY_NULL) {
@@ -503,7 +503,7 @@ static void lrec_it_setattr_print(LogRec *logrec)
         }
 
         fprintf(stderr, "[BODY  ] keylen=%u | keystr=%.*s | ovflact=%s | "
-                "mflags=%u | mcnt=%u | exptime=%u | maxbkeyrange=%s\r\n",
+                "mflags=%u | mcnt=%d | exptime=%u | maxbkeyrange=%s\r\n",
                 log->body.keylen, (log->body.keylen <= 250 ? log->body.keylen : 250), keyptr,
                 get_coll_ovflact_text(log->body.ovflact), log->body.mflags, log->body.mcnt,
                 CONVERT_REL_EXPTIME(log->body.exptime), metastr);

--- a/engines/default/items.c
+++ b/engines/default/items.c
@@ -465,7 +465,7 @@ static ENGINE_ERROR_CODE do_item_flush_expired(const char *prefix, const int npr
             } else if ((svcore->get_current_time() - fplog_stime) > FLUSH_PREFIX_LOG_INTERVAL) {
                 char str_buffer[64] = { 0 };
                 if (fplog_count > FLUSH_PREFIX_LOG_MAXCOUNT) {
-                    snprintf(str_buffer, 64, "(Previous %u logs suppressed during %u secs)",
+                    snprintf(str_buffer, 64, "(Previous %u logs suppressed during %d secs)",
                             (fplog_count-FLUSH_PREFIX_LOG_MAXCOUNT), FLUSH_PREFIX_LOG_INTERVAL);
                 }
                 logger->log(EXTENSION_LOG_INFO, NULL, "flush prefix=%s when=%u client_ip=%s%s\n",

--- a/engines/default/prefix.c
+++ b/engines/default/prefix.c
@@ -816,7 +816,7 @@ static int _prefix_scan_direct(const char *cursor, int req_count, void **item_ar
         return -1; /* invalid cursor */
     }
     if (bucket >= prefix_hsize) {
-        sprintf((char*)cursor, "%u", 0); /* scan end */
+        sprintf((char*)cursor, "%u", 0U); /* scan end */
         return 0;
     }
 
@@ -843,7 +843,7 @@ static int _prefix_scan_direct(const char *cursor, int req_count, void **item_ar
     }
     if (bucket >= prefix_hsize) { /* the end of scan */
         /* item_count : 0 or positive value */
-        sprintf((char*)cursor, "%u", 0);
+        sprintf((char*)cursor, "%u", 0U);
     } else {
         sprintf((char*)cursor, "%u", bucket);
     }

--- a/memcached.c
+++ b/memcached.c
@@ -4454,7 +4454,7 @@ static void process_bin_lop_prepare_nread(conn *c)
         for (int ii = 0; ii < nkey; ++ii) {
             fprintf(stderr, "%c", key[ii]);
         }
-        fprintf(stderr, " Index(%d) NBytes(%d)", req->message.body.index, vlen);
+        fprintf(stderr, " Index(%d) NBytes(%u)", req->message.body.index, vlen);
         if (req->message.body.create) {
             fprintf(stderr, " %s", "Create");
         }
@@ -4842,7 +4842,7 @@ static void process_bin_sop_prepare_nread(conn *c)
         for (int ii = 0; ii < nkey; ++ii) {
             fprintf(stderr, "%c", key[ii]);
         }
-        fprintf(stderr, " NBytes(%d)", vlen);
+        fprintf(stderr, " NBytes(%u)", vlen);
         fprintf(stderr, "\n");
     }
 
@@ -5164,7 +5164,7 @@ static void process_bin_sop_get(conn *c)
         for (int ii = 0; ii < nkey; ++ii) {
             fprintf(stderr, "%c", key[ii]);
         }
-        fprintf(stderr, " Count(%d) Delete(%s)\n", req_count,
+        fprintf(stderr, " Count(%u) Delete(%s)\n", req_count,
                 (req->message.body.delete ? "true" : "false"));
     }
 
@@ -5319,7 +5319,7 @@ static void process_bin_bop_prepare_nread(conn *c)
         for (int ii = 0; ii < nkey; ++ii) {
             fprintf(stderr, "%c", key[ii]);
         }
-        fprintf(stderr, " NBKey(%d) NEFlag(%d) NBytes(%d)",
+        fprintf(stderr, " NBKey(%u) NEFlag(%u) NBytes(%u)",
                 req->message.body.nbkey, req->message.body.neflag, vlen);
         if (req->message.body.create) {
             fprintf(stderr, " %s", "Create");
@@ -5557,7 +5557,7 @@ static void process_bin_bop_update_prepare_nread(conn *c)
         for (int ii = 0; ii < nkey; ++ii) {
             fprintf(stderr, "%c", key[ii]);
         }
-        fprintf(stderr, " NBKey(%d) NEFlag(%d) NBytes(%d)",
+        fprintf(stderr, " NBKey(%u) NEFlag(%u) NBytes(%u)",
                 req->message.body.nbkey, req->message.body.neflag, vlen);
         fprintf(stderr, "\n");
     }
@@ -7121,7 +7121,7 @@ static void process_bin_update(conn *c)
 
         if (nw != -1) {
             if (snprintf(buffer + nw, sizeof(buffer) - nw,
-                         " Value len is %d\n", vlen)) {
+                         " Value len is %u\n", vlen)) {
                 mc_logger->log(EXTENSION_LOG_DEBUG, c, "%s", buffer);
             }
         }
@@ -8885,7 +8885,7 @@ static void process_memlimit_command(conn *c, token_t *tokens, const size_t ntok
 
     if (ntokens == 3) {
         char buf[50];
-        sprintf(buf, "memlimit %u\r\nEND", (int)(settings.maxbytes / (1024 * 1024)));
+        sprintf(buf, "memlimit %u\r\nEND", (unsigned int)(settings.maxbytes / (1024 * 1024)));
         out_string(c, buf);
     } else if (ntokens == 4 && safe_strtoul(config_val, &mlimit)) {
         ENGINE_ERROR_CODE ret;
@@ -8915,7 +8915,7 @@ static void process_stickylimit_command(conn *c, token_t *tokens, const size_t n
 
     if (ntokens == 3) {
         char buf[50];
-        sprintf(buf, "sticky_limit %u\r\nEND", (int)(settings.sticky_limit / (1024 * 1024)));
+        sprintf(buf, "sticky_limit %u\r\nEND", (unsigned int)(settings.sticky_limit / (1024 * 1024)));
         out_string(c, buf);
     } else if (ntokens == 4 && safe_strtoul(config_val, &sticky_limit)) {
         ENGINE_ERROR_CODE ret;
@@ -12880,7 +12880,7 @@ static size_t attr_to_printable_buffer(char *ptr, ENGINE_ITEM_ATTR attr_id, item
         }
     }
     else if (attr_id == ATTR_TRIMMED)
-        sprintf(ptr, "ATTR trimmed=%u\r\n", (attr_datap->trimmed != 0 ? 1 : 0));
+        sprintf(ptr, "ATTR trimmed=%d\r\n", (attr_datap->trimmed != 0 ? 1 : 0));
 
     return strlen(ptr);
 }


### PR DESCRIPTION
### 🔗 Related Issue
- jam2in/arcus-works#562

### ⌨️ What I did
- cppchecker analyzer 에서 감지한 케이스 중 하나를 수정합니다.
  - string format 내 형식과 변수 타입이 일치하도록 변경했습니다.
    ex) `"%u", (int)a` → `"%d", (int)a`
