### PR TITLE
INTERNAL: Add max_stats_prefixes limit to stats prefix command

### DIFF
--- a/docs/ascii-protocol/ch12-command-administration.md
+++ b/docs/ascii-protocol/ch12-command-administration.md
@@ -362,6 +362,7 @@ STAT max_map_size 50000
 STAT max_btree_size 50000
 STAT max_element_bytes 16384
 STAT scrub_count 96
+STAT max_stats_prefixes 50
 STAT topkeys 0
 STAT logger syslog
 STAT ascii_extension scrub
@@ -399,6 +400,7 @@ END
 | max_map_size       | map collection의 최대 element 갯수                           |
 | max_btree_size     | btree collection의 최대 element 갯수                         |
 | max_element_bytes  | collection element 데이터의 최대 크기                        |
+| max_stats_prefixes | prefix stat 정보를 조회하는 명령이 가능한 prefix 최대 개수       |
 | topkeys            | 추적하고 있는 topkey 개수                                    |
 | logger             | 사용 중인 logger extension                                   |
 | ascii_extension    | 사용 중인 ASCII protocol extension                           |
@@ -514,6 +516,13 @@ space_shortage_level이 10 이상으로 올라가면, background에서 아이템
 
 모든 prefix들의 item 통계 정보의 결과 예는 아래와 같다.
 \<null\> prefix 통계는 prefix를 가지지 않는 items 통계이다.
+
+예외 사항으로 prefix들의 통계 정보를 조회할 때, 조회되는 개수가 설정된 "max_stats_prefixes" 값(기본값: 50)을 초과하면 조회가 불가능하다.
+필요한 경우, "stats prefixlist" 명령을 사용하여 특정 prefix의 정보를 선택적으로 조회하거나 "config max_stats_prefixes \<value\>" 명령어로 제한 개수 변경이 가능하다.
+
+| Response String | 설명 |
+| --------------- | ---- |
+| "DENIED too many prefixes" | 조회하려는 prefix 개수가 제한을 초과함 |
 
 ```
 PREFIX <null> itm 2 kitm 1 litm 1 sitm 0 mitm 0 bitm 0 tsz 144 ktsz 64 ltsz 80 stsz 0 mtsz 0 btsz 0 time 20121105152422
@@ -718,6 +727,7 @@ ARCUS Cache Server는 특정 configuration에 대해 동적으로 변경하거�
 - max_collection_size
 - max_element_bytes
 - scrub_count
+- max_stats_prefixes
 
 ### Config verbosity
 
@@ -808,6 +818,14 @@ ARCUS Cache Server에는 더 이상 유효하지 않은 아이템을 일괄 삭�
 
 ```
 config scrub_count [<scrub_count>]\r\n
