### PR TITLE
INTERNAL: Modify the term related to eflag

### DIFF
--- a/docs/ascii-protocol/ch02-collection-items.md
+++ b/docs/ascii-protocol/ch02-collection-items.md
@@ -102,28 +102,27 @@ bkey의 hexadecimal 표현과 저장 방식을 그대로 따른다.
 
 eflag에 대한 filter 조건은 아래와 같이 표현하며,
 (1) eflag의 전체/부분 값과 특정 값과의 compare 연산이나
-(2) eflag의 전체/부분 값에 대해 어떤 operand로 bitwise 연산을 취한 후의 결과와 특정 값과의 compare 연산이다.
+(2) eflag의 전체/부분 값에 대해 bitwise 연산을 취한 결과와 특정 값과의 compare 연산이다.
 
 ```
-eflag_filter: <fwhere> [<bitwop> <foperand>] <compop> <fvalue>
+eflag_filter: <offset> [<bitwop> <bitwvalue>] <compop> <compvalue>
 ```
 
-- \<fwhere\>
+- \<offset\>
   - eflag 값에서 bitwise/compare 연산을 취할 시작 offset을 바이트 단위로 나타낸다.
-    bitwise/compare 연산을 취할 데이터의 length는 \<fvalue\>의 length로 한다.
-    예를 들어, eflag 전체 데이터를 선택한다면, \<fwhere\>는 0이어야 하고
-    \<fvalue\>의 length는 eflag 전체 데이터의 length와 동일하여야 한다.
-- [\<bitwop\> \<foperand\>]
+    offset과 bitwise/compare 연산을 취할 데이터 length의 합은 eflag 데이터의 length보다 작거나 같아야 한다.
+    예를 들어, eflag 전체 데이터와 비교한다면, \<offset\>은 0이어야 \<compvalue\>의 length는 eflag 전체 데이터의 length와 동일하여야 한다.
+- [\<bitwop\> \<bitwvalue\>]
   - 생략 가능하며, eflag에 대한 bitwise 연산을 지정한다.
   - bitwise 연산이 지정되면 이 연산의 결과가 compare 연산의 대상이 되며,
     생략된다면 eflag 값 자체가 compare 연산의 대상이 된다.
   - \<bitwop\>는 "&"(bitwise and), "|"(bitwise or), "^"(bitwise xor) 중의 하나로 bitwise 연산을 지정한다.
-  - \<foperand\>는 bitwise 연산을 취할 operand로 hexadecimal로 표현한다.
-    \<foperand\>의 길이는 compare 연산을 취한 \<fvalue\>의 길이와 동일하여야 한다.
-- \<compop\> \<fvalue\>
+  - \<bitwvalue\>는 bitwise 연산을 취할 값으로 hexadecimal로 표현한다.
+    \<bitwvalue\>의 길이는 compare 연산을 취할 \<compvalue\>의 길이와 동일하여야 한다.
+- \<compop\> \<compvalue\>
   - eflag에 대한 compare 연산을 지정한다.
   - \<compop\>는 "EQ", "NE", "LT", "LE", "GT", "GE" 중의 하나로 compare 연산을 지정하며,
-    \<fvalue\>는 compare 연산을 취할 대상 값으로 마찬가지로 hexadecimal로 표현한다.
+    \<compvalue\>는 compare 연산을 취할 대상 값으로 마찬가지로 hexadecimal로 표현한다.
   - IN 또는 NOT IN 조건을 명시할 수도 있다.
     IN 조건은 "EQ" 연산과 comma separated hexadecimal values로 명시하면 되고,
     NOT IN 조건은 "NE" 연산과 comma separated hexadecimal values로 명시하면 된다.
@@ -148,22 +147,22 @@ Eflag 전체 변경은 새로운 eflag 값으로 교체하는 것이며,
 부분 변경은 eflag의 부분 데이터에 대해 bitwise 연산을 취한 결과로 교체한다.
 
 ```
-eflag_update: [<fwhere> <bitwop>] <fvalue>
+eflag_update: [<offset> <bitwop>] <value>
 ```
 
-- [\<fwhere\> \<bitwop\>]
+- [\<offset\> \<bitwop\>]
   - eflag를 부분 변경할 경우만 지정한다.
