### PR TITLE
INTERNAL: Add `EXPOSE` to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ FROM centos:7 AS base
 COPY --from=builder /arcus /arcus
 ENV PATH ${PATH}:/arcus/bin
 
+EXPOSE 11211/tcp
+
 ENTRYPOINT ["memcached",\
  "-E", "/arcus/lib/default_engine.so",\
  "-X", "/arcus/lib/ascii_scrub.so",\


### PR DESCRIPTION
### ⌨️ What I did
- 현재 memcached에 익숙하지 않은 사용자가 docker image를 사용하고자 할 때, 11211 port가 노출됨을 파악하기가 어렵습니다.
- Dockerfile에 `EXPOSE` port를 추가하여 port 정보를 노출합니다.
- `EXPOSE`는 그 자체로 아무런 동작도 하지 않으며, 11211 port를 사용하고 있음을 알리는 역할을 합니다.
> https://docs.docker.com/reference/dockerfile/#expose
> The EXPOSE instruction informs Docker that the container listens on the specified network ports at runtime.
>
> The EXPOSE instruction doesn't actually publish the port. It functions as a type of documentation between the person who builds the image and the person who runs the container, about which ports are intended to be published.
- 부가 기능으로 구동 시 `-P` option을 사용하면 사용자가 port를 명시적으로 연결하지 않아도
아래와 같이 host의 임의 port로 exepose port를 매핑하는 형태로 구동할 수 있습니다.
```
docker run -P jam2in/arcus-memcached -v
```
```
CONTAINER ID   IMAGE                   COMMAND                 PORTS
5d378e9ccc42   namsic/arcus-memcached  "memcached -E /arcus…"  0.0.0.0:32768->11211/tcp
```


---
## 🤔 기타

1. 이전에는 arcus-memcached가 11211 port를 사용함을 알리기 위해 `CMD`에 `-p` option을 지정했습니다.
그 이후 #728 에서 `CMD` 설정 자체가 제거되었고,
현재는 Docker image에 port 관련 정보가 드러나지 않습니다.
2. 사실 기존의 `-p` option을 설정하는 것도 자연스럽지 않은 부분이 있었는데,
컨테이너 내부에서 11211 port는 충돌 걱정 없이 고정으로 사용 가능한 port 입니다.
3. port를 변경하는 이유는 컨테이너 외부(호스트 장비)에서 원하는 주소로 접근하기 위함인데,
jam2in의 블로그 포스팅을 보면 아래와 같이 가이드하고 있습니다.
```
docker run -p 11212:11212 jam2in/arcus-memcached -p 11212 -v
```
위 명령을 아래와 같이 변경해도 컨테이너 외부에서 동일한 방법으로 접근할 수 있을 것입니다.
```
docker run -p 11212:11211 jam2in/arcus-memcached -v
```
즉, 일반적인 경우에는 host port를 설정하기 위해 memcached의 `-p` option을 지정하지 않아도 됩니다.
(zookeeper와 연동은 조금 특수한 상황으로, `-p` option을 함께 설정해야 합니다.)

---
