### PR TITLE
DOC: Fix response string when trimmed result in bop insert.

### DIFF
--- a/docs/ascii-protocol/ch08-command-btree-collection.md
+++ b/docs/ascii-protocol/ch08-command-btree-collection.md
@@ -92,7 +92,7 @@ Trimmed element 정보가 리턴되는 경우, 그 response string은 아래와 
 ```
 VALUE <flags> <count>\r\n
 <bkey> [<eflag>] <bytes> <data>\r\n
-END\r\n
+TRIMMED\r\n
 ```
 
 그 외의 response string과 의미는 아래와 같다.


### PR DESCRIPTION
### 🔗 Related Issue

### ⌨️ What I did

docker-compose로 캐시 클러스터 구성하여
아래의 `bop insert`를 getrim 옵션 주어 실행시키면
END 가 아닌 TRIMMED 가 응답으로 나옵니다.

문서가 잘못된 건지 구현이 잘못된건지 확인 부탁드립니다.

![스크린샷 2024-09-19 오후 3 26 24](https://github.com/user-attachments/assets/039bc4da-ef52-4610-8d81-f6d1f9961314)

PR은 문서가 잘못되었다고 가정하고 작성되었습니다.