### PR TITLE
FIX: Use `||` when comparing multiple strings with the command

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -13290,7 +13290,7 @@ static int try_read_command_ascii(conn *c)
              */
             if (c->rbytes > ((16+8)*1024)) {
                 /* The length of "stats prefixes" command cannot exceed 24 KB. */
-                if (strncmp(ptr, "get ", 4) && strncmp(ptr, "gets ", 5)) {
+                if (strncmp(ptr, "get ", 4) || strncmp(ptr, "gets ", 5)) {
                     char buffer[16];
                     memcpy(buffer, ptr, 15); buffer[15] = '\0';
                     mc_logger->log(EXTENSION_LOG_WARNING, c,


### PR DESCRIPTION
### 🔗 Related Issue
- jam2in/arcus-works#649

### ⌨️ What I did
- ptr을 여러 문자열과 비교 시 or 조건을 사용합니다.
- 두 조건을 동시에 만족할 수는 없으므로 현재는 조건문 내부로 진입하는 경우가 없을 것입니다.
