### PR TITLE
FIX: Fix memcached-init script files

### DIFF
--- a/scripts/memcached-init
+++ b/scripts/memcached-init
@@ -34,15 +34,29 @@ set -e
 
 case "$1" in
     start)
-        echo -n "Starting $DESC: "
-        start-stop-daemon --start --quiet --exec $DAEMONBOOTSTRAP
-        echo "$NAME."
+        if [ -f "$PIDFILE" ]; then
+            pid=$(cat "$PIDFILE")
+            if kill -0 "$pid" 2>/dev/null; then
+                echo "Already running with PID: $pid"
+                exit 1
+            fi
+            rm -f "$PIDFILE"
+        fi
+        nohup $DAEMONBOOTSTRAP > /dev/null 2>&1 &
+        daemon_pid=$!
+        echo "$daemon_pid" > "$PIDFILE" & echo "Started with PID: $daemon_pid"
         ;;
     stop)
-        echo -n "Stopping $DESC: "
-        start-stop-daemon --stop --quiet --oknodo --pidfile $PIDFILE --exec $DAEMON
-        echo "$NAME."
-        rm -f $PIDFILE
+        if [ -f "$PIDFILE" ]; then
+            pid=$(cat "$PIDFILE")
+            if kill -0 "$pid" 2>/dev/null; then
+                kill "$pid"
+                echo "Stopped with PID: $pid"
+            fi
+            rm -f "$PIDFILE"
+        else
+            echo "PID file not found: $PIDFILE"
+        fi
         ;;
 
     restart|force-reload)
@@ -51,12 +65,17 @@ case "$1" in
     #   option to the "reload" entry above. If not, "force-reload" is
     #   just the same as "restart".
     #
-        echo -n "Restarting $DESC: "
-        start-stop-daemon --stop --quiet --oknodo --pidfile $PIDFILE
-        rm -f $PIDFILE
+        if [ -f "$PIDFILE" ]; then
+            pid=$(cat "$PIDFILE")
+            if kill -0 "$pid" 2>/dev/null; then
+                kill "$pid"
+            fi
+            rm -f "$PIDFILE"
+        fi
         sleep 1
-        start-stop-daemon --start --quiet --exec $DAEMONBOOTSTRAP
-        echo "$NAME."
+        nohup $DAEMONBOOTSTRAP > /dev/null 2>&1 &
+        daemon_pid=$!
+        echo "$daemon_pid" > "$PIDFILE" & echo "Restarted with PID: $daemon_pid"
         ;;
     *)
         N=/etc/init.d/$NAME

--- a/scripts/memcached.conf
+++ b/scripts/memcached.conf
@@ -1,0 +1,1 @@
+-E lib/default_engine.so

--- a/scripts/start-memcached
+++ b/scripts/start-memcached
@@ -9,19 +9,12 @@
 
 use strict;
 
-if($> != 0 and $< != 0)
-{
-    print STDERR "Only root wants to run start-memcached.\n";
-    exit;
-}
-
 my $params; my $etchandle; my $etcfile = "/etc/memcached.conf";
 
 # This script assumes that memcached is located at /usr/bin/memcached, and
 # that the pidfile is writable at /var/run/memcached.pid
 
 my $memcached = "/usr/bin/memcached";
-my $pidfile = "/var/run/memcached.pid";
 
 # If we don't get a valid logfile parameter in the /etc/memcached.conf file,
 # we'll just throw away all of our in-daemon output. We need to re-tie it so
@@ -76,42 +69,8 @@ if(open $etchandle, $etcfile)
     $params = [];
 }
 
-push @$params, "-u root" unless(grep "-u", @$params);
 $params = join " ", @$params;
 
-if(-e $pidfile)
-{
-    open PIDHANDLE, "$pidfile";
-    my $localpid = <PIDHANDLE>;
-    close PIDHANDLE;
-
-    chomp $localpid;
-    if(-d "/proc/$localpid")
-    {
-        print STDERR "memcached is already running.\n";
-        exit;
-    }else{
-        `rm -f $localpid`;
-    }
-
-}
-
-my $pid = fork();
-
-if($pid == 0)
-{
-    reopen_logfile($fd_reopened);
-    exec "$memcached $params";
-    exit(0);
-
-}else{
-    if(open PIDHANDLE,">$pidfile")
-    {
-        print PIDHANDLE $pid;
-        close PIDHANDLE;
-    }else{
-
-        print STDERR "Can't write pidfile to $pidfile.\n";
-    }
-}
-
+reopen_logfile($fd_reopened);
+exec "$memcached $params";
+exit(0);


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/629

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- scripts 파일 실행에 있어 현재 arcus-memcached server를 상대로 실행 할 수 있도록 하였습니다.

  - `start-stop-daemon`의 경우 linux Debian 계열에 있는 명령어로 centOs 또는 Mac 환경에는 존재하지 않아 초경량 배포판을 제외한 모든 배포판에 있는 `nohup` 명령을 사용하여 변경하였습니다.

  - 이에 따라 사용하지 않게 된 pid 파일 관련 구현을 삭제하였습니다.
(start-stop-deamon의 경우 실행시 실행 pid를 pid 파일에 기록한 후 stop 시킬때 이를 활용하였는데, 이 pr 에서는 조회 한 후 grep 하여 정지시키도록 하였습니다.)

  - memcached.conf 파일은 memcached-init start 실행하여 memcached 서버를 구동할때 줄 옵션들을 적는 파일 입니다. 한 줄에 옵션 하니씩을 설정하게 되면 memcached server start 시에 해당 옵션들과 함께 구동됩니다.

*추가적으로 script를 실행하기 위해서는 script 파일들 안의 path들을 로컬 머신에 맞게 설정해야합니다.
