### PR TITLE
INTERNAL: Remove the check for clock_gettime function

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,16 +17,6 @@ then
 fi
 
 dnl **********************************************************************
-dnl Checks for clock_gettime function.
-dnl
-dnl if clock_gettime is available, define USE_CLOCK_GETTIME 1
-dnl else define USE_GETTIMEOFDAY 1
-dnl **********************************************************************
-AC_CHECK_LIB(rt, clock_gettime,
-        AC_DEFINE(USE_CLOCK_GETTIME, 1, [Defined if clock_gettime is available in libc]),
-        AC_DEFINE(USE_GETTIMEOFDAY, 1, [Defined if clock_gettime is not available in libc]))
-
-dnl **********************************************************************
 dnl DETECT_ICC ([ACTION-IF-YES], [ACTION-IF-NO])
 dnl
 dnl check if this is the Intel ICC compiler, and if so run the ACTION-IF-YES


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- jam2in/arcus-works#590

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 기존 코드에서는 clock_gettime 사용을 위해 librt에서 확인을 수행했지만, 링킹 옵션인 `-lrt`는 따로 지정되지 않았습니다.
- 확인 후 `-lrt`옵션을 주도록 추가하도록 변경합니다.