### PR TITLE
INTERNAL: Change tot_elem_cnt to include subtree element count in set

### DIFF
--- a/engines/default/item_base.h
+++ b/engines/default/item_base.h
@@ -236,8 +236,7 @@ typedef struct _set_hash_node {
     uint16_t refcount;
     uint8_t  slabs_clsid;         /* which slab class we're in */
     uint8_t  hdepth;
-    uint16_t tot_elem_cnt;
-    uint16_t tot_hash_cnt;
+    uint32_t tot_elem_cnt;
     int16_t  hcnt[SET_HASHTAB_SIZE];
     void    *htab[SET_HASHTAB_SIZE];
 } set_hash_node;


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/571


### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- Set에서 `tot_elem_cnt`를 해당 노드의 subtree에 포함된 모든 element의 총 개수로 변경
  - 기존에는 현재 노드의 element 개수만 의미했으나, subtree 전체를 포함하도록 수정하였습니다.

### 세부 구현 내용

- `tot_elem_cnt` 크기 확장
  - 기존 `uint16_t` 에서 `uint32_t`로 변경
  - Set의 최대 element 개수(1,000,000개)를 표현하기 위해서입니다.

- `tot_elem_cnt` 변수 관리
  
  - Element Insert (`do_set_elem_link()`)
    - Parent 노드들과 현재 노드의 `tot_elem_cnt`를 1 증가

  - Element Delete (`do_set_elem_traverse_dfs()`, `do_set_elem_traverse_delete()`)
    - DFS 탐색하면서 `tot_elem_cnt`를 1 감소

  - Chain -> Hash table 변경 (`do_set_node_link()`)
    - Parent 노드의 `tot_elem_cnt` 유지
    - Child 노드의 `tot_elem_cnt` = 기존 Chain element 개수 (num_found)

  - Hash table -> Chain (`do_set_node_unlink()`)
    - Parent 노드의 `tot_elem_cnt` 유지
    - Child 노드의 `tot_elem_cnt` = 0


### 추후 PR 내용
- offset 내부 구현 PR
- random 구현 PR (parsing, 내부)
