### PR TITLE
FIX: Fix node_name buffer size

### DIFF
--- a/cluster_config.c
+++ b/cluster_config.c
@@ -132,7 +132,7 @@ static int compare_cont_item(const void *t1, const void *t2)
 
 static int gen_node_continuum(struct cont_item *continuum, const char *node_name)
 {
-    char buffer[MAX_NODE_NAME_LENGTH+1] = "";
+    char buffer[MAX_NODE_NAME_LENGTH+4] = "";
     int  length;
     unsigned int  hh, nn, pp;
     unsigned char digest[16];
@@ -140,7 +140,7 @@ static int gen_node_continuum(struct cont_item *continuum, const char *node_name
 
     pp = 0;
     for (hh=0; hh<NUM_OF_HASHES; hh++) {
-        length = snprintf(buffer, MAX_NODE_NAME_LENGTH, "%s-%u", node_name, hh);
+        length = snprintf(buffer, sizeof(buffer), "%s-%u", node_name, hh);
         hash_md5(buffer, length, digest);
         for (nn=0; nn<NUM_PER_HASH; nn++, pp++) {
             continuum[pp].hpoint = ((uint32_t) (digest[3 + nn * NUM_PER_HASH] & 0xFF) << 24)


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/627#issuecomment-2456241826

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 현재 snprintf의 반환값을 그대로 쓰여진 문자열의 길이로 간주하여 해싱을 하는데 사용하고 있습니다.
- 이에 snprintf의 반환값이 실제로 쓰여진 문자열의 길이보다 클 경우 해싱 도중에 잘못된 주소를 참조할 수 도 있고, 원하는데로 해싱이 이루어지지 않을 우려가 있습니다.
- 따라서 버퍼의 크기를 node_name을 지을 수 있는 최장 길이로 설정하여 위의 예외들을 피하고자 합니다.
