### PR TITLE
FEATURE: add set offset command

### DIFF
--- a/engines/default/coll_set.h
+++ b/engines/default/coll_set.h
@@ -47,7 +47,7 @@ ENGINE_ERROR_CODE set_elem_exist(const char *key, const uint32_t nkey,
                                  bool *exist);
 
 ENGINE_ERROR_CODE set_elem_get(const char *key, const uint32_t nkey,
-                               const uint32_t count,
+                               const uint32_t offset, const uint32_t count,
                                const bool delete, const bool drop_if_empty,
                                struct elems_result *eresult,
                                const void *cookie);

--- a/engines/default/default_engine.c
+++ b/engines/default/default_engine.c
@@ -661,7 +661,7 @@ default_set_elem_exist(ENGINE_HANDLE* handle, const void* cookie,
 static ENGINE_ERROR_CODE
 default_set_elem_get(ENGINE_HANDLE* handle, const void* cookie,
                      const void* key, const int nkey,
-                     const uint32_t count,
+                     const uint32_t offset, const uint32_t count,
                      const bool delete, const bool drop_if_empty,
                      struct elems_result *eresult, uint16_t vbucket)
 {
@@ -674,7 +674,7 @@ default_set_elem_get(ENGINE_HANDLE* handle, const void* cookie,
 
     if (delete) ACTION_BEFORE_WRITE(cookie, key, nkey);
     else        ACTION_BEFORE_READ(cookie, key, nkey);
-    ret = set_elem_get(key, nkey, count, delete, drop_if_empty,
+    ret = set_elem_get(key, nkey, offset, count, delete, drop_if_empty,
                        eresult, cookie);
     if (delete) ACTION_AFTER_WRITE(cookie, engine, ret);
     return ret;

--- a/engines/demo/demo_engine.c
+++ b/engines/demo/demo_engine.c
@@ -401,7 +401,7 @@ Demo_set_elem_exist(ENGINE_HANDLE* handle, const void* cookie,
 static ENGINE_ERROR_CODE
 Demo_set_elem_get(ENGINE_HANDLE* handle, const void* cookie,
                      const void* key, const int nkey,
-                     const uint32_t count,
+                     const uint32_t offset, const uint32_t count,
                      const bool delete, const bool drop_if_empty,
                      struct elems_result *eresult, uint16_t vbucket)
 {

--- a/include/memcached/engine.h
+++ b/include/memcached/engine.h
@@ -420,7 +420,7 @@ extern "C" {
 
         ENGINE_ERROR_CODE (*set_elem_get)(ENGINE_HANDLE* handle, const void* cookie,
                                           const void* key, const int nkey,
-                                          const uint32_t count,
+                                          const uint32_t offset, const uint32_t count,
                                           const bool delete, const bool drop_if_empty,
                                           struct elems_result *eresult, uint16_t vbucket);
 


### PR DESCRIPTION
### 🔗 Related Issue

- https://github.com/jam2in/arcus-works/issues/571

### ⌨️ What I did

- Set get 연산시 offset을 기준으로 get을 할 수 있도록 변경했습니다.

```
sop get <key> [<offset>] <count> [delete | drop]\r\n
```

### 구현방법

Offset 탐색 방식
- Offset 탐색은 subtree count 방식을 사용하여 진행했습니다.
- `tot_elem_cnt` 를 자식 노드까지 포함한 subtree의 element 개수로 변경했습니다.
  - 기존에는 현재 노드의 element 개수만 저장했습니다.


Offset으로 탐색 시:
1. **노드 → 버킷(체인) → element** 순서로 확인합니다.

`tot_elem_cnt`를 노드별로 유지하기 위해:
1. 삽입 시:
   - 부모 `node pointer`를 저장하여 삽입이 정상적으로 작동하면 갱신합니다.
2. 삭제 시:
   - DFS로 부모 노드로 올라가며 `tot_elem_cnt`를 갱신합니다.
3. 현재 노드의 element 개수가 필요할 때:
   - `(tot_elem_cnt) - (자식 노드들의 tot_elem_cnt 합)`으로 계산하여 사용합니다.

예외처리
- `offset` 값이 `ccnt` 보다 크거나 같으면 NOT_FOUND_ELEMENT 처리합니다.


사용 예시
```
sop get skey 0
VALUE 0 7
1 b
1 c
1 a
1 f
1 g
1 d
1 e
END

sop get skey 1 1
VALUE 0 1
1 c
END

sop get skey 1 0
VALUE 0 6
1 c
1 a
1 f
1 g
1 d
1 e
END

sop get skey 3 5
VALUE 0 4
1 f
1 g
1 d
1 e
END

sop get skey 12 0
NOT_FOUND_ELEMENT
```

