### PR TITLE
INTERNAL: Change get to random get in set using hash table

### DIFF
--- a/engines/default/default_engine.c
+++ b/engines/default/default_engine.c
@@ -255,6 +255,8 @@ default_initialize(ENGINE_HANDLE* handle, const char* config_str)
     struct default_engine* se = get_handle(handle);
     logger = se->server.log->get_logger();
 
+    srand(time(NULL));
+
     ENGINE_ERROR_CODE ret = initialize_configuration(se, config_str);
     if (ret != ENGINE_SUCCESS) {
         return ret;


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/571

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- Hash table을 이용해서 Set에서 get 동작을 random get으로 변경했습니다.
 1. 해시 테이블 관리
    - coll_set.h
      - hash table 구조체 정의
    - coll_set.c 
      - init, insert, free, next_prime 함수 구현
 2. `do_set_elem_traverse_dfs` 함수 수정
    - 랜덤 offset에 위치한 element를 가져오기 위해 offset을 이용한 탐색 기능
 3. `do_set_elem_get` 함수 수정
    - 케이스 분류
      - 전체 요소 가져오는 경우
      - 가져오면서 삭제 진행하는 경우 (`get count delete`)
      - hash table을 이용하는 경우
 4. default_engine.c 수정
    - srand() 추가

## 세부 구현

### 1. Hash table 구조
- 크기: `count` * 1.3 이상의 소수
- 버킷: 한 버킷에 최대 3개 key insert 가능
- 해당 버킷이 가득 찼을 때 Insert 하면 다시 랜덤 offset 선택
- Key: rand_offset
- Index: rand_offset % (크기)
![hashtable](https://github.com/user-attachments/assets/4de242b5-35e1-44e9-8000-f492d97232f8)


### 2. Offset을 이용한 탐색 (`do_set_elem_traverse_dfs`)
- 기존 함수에서 offset 파라미터를 추가해서 지정된 offset 전까지의 요소들을 건너뜁니다.
- node 단위에서도 건너뛰고 element chain 단위로도 건너뜁니다.
  - node 단위
    - offset이 마지막 element index 보다 크면 continue, 그렇지 않으면 해당 node 탐색
  - element chain 단위
    - offset이 마지막 element index 보다 크면 continue, 그렇지 않으면 해당 element chain 탐색
![random](https://github.com/user-attachments/assets/f1792c66-5f59-4149-b89e-0af2ee486c13)


### 3. 케이스 분류 (`do_set_elem_get`)
#### 1. 전체 element 반환 (count >= ccnt || count == 0) 
  - DFS를 통해 전체 element를 순회하며 반환합니다. 
  - delete 인자가 같이 주어지면 전체를 반환하고 삭제합니다.

#### 2. 부분 삭제 (get delete)
  - 랜덤하게 offset을 선택하고, 해당 offset에 위치한 element를 DFS 탐색으로 찾아 삭제합니다.
  - count 번 반복합니다.

 #### 3. 랜덤 선택 방법 - 해시 테이블을 이용한 중복 체크
  - 랜덤하게 index(offset)를 생성합니다.
  - 이미 선택한 index인지 확인하기 위해 해시 테이블에서 확인합니다.
  - 중복되지 않은 index에 대해 DFS 탐색으로 해당 element를 찾아 반환합니다. 
  - count 번 반복합니다.