-  - \<fwhere>은 eflag에서 부분 변경할 데이터의 시작 offset을 바이트 단위로 나타내며,
-    이 경우, 부분 변경할 데이터의 length는 뒤에 명시되는 \<fvalue\>의 length로 결정된다.
+  - \<offset>은 eflag에서 부분 변경할 데이터의 시작 offset을 바이트 단위로 나타내며,
+    이 경우, 부분 변경할 데이터의 length는 뒤에 명시되는 \<value\>의 length로 결정된다.
   - \<bitwop\>는 부분 변경할 데이터에 대한 취할 bitwise 연산으로,
     "&"(bitwise and), "|"(bitwise or), "^"(bitwise xor) 중의 하나로 지정할 수 있다.
-- \<fvalue\>
+- \<value\>
   - 변경할 new value를 나타낸다.
-  - 앞서 기술한 \<fwhere\>과 \<bitwop\>가 생략되면, eflag의 전체 데이터를 \<fvalue\>로 변경한다.
-    부분 변경을 위한 \<fwhere\>과 \<bitwop\>가 지정되면
-    \<fvalue\>는 eflag 부분 데이터에 대해 bitwise 연산을 취할 operand로 사용되며,
+  - 앞서 기술한 \<offset\>과 \<bitwop\>가 생략되면, eflag의 전체 데이터를 \<value\>로 변경한다.
+    부분 변경을 위한 \<offset\>과 \<bitwop\>가 지정되면
+    \<value\>는 eflag 부분 데이터에 대해 bitwise 연산을 취할 데이터로 사용되며,
     bitwise 연산의 결과가 eflag의 new value로 변경된다.
 
 
 기존 eflag 값을 delete하여 eflag가 없는 상태로 변경할 수 있다.
-이를 위해서는 \<fwhere\>과 \<bitwop\>를 생략하고 \<fvalue\> 값으로 0을 주면 된다.
+이를 위해서는 \<offset\>과 \<bitwop\>를 생략하고 \<value\> 값으로 0을 주면 된다.

--- a/docs/ascii-protocol/ch08-command-btree-collection.md
+++ b/docs/ascii-protocol/ch08-command-btree-collection.md
@@ -121,7 +121,7 @@ B+tree collection에서 하나의 element에 대해 eflag 변경 그리고/또�
 
 ```
 bop update <key> <bkey> [<eflag_update>] <bytes> [noreply|pipe]\r\n[<data>\r\n]
-* eflag_update : [<fwhere> <bitwop>] <fvalue>
+* eflag_update : [<offset> <bitwop>] <value>
 ```
 
 - \<key\> - 대상 item의 key string
@@ -156,7 +156,7 @@ N 개의 elements를 삭제한다.
 
 ```
 bop delete <key> <bkey or "bkey range"> [<eflag_filter>] [<count>] [drop] [noreply|pipe]\r\n
-* <eflag_filter> : <fwhere> [<bitwop> <foperand>] <compop> <fvalue>
+* <eflag_filter> : <offset> [<bitwop> <bitwvalue>] <compop> <compvalue>
 ```
 
 - \<key\> - 대상 item의 key string
@@ -189,7 +189,7 @@ elements에서 offset 개를 skip한 후 count 개의 elements를 조회한다.
 
 ```
 bop get <key> <bkey or "bkey range"> [<eflag_filter>] [[<offset>] <count>] [delete|drop]\r\n
-* <eflag_filter> : <fwhere> [<bitwop> <foperand>] <compop> <fvalue>
+* <eflag_filter> : <offset> [<bitwop> <bitwvalue>] <compop> <compvalue>
 ```
 
 - \<key\> - 대상 item의 key string
@@ -248,7 +248,7 @@ elements 개수를 구한다.
 
 ```
 bop count <key> <bkey or "bkey range"> [<eflag_filter>]\r\n
-* <eflag_filter> : <fwhere> [<bitwop> <foperand>] <compop> <fvalue>
+* <eflag_filter> : <offset> [<bitwop> <bitwvalue>] <compop> <compvalue>
 ```
 
 - \<key\> - 대상 item의 key string
@@ -325,7 +325,7 @@ Increment/decrement 수행 후의 데이터 값이다.
 ```
 bop mget <lenkeys> <numkeys> <bkey or "bkey range"> [<eflag_filter>] [<offset>] <count>\r\n
 <"space separated keys">\r\n
-* <eflag_filter> : <fwhere> [<bitwop> <foperand>] <compop> <fvalue>
+* <eflag_filter> : <offset> [<bitwop> <bitwvalue>] <compop> <compvalue>
 ```
 
 - \<"space separated keys"\> - 대상 b+tree들의 key list로, 스페이스(' ')로 구분한다.
