### PR TITLE
INTERNAL: Make the -S option available with ascii protocol

### DIFF
--- a/t/binary-sasl.t.in
+++ b/t/binary-sasl.t.in
@@ -31,7 +31,7 @@ if (supports_sasl()) {
          plan skip_all => "The binary 'saslpasswd' is missing from your system";
     }
     else {
-       plan tests => 33;
+       plan tests => 30;
     }
 } else {
     plan tests => 1;
@@ -41,21 +41,6 @@ if (supports_sasl()) {
     ok($@, "Died with illegal -S args when SASL is not supported.");
     exit 0;
 }
-
-eval {
-    my $server = get_memcached($engine, "-S -B auto");
-};
-ok($@, "SASL shouldn't be used with protocol auto negotiate");
-
-eval {
-    my $server = get_memcached($engine, "-S -B ascii");
-};
-ok($@, "SASL isn't implemented in the ascii protocol");
-
-eval {
-    my $server = get_memcached($engine, "-S -B binary -B ascii");
-};
-ok($@, "SASL isn't implemented in the ascii protocol");
 
 # Based almost 100% off testClient.py which is:
 # Copyright (c) 2007  Dustin Sallings <dustin@spy.net>


### PR DESCRIPTION
### 🔗 Related Issue
- jam2in/arcus-works#634

### ⌨️ What I did

`-S` option을 ascii protocol과 함께 사용할 수 있도록 확장합니다.
ascii protocol에서 SASL 인증 수행할 방법이 없는 상태이므로,
`-S` 옵션 사용 시 ascii conn에서는 허용된 명령만 사용할 수 있습니다.

1. 기존에는 `-S` option을 설정하면 binary protocol으로 고정되고,
`-B` option에서 `auto`나 `ascii`를 명시한 상태에서 `-S` 함께 지정하면 구동 실패합니다.

2. 변경 후에는 `-S` option을 설정하더라도 ascii protocol을 사용할 수 있습니다.

3. `-S` option을 설정하여 구동한 경우에 ascii protocol 사용하는 연결은
허용되지 않은 명령에 대해 `CLIENT_ERROR unauthenticated` 응답합니다.
