### PR TITLE
INTERNAL: Refactor lqdetect show

### DIFF
--- a/lqdetect.c
+++ b/lqdetect.c
@@ -78,7 +78,6 @@ struct lq_detect_global {
     struct lq_detect_buffer buffer[LQ_CMD_NUM];
     struct lq_detect_stats stats;
     int overflow_cnt;
-    uint16_t refcount; /* lqdetect show reference count */
 };
 struct lq_detect_global lqdetect;
 
@@ -240,7 +239,6 @@ int lqdetect_init(EXTENSION_LOGGER_DESCRIPTOR *logger)
         }
         memset(lqdetect.arg[ii], 0, LQ_SAVE_CNT * sizeof(struct lq_detect_argument));
     }
-    lqdetect.refcount = 0;
     return 0;
 }
 
@@ -259,12 +257,6 @@ int lqdetect_start(uint32_t threshold, bool *already_started)
     do {
         if (lqdetect_in_use) {
             *already_started = true;
-            break;
-        }
-
-        /* if lqdetect showing, start is fail */
-        if (lqdetect.refcount != 0) {
-            ret = -1;
             break;
         }
 
@@ -335,47 +327,30 @@ char *lqdetect_stats(void)
     return str;
 }
 
-field_t *lqdetect_result_get(int *size)
+char *lqdetect_result_get(int *size)
 {
-    int hdrlen = 32;
-    int fldarr_size = LQ_CMD_NUM * 2 * sizeof(field_t);
-    int hdrarr_size = LQ_CMD_NUM * hdrlen; /* command, ntotal */
-    /* field_t and header string array */
-    field_t *fldarr = (field_t*)malloc(fldarr_size + hdrarr_size);
-    if (fldarr == NULL) {
-        return NULL;
-    }
-    char *hdrptr = (char*)fldarr + fldarr_size;
-    int fldcnt = 0;
+    int offset = 0;
+    int length = 32 * LQ_CMD_NUM; // header length
+    char *str;
 
     pthread_mutex_lock(&lqdetect.lock);
-    /* Each result consists of header and body. */
     for (int i = 0; i < LQ_CMD_NUM; i++) {
-        struct lq_detect_buffer ldb = lqdetect.buffer[i];
-        /* header */
-        fldarr[fldcnt].length = snprintf(hdrptr, hdrlen, "%s : %u\n", command_str[i], ldb.ntotal);
-        fldarr[fldcnt].value = hdrptr;
-        hdrptr += hdrlen;
-        fldcnt++;
-        /* body */
-        if (ldb.ntotal != 0) {
-            fldarr[fldcnt].length = ldb.offset;
-            fldarr[fldcnt].value = ldb.data;
-            fldcnt++;
+        length += lqdetect.buffer[i].offset;
+    }
+    str = (char*)malloc(length);
+    if (str != NULL) {
+        for (int i = 0; i < LQ_CMD_NUM; i++) {
+            struct lq_detect_buffer *ldb = &lqdetect.buffer[i];
+            offset += snprintf(str + offset, length - offset, "%s : %u\n", command_str[i], ldb->ntotal);
+            if (ldb->ntotal > 0) {
+                offset += snprintf(str + offset, length - offset, "%s", ldb->data);
+            }
         }
     }
-    lqdetect.refcount++;
     pthread_mutex_unlock(&lqdetect.lock);
-    *size = fldcnt;
-    return fldarr;
-}
 
-void lqdetect_result_release(field_t *results)
-{
-    free(results);
-    pthread_mutex_lock(&lqdetect.lock);
-    lqdetect.refcount--;
-    pthread_mutex_unlock(&lqdetect.lock);
+    *size = offset;
+    return str;
 }
 
 void lqdetect_lop_insert(char *client_ip, char *key, int coll_index)

--- a/lqdetect.h
+++ b/lqdetect.h
@@ -10,8 +10,7 @@ extern bool lqdetect_in_use;
 
 int lqdetect_init(EXTENSION_LOGGER_DESCRIPTOR *logger);
 void lqdetect_final(void);
-field_t *lqdetect_result_get(int *size);
-void lqdetect_result_release(field_t *results);
+char *lqdetect_result_get(int *size);
 int lqdetect_start(uint32_t threshold, bool *already_started);
 void lqdetect_stop(bool *already_stopped);
 char *lqdetect_stats(void);

--- a/memcached.c
+++ b/memcached.c
@@ -668,10 +668,6 @@ conn *conn_new(const int sfd, STATE_FUNC init_state,
     c->conn_prev = NULL;
     c->conn_next = NULL;
 
-#ifdef DETECT_LONG_QUERY
-    c->lq_result = NULL;
-#endif
-
     c->write_and_go = init_state;
     c->write_and_free = 0;
     c->item = 0;
@@ -832,13 +828,6 @@ static void conn_cleanup(conn *c)
         mc_engine.v1->release(mc_engine.v0, c, c->item);
         c->item = 0;
     }
-
-#ifdef DETECT_LONG_QUERY
-    if (c->lq_result) {
-        lqdetect_result_release(c->lq_result);
-        c->lq_result = NULL;
-    }
-#endif
 
     if (c->coll_eitem != NULL) {
         conn_coll_eitem_free(c);
@@ -7580,12 +7569,6 @@ static void reset_cmd_handler(conn *c)
         mc_engine.v1->release(mc_engine.v0, c, c->item);
         c->item = NULL;
     }
-#ifdef DETECT_LONG_QUERY
-    if (c->lq_result) {
-        lqdetect_result_release(c->lq_result);
-        c->lq_result = NULL;
-    }
-#endif
     if (c->coll_eitem != NULL) {
         conn_coll_eitem_free(c);
         c->coll_eitem = NULL;
@@ -10025,25 +10008,13 @@ static void process_lqdetect_command(conn *c, token_t *tokens, size_t ntokens)
             out_string(c, "\tlong query detection stopped.\n");
         }
     } else if (ntokens > 2 && strcmp(type, "show") == 0) {
-        int size, i;
-        c->lq_result = lqdetect_result_get(&size);
-        if (c->lq_result == NULL) {
-            out_string(c, "SERVER_ERROR out of memory");
-            return;
-        }
-        for (i = 0; i < size; i++) {
-            if (add_iov(c, c->lq_result[i].value, c->lq_result[i].length) != 0) {
-                break;
-            }
-        }
-        if (i < size) {
-            lqdetect_result_release(c->lq_result);
-            c->lq_result = NULL;
+        int size;
+        char *str = lqdetect_result_get(&size);
+        if (str) {
+            write_and_free(c, str, size);
+        } else {
             out_string(c, "SERVER_ERROR out of memory writing show response");
-            return;
         }
-        conn_set_state(c, conn_mwrite);
-        c->msgcurr = 0;
     } else if (ntokens > 2 && strcmp(type, "stats") == 0) {
         char *str = lqdetect_stats();
         if (str) {
@@ -13954,12 +13925,6 @@ bool conn_mwrite(conn *c)
                 c->suffixcurr++;
                 c->suffixleft--;
             }
-#ifdef DETECT_LONG_QUERY
-            if (c->lq_result) {
-                lqdetect_result_release(c->lq_result);
-                c->lq_result = NULL;
-            }
-#endif
             if (c->coll_eitem != NULL) {
                 conn_coll_eitem_free(c);
                 c->coll_eitem = NULL;

--- a/memcached.h
+++ b/memcached.h
@@ -378,10 +378,6 @@ struct conn {
     char   **suffixcurr;
     int    suffixleft;
 
-#ifdef DETECT_LONG_QUERY
-    field_t *lq_result;
-#endif
-
     enum protocol protocol;   /* which protocol this connection speaks */
     enum network_transport transport; /* what transport is used by this connection */
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/554

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 기존 `<value, length>` 구조의 배열을 리턴하는 로직에서 간단하게 `filed_t` 하나만을 반환하는 로직으로 변경하였습니다.
- 기존의 char * 를 구조체에 담는 방식에서 실제 출력 하는 문자열을 이어붙여 만들어서 리턴하도록 함수를 변경하였습니다.
- 문자열을 이어붙이기 위한 공간을 할당하기 전에 이어붙일 문자열의 길이를 측정하여 이에 맞는 공간 만큼만 할당하도록 합니다.
    - 이때 길이를 측정할 때 header 는 기존과 같이 최대 길이를 32 라고 두고 초기화 하였습니다.
    - body 는 lqdetect 에 `total_offset` 을 선언하여 buffer 의 offset 이 증가할때 같이 증가하여 이를 활용했습니다. 
- 실패 할 경우의 message 는 `SERVER ERROR out of memory writing show response.` 를 출력하도록 하였습니다.
- lq->result 를 삭제함으로서 lq_release 삭제했습니다.