@@ -411,7 +411,7 @@ elements를 sort merge 형태로 조회하면서 count 개의 elements를 가져
 ```
 bop smget <lenkeys> <numkeys> <bkey or "bkey range"> [<eflag_filter>] <count> duplicate|unique\r\n
 <"space separated keys">\r\n
-* <eflag_filter> : <fwhere> [<bitwop> <foperand>] <compop> <fvalue>
+* <eflag_filter> : <offset> [<bitwop> <bitwvalue>] <compop> <compvalue>
 ```
 
 - \<"space separated keys"\> - 대상 b+tree들의 key list로, 스페이스(' ')로 구분한다.

--- a/engines/default/cmdlogrec.c
+++ b/engines/default/cmdlogrec.c
@@ -1181,7 +1181,7 @@ static ENGINE_ERROR_CODE lrec_bt_elem_delete_logical_redo(LogRec *logrec)
         memcpy(efilter.compval, compvalptr, body->compvcnt*body->ncompval);
         efilter.ncompval = body->ncompval;
         efilter.compvcnt = body->compvcnt;
-        efilter.fwhere   = body->fwhere;
+        efilter.offset   = body->f_offset;
         efilter.bitwop   = body->bitwop;
         efilter.compop   = body->compop;
     }
@@ -1240,8 +1240,8 @@ static void lrec_bt_elem_delete_logical_print(LogRec *logrec)
                 memcpy(tmpptr, ",0x", 3); tmpptr += 3;
             }
         }
