### PR TITLE
FIX: Prevent calling `sasl_server_step()` before `sasl_server_start()`

### DIFF
--- a/memcached.h
+++ b/memcached.h
@@ -275,6 +275,7 @@ struct conn {
     int    sfd;
     short  nevents;
     sasl_conn_t *sasl_conn;
+    bool sasl_started;
     bool authenticated;
     STATE_FUNC   state;
     enum bin_substates substate;


### PR DESCRIPTION
### ⌨️ What I did
- 사용자(클라이언트)는 `sasl auth` 명령을 통해 인증 방식과 초기 데이터를 전달하고,
그 이후에는 `sasl step` 명령을 통해 challenge와 response를 주고받게 됩니다.

- 그런데 `sasl auth`를 수행하지 않고 `sasl step` 명령을 전송하는 경우,
서버에서 `sasl_server_step()` 함수를 호출하면서 segfault 발생하게 됩니다.

- `c->sasl_started` flag를 추가하여 문제를 해결합니다.
https://github.com/memcached/memcached/commit/ced9e1730cb6bb3beece9b22e7bd5cb2d05ed2c8 구현을 참고하였습니다.