### PR TITLE
CLEANUP: Refactor cmdlog include

### DIFF
--- a/cmdlog.c
+++ b/cmdlog.c
@@ -15,20 +15,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "cmdlog.h"
+
 #include <stdio.h>
-#include <stdint.h>
 #include <pthread.h>
 #include <stdlib.h>
-#include <stdbool.h>
 #include <string.h>
 #include <sys/time.h>
 #include <fcntl.h>
-#include <unistd.h>
 #include <assert.h>
 #include <errno.h>
-#include <memcached/util.h>
 
-#include "cmdlog.h"
+#include "memcached/util.h"
 
 #define CMDLOG_INPUT_SIZE 400
 #define CMDLOG_BUFFER_SIZE  (10 * 1024 * 1024)   /* 10MB */

--- a/cmdlog.h
+++ b/cmdlog.h
@@ -17,7 +17,9 @@
 #ifndef CMDLOG_H
 #define CMDLOG_H
 
-#include "memcached/extension_loggers.h"
+#include <stdbool.h>
+
+#include "memcached/extension.h"
 
 #define COMMAND_LOGGING
 

--- a/memcached.c
+++ b/memcached.c
@@ -61,6 +61,7 @@
 #include <stdarg.h>
 #include <stddef.h>
 
+#include "cmdlog.h"
 #include "lqdetect.h"
 
 /* Lock for global stats */

--- a/memcached.h
+++ b/memcached.h
@@ -31,7 +31,6 @@
 #include "cache.h"
 #include "topkeys.h"
 #include "mc_util.h"
-#include "cmdlog.h"
 #include "engine_loader.h"
 #include "sasl_defs.h"
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/621

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- [google style guide](https://google.github.io/styleguide/cppguide.html) 에 맞춰 include 순서 변경
- `cmdlog.h`의 위치를 `memcached.h`에서 `memcached.c`로 옮김
- 헤더파일 단독으로 컴파일이 가능하도록 변경
- 꼭 필요한 파일만 include 하도록 변경
