### PR TITLE
INTERNAL: Do not include `sasl_defs.h` in `memcached.h`

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -63,6 +63,7 @@
 
 #include "cmdlog.h"
 #include "lqdetect.h"
+#include "sasl_defs.h"
 
 /* Lock for global stats */
 static pthread_mutex_t stats_lock = PTHREAD_MUTEX_INITIALIZER;
@@ -868,7 +869,7 @@ static void conn_cleanup(conn *c)
     }
 
     if (c->sasl_conn) {
-        sasl_dispose(&c->sasl_conn);
+        sasl_dispose((sasl_conn_t**)&c->sasl_conn);
         c->sasl_conn = NULL;
     }
 
@@ -4128,7 +4129,7 @@ static void init_sasl_conn(conn *c)
     if (!c->sasl_conn) {
         int result=sasl_server_new("memcached",
                                    NULL, NULL, NULL, NULL,
-                                   NULL, 0, &c->sasl_conn);
+                                   NULL, 0, (sasl_conn_t**)&c->sasl_conn);
         if (result != SASL_OK) {
             if (settings.verbose) {
                 mc_logger->log(EXTENSION_LOG_INFO, c,

--- a/memcached.h
+++ b/memcached.h
@@ -32,7 +32,6 @@
 #include "topkeys.h"
 #include "mc_util.h"
 #include "engine_loader.h"
-#include "sasl_defs.h"
 
 /* This is the address we use for admin purposes.  For example, doing stats
  * and heart beats from arcus_zk.
@@ -274,7 +273,7 @@ typedef bool (*STATE_FUNC)(conn *);
 struct conn {
     int    sfd;
     short  nevents;
-    sasl_conn_t *sasl_conn;
+    void *sasl_conn;
     bool sasl_started;
     bool authenticated;
     STATE_FUNC   state;

--- a/sasl_defs.c
+++ b/sasl_defs.c
@@ -5,6 +5,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "sasl_defs.h"
+
 #ifdef HAVE_SASL_CB_GETCONF
 /* The locations we may search for a SASL config file if the user didn't
  * specify one in the environment variable SASL_CONF_PATH


### PR DESCRIPTION
### ⌨️ What I did
- `memcached.h`에서 `sasl_defs.h`를 include하는 대신, sasl API를 사용하는 각 소스 파일에서 include하도록 변경합니다.
