### PR TITLE
FEATURE: Add an upsert command for map structure

### DIFF
--- a/engines/default/coll_map.h
+++ b/engines/default/coll_map.h
@@ -34,9 +34,9 @@ void map_elem_free(map_elem_item *elem);
 void map_elem_release(map_elem_item **elem_array, const int elem_count);
 
 ENGINE_ERROR_CODE map_elem_insert(const char *key, const uint32_t nkey,
-                                  map_elem_item *elem,
-                                  item_attr *attrp,
-                                  bool *created, const void *cookie);
+                                  map_elem_item *elem, const bool replace_if_exist,
+                                  item_attr *attrp, bool *replaced, bool *created,
+                                  const void *cookie);
 
 ENGINE_ERROR_CODE map_elem_update(const char *key, const uint32_t nkey,
                                   const field_t *field,

--- a/engines/default/default_engine.c
+++ b/engines/default/default_engine.c
@@ -736,14 +736,17 @@ default_map_elem_release(ENGINE_HANDLE* handle, const void *cookie,
 static ENGINE_ERROR_CODE
 default_map_elem_insert(ENGINE_HANDLE* handle, const void* cookie,
                         const void* key, const int nkey, eitem *eitem,
-                        item_attr *attrp, bool *created, uint16_t vbucket)
+                        const bool replace_if_exist, item_attr *attrp,
+                        bool *replaced, bool *created, uint16_t vbucket)
 {
     struct default_engine *engine = get_handle(handle);
     ENGINE_ERROR_CODE ret;
     VBUCKET_GUARD(engine, vbucket);
 
     ACTION_BEFORE_WRITE(cookie, key, nkey);
-    ret = map_elem_insert(key, nkey, (map_elem_item*)eitem, attrp, created, cookie);
+    ret = map_elem_insert(key, nkey, (map_elem_item*)eitem,
+                          replace_if_exist, attrp,
+                          replaced, created, cookie);
     ACTION_AFTER_WRITE(cookie, engine, ret);
     return ret;
 }

--- a/engines/demo/demo_engine.c
+++ b/engines/demo/demo_engine.c
@@ -444,7 +444,8 @@ Demo_map_elem_release(ENGINE_HANDLE* handle, const void *cookie,
 static ENGINE_ERROR_CODE
 Demo_map_elem_insert(ENGINE_HANDLE* handle, const void* cookie,
                         const void* key, const int nkey, eitem *eitem,
-                        item_attr *attrp, bool *created, uint16_t vbucket)
+                        const bool replace_if_exist, item_attr *attrp,
+                        bool *replaced, bool *created, uint16_t vbucket)
 {
     return ENGINE_ENOTSUP;
 }

--- a/include/memcached/engine.h
+++ b/include/memcached/engine.h
@@ -452,7 +452,9 @@ extern "C" {
                                              const void* key,
                                              const int nkey,
                                              eitem *eitem,
+                                             const bool replace_if_exist,
                                              item_attr *attrp,
+                                             bool *replaced,
                                              bool *created,
                                              uint16_t vbucket);
         ENGINE_ERROR_CODE (*map_elem_update)(ENGINE_HANDLE* handle,

--- a/include/memcached/types.h
+++ b/include/memcached/types.h
@@ -126,6 +126,7 @@ extern "C" {
         /* map operation */
         OPERATION_MOP_CREATE = 0x70, /**< Map operation with create structure semantics */
         OPERATION_MOP_INSERT,        /**< Map operation with insert element semantics */
+        OPERATION_MOP_UPSERT,        /**< Map operation with upsert element semantics */
         OPERATION_MOP_UPDATE,        /**< Map operation with update element semantics */
         OPERATION_MOP_DELETE,        /**< Map operation with delete element semantics */
         OPERATION_MOP_GET,            /**< Map operation with get element semantics */

--- a/t/coll_mop_upsert.t
+++ b/t/coll_mop_upsert.t
@@ -1,0 +1,86 @@
+#!/usr/bin/perl
+
+use strict;
+use Test::More tests => 14;
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use MemcachedTest;
+
+=head
+get kvkey
+get mkey1
+mop upsert mkey1 field1 6 create 11 0 0
+datum9
+mop upsert mkey1 field2 6
+datum7
+setattr mkey1 maxcount=2
+mop upsert mkey1 field1 6
+datum5
+mop get mkey1 13 2
+field1 field2
+
+mop upsert mkey2 field1 6
+datum2
+set kvkey 0 0 6
+datumx
+mop upsert kvkey field1 6
+datum2
+mop upsert mkey1 field1 6
+datum4
+setattr mkey1 maxcount=4000
+
+delete kvkey
+delete mkey1
+=cut
+
+my $engine = shift;
+my $server = get_memcached($engine);
+my $sock = $server->sock;
+
+my $cmd;
+my $val;
+my $rst;
+
+# Initialize
+$cmd = "get kvkey"; $rst = "END";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "get mkey1"; $rst = "END";
+mem_cmd_is($sock, $cmd, "", $rst);
+
+# Success Cases
+$cmd = "mop upsert mkey1 field1 6 create 11 0 0"; $val = "datum9"; $rst = "CREATED_STORED";
+mem_cmd_is($sock, $cmd, $val, $rst);
+$cmd = "mop upsert mkey1 field2 6"; $val = "datum7"; $rst = "STORED";
+mem_cmd_is($sock, $cmd, $val, $rst);
+$cmd = "setattr mkey1 maxcount=2"; $rst = "OK";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "mop upsert mkey1 field1 6"; $val = "datum0"; $rst = "REPLACED";
+mem_cmd_is($sock, $cmd, $val, $rst);
+$cmd = "mop get mkey1 13 2"; $val = "field1 field2";
+$rst = "VALUE 11 2
+field1 6 datum0
+field2 6 datum7
+END";
+mem_cmd_is($sock, $cmd, $val, $rst);
+
+# Fail Cases
+$cmd = "mop upsert mkey2 field1 6"; $val = "datum2"; $rst = "NOT_FOUND";
+mem_cmd_is($sock, $cmd, $val, $rst);
+$cmd = "set kvkey 0 0 6"; $val = "datumx"; $rst = "STORED";
+mem_cmd_is($sock, $cmd, $val, $rst);
+$cmd = "mop upsert kvkey field1 6"; $val = "datum2"; $rst = "TYPE_MISMATCH";
+mem_cmd_is($sock, $cmd, $val, $rst);
+$cmd = "mop upsert mkey1 field3 6"; $val = "datum5"; $rst = "OVERFLOWED";
+mem_cmd_is($sock, $cmd, $val, $rst);
+$cmd = "setattr mkey1 maxcount=4000"; $rst = "OK";
+mem_cmd_is($sock, $cmd, "", $rst);
+
+# Finalize
+$cmd = "delete kvkey"; $rst = "DELETED";
+mem_cmd_is($sock, $cmd, "", $rst);
+$cmd = "delete mkey1"; $rst = "DELETED";
+mem_cmd_is($sock, $cmd, "", $rst);
+
+# after test
+release_memcached($engine, $server);
+

--- a/t/tlist/engine_default_b.txt
+++ b/t/tlist/engine_default_b.txt
@@ -44,6 +44,7 @@
 ./t/coll_mop_delete.t
 ./t/coll_mop_get.t
 ./t/coll_mop_insert.t
+./t/coll_mop_upsert.t
 ./t/coll_mop_update.t
 ./t/coll_pipeline_general.t
 ./t/coll_pipeline_sop_exist.t

--- a/t/tlist/engine_default_s.txt
+++ b/t/tlist/engine_default_s.txt
@@ -37,6 +37,7 @@
 ./t/coll_mop_delete.t
 ./t/coll_mop_get.t
 ./t/coll_mop_insert.t
+./t/coll_mop_upsert.t
 ./t/coll_mop_update.t
 ./t/coll_pipeline_general.t
 ./t/coll_pipeline_sop_exist.t


### PR DESCRIPTION
### 🔗 Related Issue
- jam2in/arcus-works#578

### ⌨️ What I did
- Mop Upsert 명령어를 추가합니다.
  - Btree의 Upsert와 유사한 방식으로 추가했습니다.
    - `mop upsert`의 경우, `mop insert` 로직을 공유합니다.
    - 엔진 인터페이스의 `map_elem_insert`에서 replace 관련 플래그를 추가합니다.
    ```diff
    ENGINE_ERROR_CODE (*map_elem_insert)(ENGINE_HANDLE* handle,
                                         const void* cookie,
                                         const void* key,
                                         const int nkey,
                                         eitem *eitem,
    +                                    const bool replace_if_exist,
                                         item_attr *attrp,
    +                                    bool *replaced,
                                         bool *created,
                                         uint16_t vbucket);
    ```
    - `replace_if_exist` : insert 시 해당 elem이 이미 존재한 경우 replace할 지 여부
    - `replaced` : replace가 발생한 경우 해당 변수가 true로 설정됨
      - 이 변수가 true이면, 사용자에게 `REPLACED`를 출력 
- 간단한 사용 결과는 아래와 같습니다. 
```
mop insert m 0 1 create 0 0 10
1
CREATED_STORED

mop insert m 0 1
2
ELEMENT_EXISTS

mop get m 1 1
0
VALUE 0 1
0 1 1
END

mop upsert m 0 1
2
REPLACED

mop get m 1 1
0
VALUE 0 1
0 1 2
END
```
- Perl 스크립트로 구현한 테스트 결과는 아래와 같습니다. (해당 테스트는 다음 PR로 추가 예정)
```
1..14
[ Initialize Checking ]
ok 1 - get kvkey:
ok 2 - get mkey1:

[ Success Cases ]
ok 3 - mop upsert mkey1 field1 6 create 11 0 0:datum9 // CREATED_STORED
ok 4 - mop upsert mkey1 field2 6:datum7 // STORED
ok 5 - mop upsert mkey1 field1 6:datum0 // REPLACED
ok 6 - mop get mkey1 13 2:field1 field2 // VALUE 11 2\r\nfield1 6 datum0\r\nfield2 6 datum7\r\nEND

[ Fail Cases ]
ok 7 - mop upsert mkey2 field1 6:datum2 // NOT_FOUND
ok 8 - set kvkey 0 0 6:datumx // STORED
ok 9 - mop upsert kvkey field1 6:datum2 // TYPE_MISMATCH
ok 10 - setattr mkey1 maxcount=2: // OK
ok 11 - mop upsert mkey1 field3 6:datum5 // OVERFLOWED
ok 11 - setattr mkey1 maxcount=4000: // OK

[ Finalize ]
ok 12 - delete kvkey: // DELETED
ok 13 - delete mkey1: // DELETED
```