### PR TITLE
INTERNAL: Add authenticated flag to conn struct

### DIFF
--- a/memcached.h
+++ b/memcached.h
@@ -275,6 +275,7 @@ struct conn {
     int    sfd;
     short  nevents;
     sasl_conn_t *sasl_conn;
+    bool authenticated;
     STATE_FUNC   state;
     enum bin_substates substate;
     struct event event;

--- a/t/binary-sasl.t.in
+++ b/t/binary-sasl.t.in
@@ -31,7 +31,7 @@ if (supports_sasl()) {
          plan skip_all => "The binary 'saslpasswd' is missing from your system";
     }
     else {
-       plan tests => 25;
+       plan tests => 33;
     }
 } else {
     plan tests => 1;
@@ -256,6 +256,38 @@ $check->('x','somevalue');
 }
 $empty->('x');
 
+{
+    my $mc = MC::Client->new;
+
+    # Attempt bad authentication.
+    is ($mc->authenticate('testuser', 'wrongpassword'), 0x20, "bad auth");
+
+    # This should fail because $mc is not authenticated
+    my ($status, $val)= $mc->set('x', "somevalue");
+    ok($status, "this fails to authenticate");
+    cmp_ok($status,'==',ERR_AUTH_ERROR, "error code matches");
+}
+$empty->('x', 'somevalue');
+
+{
+    my $mc = MC::Client->new;
+
+    # Attempt bad authentication.
+    is ($mc->authenticate('testuser', 'wrongpassword'), 0x20, "bad auth");
+
+    # Mix an authenticated connection and an unauthenticated connection to
+    # confirm c->authenticated is not shared among connections
+    my $mc2 = MC::Client->new;
+    is ($mc2->authenticate('testuser', 'testpass'), 0, "authenticated");
+    my ($status, $val)= $mc2->set('x', "somevalue");
+    ok(! $status);
+
+    # This should fail because $mc is not authenticated
+    ($status, $val)= $mc->set('x', "somevalue");
+    ok($status, "this fails to authenticate");
+    cmp_ok($status,'==',ERR_AUTH_ERROR, "error code matches");
+}
+
 # check the SASL stats, make sure they track things correctly
 # note: the enabled or not is presence checked in stats.t
 
@@ -268,8 +300,8 @@ $empty->('x');
 
 {
     my %stats = $mc->stats('');
-    is ($stats{'cmd_auth'}, 2, "auth commands counted");
-    is ($stats{'auth_errors'}, 1, "auth errors correct");
+    is ($stats{'cmd_auth'}, 5, "auth commands counted");
+    is ($stats{'auth_errors'}, 3, "auth errors correct");
 }
 
 


### PR DESCRIPTION
## ⌨️ What I did

- conn 구조체에 authenticated flag를 추가합니다.
- https://github.com/memcached/memcached/commit/87c1cf0f20be20608d3becf854e9cf0910f4ad32 와 동일한 변경입니다.

> It was previously possible to bypass authentication due to implicit state management.
Now we explicitly consider ourselves unauthenticated on any new connections and authentication attempts.