### PR TITLE
Fix binary protocol for sasl

### DIFF
--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -399,7 +399,7 @@ integers separated by a colon (treat this as a floating point number).
 | cas_hits              | 64u     | Number of successful CAS reqs.            |
 | cas_badval            | 64u     | Number of CAS reqs for which a key was    |
 |                       |         | found, but the CAS value did not match.   |
-| auth_cmds             | 64u     | Number of authentication commands         |
+| cmd_auth              | 64u     | Number of authentication commands         |
 |                       |         | handled, success or failure.              |
 | auth_errors           | 64u     | Number of failed authentications.         |
 | evictions             | 64u     | Number of valid items removed from cache  |

--- a/docs/ascii-protocol/ch12-command-administration.md
+++ b/docs/ascii-protocol/ch12-command-administration.md
@@ -179,7 +179,7 @@ STAT cmd_bop_incr 0
 STAT cmd_bop_decr 0
 STAT cmd_getattr 0
 STAT cmd_setattr 0
-STAT auth_cmds 0
+STAT cmd_auth 0
 STAT auth_errors 0
 STAT get_hits 0
 STAT get_misses 0
@@ -306,7 +306,7 @@ END
 | reject_connections    | 클라이언트와의 연결을 거절한 횟수                            |
 | total_connections     | 서버 구동 이후 누적 connection 총합                          |
 | connection_structures | 서버가 할당한 connection 구조체 개수                         |
-| auth_cmds             | sasl 인증 횟수                                               |
+| cmd_auth              | sasl 인증 횟수                                               |
 | auth_errors           | sasl 인증 실패 횟수                                          |
 | cas_badval            | 키는 찾았으나 cas 값이 맞지 않은 요청의 횟수                 |
 | bytes_read            | 서버가 네트워크에서 읽은 데이터 용량 총합(bytes)             |

--- a/sasl_defs.c
+++ b/sasl_defs.c
@@ -141,15 +141,15 @@ static int sasl_log(void *context, int level, const char *message)
 
 static sasl_callback_t sasl_callbacks[] = {
 #ifdef ENABLE_SASL_PWDB
-   { SASL_CB_SERVER_USERDB_CHECKPASS, sasl_server_userdb_checkpass, NULL },
+   { SASL_CB_SERVER_USERDB_CHECKPASS, (int(*)(void))sasl_server_userdb_checkpass, NULL },
 #endif
 
 #ifdef ENABLE_SASL
-   { SASL_CB_LOG, sasl_log, NULL },
+   { SASL_CB_LOG, (int(*)(void))sasl_log, NULL },
 #endif
 
 #ifdef HAVE_SASL_CB_GETCONF
-   { SASL_CB_GETCONF, sasl_getconf, NULL },
+   { SASL_CB_GETCONF, (int(*)(void))sasl_getconf, NULL },
 #endif
 
    { SASL_CB_LIST_END, NULL, NULL }

--- a/t/binary-sasl.t.in
+++ b/t/binary-sasl.t.in
@@ -268,7 +268,7 @@ $empty->('x');
 
 {
     my %stats = $mc->stats('');
-    is ($stats{'auth_cmds'}, 2, "auth commands counted");
+    is ($stats{'cmd_auth'}, 2, "auth commands counted");
     is ($stats{'auth_errors'}, 1, "auth errors correct");
 }
 

--- a/t/stats.t
+++ b/t/stats.t
@@ -40,7 +40,7 @@ my $rst;
 ## STAT cas_misses 0
 ## STAT cas_hits 0
 ## STAT cas_badval 0
-## STAT auth_cmds 0
+## STAT cmd_auth 0
 ## STAT auth_errors 0
 ## STAT auth_unknowns 0
 ## STAT bytes_read 7
@@ -95,7 +95,7 @@ my $rst;
 ## STAT cmd_bop_decr 0
 ## STAT cmd_getattr 0
 ## STAT cmd_setattr 0
-## STAT auth_cmds 0
+## STAT cmd_auth 0
 ## STAT auth_errors 0
 ## STAT get_hits 0
 ## STAT get_misses 0


### PR DESCRIPTION
### 🔗 Related Issue
- https://github.com/naver/arcus-memcached/commit/849f9f201f257a45357c541f5dd34b3c35a90330

### ⌨️ What I did
- `auth_cmds` stat 기준으로 작성되어 있던 문서와 테스트를 `cmd_auth`로 변경합니다.
  - auth_cmds라는 stat이 없는 상태이기 때문에 sasl 사용 시 바이너리 테스트 실패하고 있었습니다.

- sasl_callback_t의 proc 필드에 함수 전달 시 타입 캐스팅 추가합니다.
  - 아래 Werror로 빌드 실패하는 문제를 해결합니다.
```
sasl_defs.c:148:4: error: initialization from incompatible pointer type [-Werror]
    { SASL_CB_LOG, sasl_log, NULL },
    ^
sasl_defs.c:148:4: error: (near initialization for ‘sasl_callbacks[0].proc’) [-Werror]
```