+```
+
+### Config max_stats_prefixes
+
+ARCUS Cache Server에서 한번에 조회할 수 있는 prefix stat의 최대 개수를 변경/조회 한다.
+\<value\> 인자가 생략되면 현재 설정되어 있는 prefix stat의 최대 개수를 조회한다.
+```
+config max_stats_prefixes [<value>]\r\n
 ```
 
 ## Command Logging

--- a/engines/default/default_engine.c
+++ b/engines/default/default_engine.c
@@ -1217,6 +1217,18 @@ default_prefix_dump_stats(ENGINE_HANDLE* handle, const void* cookie,
     return stats;
 }
 
+static int
+default_prefix_count(ENGINE_HANDLE* handle, const void* cookie)
+{
+    struct default_engine* engine = get_handle(handle);
+    int prefix_cnt;
+
+    pthread_mutex_lock(&engine->cache_lock);
+    prefix_cnt = prefix_count();
+    pthread_mutex_unlock(&engine->cache_lock);
+    return prefix_cnt;
+}
+
 /*
  * Dump API
  */
@@ -2012,6 +2024,7 @@ create_instance(uint64_t interface, GET_SERVER_API get_server_api,
          .get_stats        = default_get_stats,
          .reset_stats      = default_reset_stats,
          .prefix_dump_stats = default_prefix_dump_stats,
+         .prefix_count     = default_prefix_count,
          /* Dump API */
          .cachedump        = default_cachedump,
          .dump             = default_dump,

--- a/engines/default/prefix.c
+++ b/engines/default/prefix.c
@@ -535,7 +535,11 @@ static uint32_t do_count_invalid_prefix(void)
 
 uint32_t prefix_count(void)
 {
-    return prefxp->total_prefix_items;
+    int prefix_cnt = prefxp->total_prefix_items;
+    if (null_pt->total_count_exclusive > 0) {
+        prefix_cnt += 1;
+    }
+    return prefix_cnt;
 }
 
 static int _prefix_stats_write_buffer(char *buffer, const size_t buflen,

--- a/include/memcached/engine.h
+++ b/include/memcached/engine.h
@@ -654,6 +654,11 @@ extern "C" {
             token_t *tokenes, const size_t ntokens, int *length);
 
         /**
+         * Get number of prefixes in engine
+         */
+        int (*prefix_count)(ENGINE_HANDLE* handle, const void* cookie);
+
+        /**
          * Set engine config.
          *
          * @param handle the engine handle

--- a/memcached.h
+++ b/memcached.h
@@ -244,6 +244,7 @@ struct settings {
     uint32_t max_btree_size;     /* Maximum elements in b+tree collection */
     uint32_t max_element_bytes;  /* Maximum element bytes of collections */
     uint32_t scrub_count;        /* count of scrubbing items at each try */
+    uint32_t max_stats_prefixes; /* Maximum prefixes to view stats */
     int topkeys;            /* Number of top keys to track */
     struct {
         EXTENSION_DAEMON_DESCRIPTOR *daemons;


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/625

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 서버 자체적으로 prefixes 수가 많은 경우, prefix 관련 stat 정보 제공 기능을 제한하기 위해 `max_stats_prefixes` 설정값을 추가했습니다.

### 주요 변경 사항
- `max_stats_prefixes` 설정값을 추가했습니다.
  - Default: 50, Min: 0, Max: UINT32_MAX

- 변경 방법:
  - 명령어: `config max_stats_prefixes [<value>]`
  - `help admin` 명령어를 통해서 확인할 수 있습니다.
  - 변경 로직은 `scrub_count` config 관련해서 참고했습니다.

- `stats prefixes` 명령어 제한 (Item)
  - 서버의 Prefix 수가 설정값보다 많은 경우, 로그를 남기고 동작을 차단합니다.
    - `Too many prefixes. Operation blocked.`
    
- `stats detail dump` 명령어 제한 (Operation)
  - operation 관련 stats를 출력할 때 엔진을 거치지 않기 떄문에 logger 대신 printf를 통해 에러 메시지를 출력하고 동작을 차단합니다.
    - `Too many prefixes. Operation blocked.`

- Test file 변경
  - flush-prefix.t에서 기존에 Prefix를 1000개 추가하던 로직을 50개로 변경해, 새 설정값에 맞춰 테스트가 작동하도록 수정했습니다.

- 서버 내의 Prefix 개수에는 NULL prefix도 포함해서 동작을 제한합니다.
- Telnet을 통해 stats 명령어 실행 시, prefix 제한에 걸릴 경우 적절한 반환값이 없어 현재는 `SERVER_ERROR no more memory`를 반환하고 있습니다.
```C
        stats = mc_engine.v1->prefix_dump_stats(mc_engine.v0, c, NULL, 0, &len);
        if (stats == NULL) {
            if (len == -1)
                out_string(c, "NOT_SUPPORTED");
            else
                out_string(c, "SERVER_ERROR no more memory");
            return;
        }
```

### Stats 실험 결과
max_stats_prefixes 값을 5로 변경해서 stats 제한을 실험합니다.
```
config max_stats_prefixes
max_stats_prefixes 50
END

config max_stats_prefixes 5
END

config max_stats_prefixes
max_stats_prefixes 5
END

stats prefixes
PREFIX <null> itm 1 kitm 1 litm 0 sitm 0 mitm 0 bitm 0 tsz 88 ktsz 88 ltsz 0 stsz 0 mtsz 0 btsz 0 time 20250115132212
PREFIX pre3 itm 1 kitm 1 litm 0 sitm 0 mitm 0 bitm 0 tsz 88 ktsz 88 ltsz 0 stsz 0 mtsz 0 btsz 0 time 20250115132155
PREFIX pre2 itm 1 kitm 1 litm 0 sitm 0 mitm 0 bitm 0 tsz 88 ktsz 88 ltsz 0 stsz 0 mtsz 0 btsz 0 time 20250115131920
PREFIX pre4 itm 1 kitm 1 litm 0 sitm 0 mitm 0 bitm 0 tsz 88 ktsz 88 ltsz 0 stsz 0 mtsz 0 btsz 0 time 20250115132201
PREFIX pre1 itm 1 kitm 1 litm 0 sitm 0 mitm 0 bitm 0 tsz 88 ktsz 88 ltsz 0 stsz 0 mtsz 0 btsz 0 time 20250115131912
END

stats detail dump
PREFIX pre3 get 0 hit 0 set 1 del 0 inc 0 dec 0 lcs 0 lis 0 lih 0 lds 0 ldh 0 lgs 0 lgh 0 ...
PREFIX pre2 get 0 hit 0 set 1 del 0 inc 0 dec 0 lcs 0 lis 0 lih 0 lds 0 ldh 0 lgs 0 lgh 0 ...
PREFIX <null> get 0 hit 0 set 1 del 0 inc 0 dec 0 lcs 0 lis 0 lih 0 lds 0 ldh 0 lgs 0 lgh 0 ...
PREFIX pre4 get 0 hit 0 set 1 del 0 inc 0 dec 0 lcs 0 lis 0 lih 0 lds 0 ldh 0 lgs 0 lgh 0 ...
PREFIX pre1 get 0 hit 0 set 1 del 0 inc 0 dec 0 lcs 0 lis 0 lih 0 lds 0 ldh 0 lgs 0 lgh 0 ...
END

set pre5:key5 0 0 1
a
STORED

stats prefixes
DENIED too many prefixes

stats detail dump
DENIED too many prefixes

```