### PR TITLE
FIX: Do not use space in SERVER_ERROR status

### DIFF
--- a/docs/ascii-protocol/ch04-command-key-value.md
+++ b/docs/ascii-protocol/ch04-command-key-value.md
@@ -25,7 +25,7 @@ Response string과 그 의미는 아래와 같다.
 | "EXISTS"             | cas 연산의 응답으로, 해당 아이템이 클라이언트의 마지막 fetch 이후 수정된 적이 있음을 뜻함.
 | "TYPE_MISMATCH"      | 해당 아이템이 key-value 타입이 아님.
 | "CLIENT_ERROR"       | 클라이언트에서 잘못된 질의를 했음을 의미. 이어 나오는 문자열을 통해 오류의 원인을 파악 가능. 예) bad command line format
-| "SERVER ERROR"       | 서버 측의 오류로 저장하지 못했음을 의미. 이어 나오는 문자열을 통해 오류의 원인을 파악 가능. 예) out of memory
+| "SERVER_ERROR"       | 서버 측의 오류로 저장하지 못했음을 의미. 이어 나오는 문자열을 통해 오류의 원인을 파악 가능. 예) out of memory
 
 ## retrieval 명령
 
@@ -69,7 +69,7 @@ END\r\n
 | Response String      | 설명                     |
 |----------------------|------------------------ |
 | "CLIENT_ERROR"       | 클라이언트에서 잘못된 질의를 했음을 의미. 이어 나오는 문자열을 통해 오류의 원인을 파악 가능. 예) bad command line format
-| "SERVER ERROR"       | 서버 측의 오류로 조회하지 못했음을 의미. 이어 나오는 문자열을 통해 오류의 원인을 파악 가능. 예) out of memory writing get response
+| "SERVER_ERROR"       | 서버 측의 오류로 조회하지 못했음을 의미. 이어 나오는 문자열을 통해 오류의 원인을 파악 가능. 예) out of memory writing get response
 
 mget 명령에서 메모리 부족으로 일부 key에 대해서만 정상 조회한 후 실패한 경우, 전체 연산을 서버 에러 처리한다.
 
@@ -109,4 +109,4 @@ decr <key> <delta> [<flags> <exptime> <initial>] [noreply]\r\n
 | "NOT_FOUND"          | key miss
 | "TYPE_MISMATCH"      | 해당 아이템이 key-value 타입이 아님
 | "CLIENT_ERROR"       | 클라이언트에서 잘못된 질의를 했음을 의미. 이어 나오는 문자열을 통해 오류의 원인을 파악 가능. 예) invalid numeric delta argument, cannot increment or decrement non-numeric value
-| "SERVER ERROR"       | 서버 측의 오류로 연산하지 못했음을 의미. 이어 나오는 문자열을 통해 오류의 원인을 파악 가능. 예) out of memory
+| "SERVER_ERROR"       | 서버 측의 오류로 연산하지 못했음을 의미. 이어 나오는 문자열을 통해 오류의 원인을 파악 가능. 예) out of memory

--- a/memcached.c
+++ b/memcached.c
@@ -2453,7 +2453,7 @@ process_bop_mget_single(conn *c, const char *key, size_t nkey,
             ret = ENGINE_SUCCESS;
         }
         else {
-            /* ENGINE_ENOMEM or ENGINE_DISCONNECT or SERVER error */
+            /* ENGINE_ENOMEM or ENGINE_DISCONNECT or SERVER_ERROR */
             STATS_CMD_NOKEY(c, bop_get);
         }
         if (ret == ENGINE_SUCCESS) {
@@ -10028,7 +10028,7 @@ static void process_lqdetect_command(conn *c, token_t *tokens, size_t ntokens)
         int size, i;
         c->lq_result = lqdetect_result_get(&size);
         if (c->lq_result == NULL) {
-            out_string(c, "SERVER ERROR out of memory");
+            out_string(c, "SERVER_ERROR out of memory");
             return;
         }
         for (i = 0; i < size; i++) {
@@ -10039,7 +10039,7 @@ static void process_lqdetect_command(conn *c, token_t *tokens, size_t ntokens)
         if (i < size) {
             lqdetect_result_release(c->lq_result);
             c->lq_result = NULL;
-            out_string(c, "SERVER ERROR out of memory writing show response");
+            out_string(c, "SERVER_ERROR out of memory writing show response");
             return;
         }
         conn_set_state(c, conn_mwrite);


### PR DESCRIPTION
### ⌨️ What I did
- `SERVER ERROR` 대신 `SERVER_ERROR`를 사용합니다.
