### PR TITLE
INTERNAL: Refactor lq_detect_buffer struct

### DIFF
--- a/lqdetect.h
+++ b/lqdetect.h
@@ -12,7 +12,6 @@
 extern bool lqdetect_in_use;
 
 int lqdetect_init(EXTENSION_LOGGER_DESCRIPTOR *logger);
-void lqdetect_final(void);
 char *lqdetect_result_get(int *size);
 int lqdetect_start(uint32_t threshold, bool *already_started);
 void lqdetect_stop(bool *already_stopped);

--- a/memcached.c
+++ b/memcached.c
@@ -15862,9 +15862,6 @@ int main (int argc, char **argv)
 #ifdef COMMAND_LOGGING
     cmdlog_final(); /* finalize command logging */
 #endif
-#ifdef DETECT_LONG_QUERY
-    lqdetect_final(); /* finalize long query detection */
-#endif
     mc_engine.v1->destroy(mc_engine.v0);
     mc_logger->log(EXTENSION_LOG_INFO, NULL, "Memcached engine destroyed.\n");
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/621
- https://github.com/naver/arcus-memcached/pull/796#discussion_r1833860547

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 기존 `lq_detect_buffer`의 data에 출력될 문자열을 미리 붙인 후 출력하는 방식에서 `lq_detect_argument`에서 client_ip, time 을 가지고 있다가 마지막에 합쳐서 출력하는 형태로 변경하였습니다.
- 이에 맞추어 기존에 출력하려던 버퍼를 `LQ_INPUT_SIZE`로 최대로 잡는 방식에서 실제로 출력할 문자열의 길이만큼만 할당하도록 변경하였습니다.
- 따라서 추후 key size 등이 증가하여도 추가적인 변경없이 확장 할 수 있습니다.
