### PR TITLE
INTERNAL: Move a default_topkeys variable

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -111,7 +111,6 @@ union mc_engine mc_engine;
 static conn *listen_conn = NULL;
 static struct event_base *main_base;
 struct thread_stats *default_thread_stats;
-topkeys_t *default_topkeys = NULL;
 
 #ifdef ENABLE_ZK_INTEGRATION
 static char *arcus_zk_cfg = NULL;

--- a/memcached.h
+++ b/memcached.h
@@ -504,7 +504,6 @@ struct conn {
  */
 /* The external variables used in below macros */
 extern struct thread_stats *default_thread_stats;
-extern topkeys_t *default_topkeys;
 
 #define MY_THREAD_STATS(c) (&default_thread_stats[(c)->thread->index])
 

--- a/topkeys.c
+++ b/topkeys.c
@@ -7,6 +7,8 @@
 #include <memcached/genhash.h>
 #include "topkeys.h"
 
+topkeys_t *default_topkeys = NULL;
+
 static topkey_item_t *topkey_item_init(const void *key, int nkey, rel_time_t ctime)
 {
     topkey_item_t *item = calloc(sizeof(topkey_item_t) + nkey, 1);

--- a/topkeys.h
+++ b/topkeys.h
@@ -103,6 +103,8 @@ typedef struct topkeys {
     int max_keys;
 } topkeys_t;
 
+extern topkeys_t *default_topkeys;
+
 topkeys_t *topkeys_init(int max_keys);
 void topkeys_free(topkeys_t *topkeys);
 topkey_item_t *topkeys_item_get_or_create(topkeys_t *tk,


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- jam2in/arcus-works#506

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- `default_topkeys` 변수를 memcached.c 에서 topkey.c 로 이동시킵니다.
- memcached.h에서 전역화되어 있는 변수이기에 프로토콜 분리에 문제는 없으나 topkey에 관한 변수이므로 topkey 모듈에 있는 편이 자연스럽다고 생각했습니다.
