### PR TITLE
INTERNAL: Fix deprecated items, `centos:7` to `rockylinux:8` and `ENV key value` to `ENV key=value`, in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7 AS builder
+FROM rockylinux:8 AS builder
 RUN yum update -y
 RUN yum install -y make libtool which git
 # Copy all files from the repository not included in .dockerignore to /src in the image.
@@ -9,9 +9,9 @@ RUN ./config/autorun.sh
 RUN ./configure --prefix=/arcus --enable-zk-integration
 RUN make && make install
 
-FROM centos:7 AS base
+FROM rockylinux:8 AS base
 COPY --from=builder /arcus /arcus
-ENV PATH ${PATH}:/arcus/bin
+ENV PATH=${PATH}:/arcus/bin
 
 EXPOSE 11211/tcp
 
@@ -27,8 +27,8 @@ FROM base
 RUN yum update -y
 RUN yum install -y bind-utils nc
 RUN yum clean all -y
-ENV MEMCACHED_DIR /arcus-memcached
-ENV PATH ${PATH}:${MEMCACHED_DIR}
-ENV ARCUS_USER root
+ENV MEMCACHED_DIR=/arcus-memcached
+ENV PATH=${PATH}:${MEMCACHED_DIR}
+ENV ARCUS_USER=root
 WORKDIR ${MEMCACHED_DIR}
 RUN ln -s /arcus/lib ${MEMCACHED_DIR}/.libs


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/583

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- Dockerfile 내의 Deprecated 항목들을 수정합니다.
