### PR TITLE
DOC: Use a list instead of line breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,12 +122,12 @@ https://github.com/naver/arcus-memcached/issues
 In addition to those who had contributed to the original memcached,
 the following people at NAVER have contributed to arcus-memcached.
 
-JunHyun Park <junhyun.park@navercorp.com>; <jhpark816@gmail.com>  
-HyongYoub Kim <hyongyoub.kim@navercorp.com>  
-YeaSol Kim (ngleader) <sol.k@navercorp.com>; <ngleader@gmail.com>  
-HoonMin Kim (harebox) <hoonmin.kim@navercorp.com>; <harebox@gmail.com>  
-SeongHwan Jeong (scryner) <scryner@nhnent.com>  
-Chang Song <chang.song@navercorp.com>  
+- JunHyun Park <junhyun.park@navercorp.com>; <jhpark816@gmail.com>
+- HyongYoub Kim <hyongyoub.kim@navercorp.com>
+- YeaSol Kim (ngleader) <sol.k@navercorp.com>; <ngleader@gmail.com>
+- HoonMin Kim (harebox) <hoonmin.kim@navercorp.com>; <harebox@gmail.com>
+- SeongHwan Jeong (scryner) <scryner@nhnent.com>
+- Chang Song <chang.song@navercorp.com>
 
 ## License
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- naver/arcus-c-client#343

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 줄바꿈 대신에 Markdown의 리스트를 활용합니다.
