### PR TITLE
FEATURE: Add sasl command

### DIFF
--- a/t/binary-sasl.t.in
+++ b/t/binary-sasl.t.in
@@ -31,7 +31,7 @@ if (supports_sasl()) {
          plan skip_all => "The binary 'saslpasswd' is missing from your system";
     }
     else {
-       plan tests => 33;
+       plan tests => 30;
     }
 } else {
     plan tests => 1;
@@ -41,21 +41,6 @@ if (supports_sasl()) {
     ok($@, "Died with illegal -S args when SASL is not supported.");
     exit 0;
 }
-
-eval {
-    my $server = get_memcached($engine, "-S -B auto");
-};
-ok($@, "SASL shouldn't be used with protocol auto negotiate");
-
-eval {
-    my $server = get_memcached($engine, "-S -B ascii");
-};
-ok($@, "SASL isn't implemented in the ascii protocol");
-
-eval {
-    my $server = get_memcached($engine, "-S -B binary -B ascii");
-};
-ok($@, "SASL isn't implemented in the ascii protocol");
 
 # Based almost 100% off testClient.py which is:
 # Copyright (c) 2007  Dustin Sallings <dustin@spy.net>


### PR DESCRIPTION
(동작 확인 단계이고 세부 구현은 충분히 확인하지 않았습니다.)

- jam2in/arcus-works#634

## ⌨️ What I did
- `-S` 옵션 활성화 시 ascii protocol도 사용할 수 있도록 합니다.
- `sasl` 명령을 추가합니다.
  - `sasl mech`
  - `sasl auth`
- ascii protocol 기준 인증하지 않고 사용할 수 있는 명령은 아래와 같습니다.
  - `sasl` 계열 명령
  - `version`
  - `quit`

### `sasl mech`
- 공백으로 구분된 인증 방식 목록을 반환합니다.
- value의 key(`mech`)와 flag(`0`)는 dummy 값 입니다.
```
sasl mech\r\n
```
```sh
VALUE mech 0 {body length}\r\n
{mechanism list}\r\n
END\r\n
```

### `sasl auth`
- 선택한 방식으로 인증 프로세스를 시작합니다.
```
sasl auth {mech} {body length}\r\n
{data}\r\n
```

- 인증이 성공하면 `END` 응답을 반환합니다.
```
END\r\n
```
- 추가 challenge가 필요한 경우 `VALUE`와 함께 서버의 data를 응답합니다.
- value의 key(`sasl`)와 flag(`0`)는 dummy 값 입니다.
```
VALUE sasl 0 {body length}\r\n
{data}\r\n
```
- 클라이언트는 `VALUE` 응답을 받으면 mechanism 인자가 없는 `sasl auth` 명령을 통해 인증을 계속 진행합니다.
- `VALUE` 없는 `END` 응답이 반환될 때까지 인증 step을 계속 진행할 수 있습니다.
```
sasl auth {body length}\r\n
{data}\r\n
```