-        sprintf(efilterstr, "(fwhere=%u, bitwop=%u, bitwval=0x%s, compop=%u, compval(count=%u)=0x%s)",
-                log->body.fwhere, log->body.bitwop, (log->body.nbitwval > 0 ? bitwvalstr : "NULL"),
+        sprintf(efilterstr, "(f_offset=%u, bitwop=%u, bitwval=0x%s, compop=%u, compval(count=%u)=0x%s)",
+                log->body.f_offset, log->body.bitwop, (log->body.nbitwval > 0 ? bitwvalstr : "NULL"),
                 log->body.compop, log->body.compvcnt, compvalstr);
     } else {
         sprintf(efilterstr, "NULL");
@@ -1794,7 +1794,7 @@ int lrec_construct_btree_elem_delete_logical(LogRec *logrec, hash_item *it,
         log->body.nbitwval = efilter->nbitwval;
         log->body.ncompval = efilter->ncompval;
         log->body.compvcnt = efilter->compvcnt;
-        log->body.fwhere   = efilter->fwhere;
+        log->body.f_offset = efilter->offset;
         log->body.bitwop   = efilter->bitwop;
         log->body.compop   = efilter->compop;
     }

--- a/engines/default/cmdlogrec.h
+++ b/engines/default/cmdlogrec.h
@@ -360,7 +360,7 @@ typedef struct _Btree_elem_delete_logical_data {
     uint8_t  nbitwval;   /* bitwise value length */
     uint8_t  ncompval;   /* compare value length */
     uint8_t  compvcnt;   /* # of compare values */
-    uint8_t  fwhere;     /* filter offset */
+    uint8_t  f_offset;   /* filter offset */
     uint8_t  bitwop;     /* bitwise operation */
     uint8_t  compop;     /* compare operation */
     uint32_t offset;     /* element offset */

--- a/engines/default/coll_btree.c
+++ b/engines/default/coll_btree.c
@@ -1028,12 +1028,12 @@ static btree_elem_item *do_btree_find_prev(btree_elem_posi *posi,
 static inline bool do_btree_elem_filter(btree_elem_item *elem, const eflag_filter *efilter)
 {
     assert(efilter != NULL);
-    if (efilter->fwhere >= elem->neflag || efilter->ncompval > (elem->neflag-efilter->fwhere)) {
+    if (efilter->offset >= elem->neflag || efilter->ncompval > (elem->neflag-efilter->offset)) {
         return (efilter->compop == COMPARE_OP_NE ? true : false);
     }
 
     unsigned char result[MAX_EFLAG_LENG];
-    unsigned char *operand = elem->data + BTREE_REAL_NBKEY(elem->nbkey) + efilter->fwhere;
+    unsigned char *operand = elem->data + BTREE_REAL_NBKEY(elem->nbkey) + efilter->offset;
 
     if (efilter->nbitwval > 0) {
         (*BINARY_BITWISE_OP[efilter->bitwop])(operand, efilter->bitwval, efilter->nbitwval, result);
@@ -1748,7 +1748,7 @@ static ENGINE_ERROR_CODE do_btree_elem_update(btree_meta_info *info,
 
     /* check eflag update validation check */
     if (eupdate != NULL && eupdate->neflag > 0 && eupdate->bitwop < BITWISE_OP_MAX) {
-        if (eupdate->fwhere >= elem->neflag || eupdate->neflag > (elem->neflag-eupdate->fwhere)) {
+        if (eupdate->offset >= elem->neflag || eupdate->neflag > (elem->neflag-eupdate->offset)) {
             return ENGINE_EBADEFLAG;
         }
     }
@@ -1762,7 +1762,7 @@ static ENGINE_ERROR_CODE do_btree_elem_update(btree_meta_info *info,
         /* do in-place update */
         if (eupdate != NULL) {
             if (eupdate->bitwop < BITWISE_OP_MAX) {
-                ptr = elem->data + real_nbkey + eupdate->fwhere;
+                ptr = elem->data + real_nbkey + eupdate->offset;
                 (*BINARY_BITWISE_OP[eupdate->bitwop])(ptr, eupdate->eflag, eupdate->neflag, ptr);
             } else {
                 if (eupdate->neflag > 0) {
@@ -1801,7 +1801,7 @@ static ENGINE_ERROR_CODE do_btree_elem_update(btree_meta_info *info,
                 memcpy(new_elem->data + real_nbkey, elem->data + real_nbkey, elem->neflag);
             }
             if (eupdate != NULL) {
-                ptr = new_elem->data + real_nbkey + eupdate->fwhere;
+                ptr = new_elem->data + real_nbkey + eupdate->offset;
                 (*BINARY_BITWISE_OP[eupdate->bitwop])(ptr, eupdate->eflag, eupdate->neflag, ptr);
             }
         } else {

--- a/include/memcached/protocol_binary.h
+++ b/include/memcached/protocol_binary.h
@@ -743,7 +743,7 @@ extern "C"
                 uint8_t  nbkey;
                 uint8_t  eflag[MAX_EFLAG_LENG];
                 uint8_t  neflag;
-                uint8_t  fwhere;
+                uint8_t  offset;
                 uint8_t  bitwop;
                 uint8_t  novalue;
                 uint8_t  reserved[5];

--- a/include/memcached/types.h
+++ b/include/memcached/types.h
@@ -341,7 +341,7 @@ extern "C" {
         uint8_t nbitwval; /* bitwise value length */
         uint8_t ncompval; /* compare value length */
         uint8_t compvcnt; /* # of compare values */
-        uint8_t fwhere; /* filter offset */
+        uint8_t offset; /* filter offset */
         uint8_t bitwop; /* bitwise operation */
         uint8_t compop; /* compare operation */
     } eflag_filter;
@@ -350,7 +350,7 @@ extern "C" {
     typedef struct {
         unsigned char eflag[MAX_EFLAG_LENG];
         uint8_t  neflag;
-        uint8_t  fwhere;
+        uint8_t  offset;
         uint8_t  bitwop;
         uint8_t reserved[6];
     } eflag_update;

--- a/memcached.c
+++ b/memcached.c
@@ -5544,7 +5544,7 @@ static void process_bin_bop_update_prepare_nread(conn *c)
     c->coll_bkrange.from_nbkey = req->message.body.nbkey;
     c->coll_bkrange.to_nbkey   = BKEY_NULL;
     /* build elem update */
-    c->coll_eupdate.fwhere = req->message.body.fwhere;
+    c->coll_eupdate.offset = req->message.body.offset;
     c->coll_eupdate.bitwop = req->message.body.bitwop;
     c->coll_eupdate.neflag = req->message.body.neflag;
     if (req->message.body.neflag > 0) {
@@ -9393,9 +9393,9 @@ static void process_help_command(conn *c, token_t *tokens, const size_t ntokens)
         "\t" "bop gbp <key> <order> <position or \"position range\">\\r\\n" "\n"
         "\n"
         "\t" "* <attributes> : <flags> <exptime> <maxcount> [<ovflaction>] [unreadable]" "\n"
-        "\t" "* <eflag_update> : [<fwhere> <bitwop>] <fvalue>" "\n"
-        "\t" "* <eflag_filter> : <fwhere> [<bitwop> <foperand>] <compop> <fvalue>" "\n"
-        "\t" "                 : <fwhere> [<bitwop> <foperand>] EQ|NE <comma separated fvalue list>" "\n"
+        "\t" "* <eflag_update> : [<offset> <bitwop>] <value>" "\n"
+        "\t" "* <eflag_filter> : <offset> [<bitwop> <bitwvalue>] <compop> <compvalue>" "\n"
+        "\t" "                 : <offset> [<bitwop> <bitwvalue>] EQ|NE <comma separated compvalue list>" "\n"
         "\t" "* <bitwop> : &, |, ^" "\n"
         "\t" "* <compop> : EQ, NE, LT, LE, GT, GE" "\n"
         );
@@ -11739,7 +11739,7 @@ static inline int get_efilter_from_tokens(token_t *tokens, const int ntokens, ef
         if (! safe_strtoul(tokens[0].value, &offset) || offset >= MAX_EFLAG_LENG) {
             return -1;
         }
-        efilter->fwhere = (uint8_t)offset;
+        efilter->offset = (uint8_t)offset;
         token_count = 1;
 
         if (ntokens >= 5 && strncmp(tokens[4].value, "0x", 2) == 0) {
@@ -12298,7 +12298,7 @@ static void process_bop_command(conn *c, token_t *tokens, const size_t ntokens)
                     out_string(c, "CLIENT_ERROR bad command line format");
                     return;
                 }
-                c->coll_eupdate.fwhere = (uint8_t)offset;
+                c->coll_eupdate.offset = (uint8_t)offset;
                 c->coll_eupdate.bitwop = get_bitwise_op_from_str(tokens[read_ntokens+1].value);
                 if (c->coll_eupdate.bitwop == BITWISE_OP_MAX) {
                     print_invalid_command(c, tokens, ntokens);

--- a/t/coll_bop_eflag.t
+++ b/t/coll_bop_eflag.t
@@ -42,13 +42,13 @@ sub do_btree_efilter {
     $bkrange = "0x" . "0"x62 . ".." . "0x" . "F"x62;
 
     # prepare for making efilter.
-    my $foperand = "0x" . "F"x62;
-    my $fvallist = "0x" . sprintf "%062d", 1;
+    my $bitwvalue = "0x" . "F"x62;
+    my $compvallist = "0x" . sprintf "%062d", 1;
     for ($eidx = 2; $eidx <= 100; $eidx += 1) {
-        $fvallist .= ",0x" . sprintf "%062d", $eidx;
+        $compvallist .= ",0x" . sprintf "%062d", $eidx;
     }
     # longest efilter case 1
-    $efilter = "0 & $foperand EQ $fvallist";
+    $efilter = "0 & $bitwvalue EQ $compvallist";
 
     # bop count
     $cmd = "bop count $kstr $bkrange $efilter"; $rst = "COUNT=99";
@@ -68,7 +68,7 @@ sub do_btree_efilter {
     mem_cmd_is($sock, $cmd, "", $rst);
 
     # longest efilter case 2
-    $efilter = "0 & $foperand NE $fvallist";
+    $efilter = "0 & $bitwvalue NE $compvallist";
 
     # bop count
     $cmd = "bop count $kstr $bkrange $efilter"; $rst = "COUNT=1";

--- a/t/long_query_detect_issue.t
+++ b/t/long_query_detect_issue.t
@@ -42,13 +42,13 @@ sub do_btree_efilter {
     $bkrange = "0x" . "0"x62 . ".." . "0x" . "F"x62;
 
     # prepare for making efilter.
-    my $foperand = "0x" . "F"x62;
-    my $fvallist = "0x" . sprintf "%062d", 1;
+    my $bitwvalue = "0x" . "F"x62;
+    my $compvallist = "0x" . sprintf "%062d", 1;
     for ($eidx = 2; $eidx <= 100; $eidx += 1) {
-        $fvallist .= ",0x" . sprintf "%062d", $eidx;
+        $compvallist .= ",0x" . sprintf "%062d", $eidx;
     }
     # longest efilter case 1
-    $efilter = "0 & $foperand EQ $fvallist";
+    $efilter = "0 & $bitwvalue EQ $compvallist";
 
     # bop count
     $cmd = "bop count $kstr $bkrange $efilter"; $rst = "COUNT=99";
@@ -68,7 +68,7 @@ sub do_btree_efilter {
     mem_cmd_is($sock, $cmd, "", $rst);
 
     # longest efilter case 2
-    $efilter = "0 & $foperand NE $fvallist";
+    $efilter = "0 & $bitwvalue NE $compvallist";
 
     # bop count
     $cmd = "bop count $kstr $bkrange $efilter"; $rst = "COUNT=1";


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- naver/arcus-c-client#328

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- eflag 관련 용어를 변경합니다.
  - fwhere => offset (일부 구조체에서 offset 변수가 이미 존재하여 f_offset 이라는 이름을 사용했습니다.)
  - operand => bitwvalue
  - fvalue => compvalue(eflag_filter), value(eflag_update)
