### PR TITLE
INTERNAL: Rename memory block macros

### DIFF
--- a/mc_util.h
+++ b/mc_util.h
@@ -62,14 +62,14 @@ typedef struct _mblck_pool {
 /*
  * memory block macros
  */
-#define MBLCK_GET_HEADBLK(l) ((l)->head)
-#define MBLCK_GET_TAILBLK(l) ((l)->tail)
-#define MBLCK_GET_NUMBLKS(l) ((l)->blck_cnt)
-#define MBLCK_GET_BODYLEN(l) ((l)->body_len)
-#define MBLCK_GET_ITEMCNT(l) ((l)->item_cnt)
-#define MBLCK_GET_ITEMLEN(l) ((l)->item_len)
-#define MBLCK_GET_NEXTBLK(b) ((b)->next)
-#define MBLCK_GET_BODYPTR(b) ((b)->data)
+#define MBLCK_HEAD(l) ((l)->head)
+#define MBLCK_TAIL(l) ((l)->tail)
+// #define MBLCK_ICNT(l) ((l)->item_cnt)
+// #define MBLCK_ILEN(l) ((l)->item_len)
+#define MBLCK_COUNT(l) ((l)->blck_cnt)
+#define MBLCK_BDLEN(l) ((l)->body_len)
+#define NEXT_MBLCK(b) ((b)->next)
+#define DATA_MBLCK(b) ((b)->data)
 
 /* memory block functions */
 int  mblck_pool_create(mblck_pool_t *pool, uint32_t blck_len, uint32_t blck_cnt);

--- a/memcached.c
+++ b/memcached.c
@@ -1007,10 +1007,10 @@ static void ritem_set_first(conn *c, int rtype, int vleng)
     c->rtype = rtype;
 
     if (c->rtype == CONN_RTYPE_MBLCK) {
-        c->membk = MBLCK_GET_HEADBLK(&c->memblist);
-        c->ritem = MBLCK_GET_BODYPTR(c->membk);
-        c->rlbytes = vleng < MBLCK_GET_BODYLEN(&c->memblist)
-                   ? vleng : MBLCK_GET_BODYLEN(&c->memblist);
+        c->membk = MBLCK_HEAD(&c->memblist);
+        c->ritem = DATA_MBLCK(c->membk);
+        c->rlbytes = vleng < MBLCK_BDLEN(&c->memblist)
+                   ? vleng : MBLCK_BDLEN(&c->memblist);
         c->rltotal = vleng;
     }
     else if (c->rtype == CONN_RTYPE_HINFO) {
@@ -1060,10 +1060,10 @@ static void ritem_set_next(conn *c)
     assert(c->rltotal > 0);
 
     if (c->rtype == CONN_RTYPE_MBLCK) {
-        c->membk = MBLCK_GET_NEXTBLK(c->membk);
-        c->ritem = MBLCK_GET_BODYPTR(c->membk);
-        c->rlbytes = c->rltotal < MBLCK_GET_BODYLEN(&c->memblist)
-                   ? c->rltotal : MBLCK_GET_BODYLEN(&c->memblist);
+        c->membk = NEXT_MBLCK(c->membk);
+        c->ritem = DATA_MBLCK(c->membk);
+        c->rlbytes = c->rltotal < MBLCK_BDLEN(&c->memblist)
+                   ? c->rltotal : MBLCK_BDLEN(&c->memblist);
     }
     else if (c->rtype == CONN_RTYPE_HINFO) {
         c->ritem = c->hinfo.addnl[c->rindex]->ptr;


### PR DESCRIPTION
### 🔗 Related Issue
- jam2in/arcus-works#539
- #756 

### ⌨️ What I did
- Memory Block 관련 매크로 이름을 간결하게 변경합니다.
  - 모든 Memory Block에 대한 공통적인 정보를 접근하는 경우는 `MBLCK_[Name]`
  - 한 Memory Block에 대하여 접근하는 경우는 `[Name]_MBLCK`
- 현재 사용중이지 않은 매크로는 비활성화 시켰습니다.
```diff
- #define MBLCK_GET_NUMBLKS(l) ((l)->blck_cnt)
- #define MBLCK_GET_BODYLEN(l) ((l)->body_len)
```
- 매크로 이름 변경 이유
  - 기존에 비해 가독성이 좋아집니다.
  - 이전 논의에서 현재 사용중인 매크로 이름과 사용방식 변경을 고려해보라는 의견이 있었습니다.