### PR TITLE
CLEANUP: Remove do_set_elem_delete_fast() functions

### DIFF
--- a/engines/demo/dm_items.c
+++ b/engines/demo/dm_items.c
@@ -28,7 +28,6 @@
 
 #include "demo_engine.h"
 
-//#define SET_DELETE_NO_MERGE
 //#define BTREE_DELETE_NO_MERGE
 
 /* item unlink cause */


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/682

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- `do_set_elem_delete_fast()` 함수와  `do_set_elem_traverse_fast()` 함수를 삭제했습니다.
  - Set 구현에서 SET_DELETE_NO_MERGE 관련 최적화를 통한 성능 향상 결과가 미미하기 때문입니다.
