### PR TITLE
INTERNAL: Limit the count of elems get from set structure

### DIFF
--- a/docs/ascii-protocol/ch06-command-set-collection.md
+++ b/docs/ascii-protocol/ch06-command-set-collection.md
@@ -113,6 +113,10 @@ sop get <key> <count> [delete|drop]\r\n
 - delete or drop - element 조회하면서 그 element를 delete할 것인지,
 그리고 delete로 인해 empty set이 될 경우 그 set을 drop할 것인지를 지정한다.
 
+sop get 명령은 다음과 같은 특징을 갖는다.
+- count 값은 0 또는 양수이며, 양수인 경우 elements를 랜덤하게 조회한다.
+- long request를 방지하기 위해 count의 최대값은 1000으로 제한한다.
+
 성공 시의 response string은 아래와 같다.
 VALUE 라인의 \<count\>는 조회된 element 개수를 의미한다.
 마지막 라인은 END, DELETED, DELETED_DROPPED 중의 하나를 가지며
@@ -137,6 +141,7 @@ END|DELETED|DELETED_DROPPED\r\n
 | "TYPE_MISMATCH"                                      | 해당 item이 set collection이 아님
 | "UNREADABLE"                                         | 해당 item이 unreadable item임
 | "NOT_SUPPORTED"                                      | 지원하지 않음
+| "DENIED too many count"                              | count 제약 개수를 초과함
 | "CLIENT_ERROR bad command line format"               | protocol syntax 틀림
 | "SERVER_ERROR out of memory [writing get response]"  | 메모리 부족
 

--- a/memcached.c
+++ b/memcached.c
@@ -10950,6 +10950,10 @@ static void process_sop_command(conn *c, token_t *tokens, const size_t ntokens)
             out_string(c, "CLIENT_ERROR bad command line format");
             return;
         }
+        if (count > MAX_SOP_GET_COUNT) {
+            out_string(c, "DENIED too many count");
+            return;
+        }
         if (ntokens == 6) {
             if (strcmp(tokens[SOP_KEY_TOKEN+2].value, "delete")==0) {
                 delete = true;

--- a/memcached.h
+++ b/memcached.h
@@ -84,6 +84,7 @@
 #define BIN_PKT_HDR_WORDS (MIN_BIN_PKT_LENGTH/sizeof(uint32_t))
 
 #define MAX_MGET_KEY_COUNT 10000
+#define MAX_SOP_GET_COUNT 1000
 
 #ifdef SUPPORT_BOP_MGET
 /* In bop mget, max limit on the number of given keys */

--- a/t/coll_sop_unittest.t
+++ b/t/coll_sop_unittest.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 use strict;
-use Test::More tests => 83007;
+use Test::More tests => 83005;
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
@@ -76,7 +76,6 @@ $rst = "ATTR count=2849
 ATTR maxcount=$default_set_size
 END";
 mem_cmd_is($sock, $cmd, "", $rst);
-assert_sop_get("skey 2849", $flags, 2849, 0, 2848);
 assert_sop_get("skey 0",    $flags, 2849, 0, 2848);
 $cmd = "sop exist skey 6"; $val="datum6"; $rst = "EXIST";
 mem_cmd_is($sock, $cmd, $val, $rst);
@@ -102,7 +101,7 @@ $rst = "ATTR count=10
 ATTR maxcount=$maximum_set_size
 END";
 mem_cmd_is($sock, $cmd, "", $rst);
-sop_get_is($sock, "skey 10", $flags, 10,
+sop_get_is($sock, "skey 0", $flags, 10,
            "datum0,datum1,datum2,datum3,datum4,datum5,datum6,datum7,datum8,datum9");
 $cmd = "sop delete skey 6"; $val="datum1"; $rst = "DELETED";
 mem_cmd_is($sock, $cmd, $val, $rst);
@@ -118,7 +117,7 @@ $cmd = "sop delete skey 6"; $val="datum3"; $rst = "NOT_FOUND_ELEMENT";
 mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "sop delete skey 7"; $val="datum10"; $rst = "NOT_FOUND_ELEMENT";
 mem_cmd_is($sock, $cmd, $val, $rst);
-sop_get_is($sock, "skey 10 delete", $flags, 5,
+sop_get_is($sock, "skey 0 delete", $flags, 5,
            "datum0,datum2,datum4,datum6,datum8");
 $cmd = "sop insert skey 6"; $val="datum3"; $rst = "STORED";
 mem_cmd_is($sock, $cmd, $val, $rst);
@@ -134,8 +133,7 @@ $rst = "ATTR count=50000
 ATTR maxcount=$maximum_set_size
 END";
 mem_cmd_is($sock, $cmd, "", $rst);
-assert_sop_get("skey 50000", $flags, 50000, 0, 49999);
-assert_sop_get("skey 0",     $flags, 50000, 0, 49999);
+assert_sop_get("skey 0", $flags, 50000, 0, 49999);
 $cmd = "sop delete skey 6"; $val="datum4"; $rst = "DELETED";
 mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "sop delete skey 7"; $val="datum44"; $rst = "DELETED";
@@ -182,7 +180,7 @@ mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "sop exist skey 10"; $val="datum26666"; $rst = "EXIST";
 mem_cmd_is($sock, $cmd, $val, $rst);
 sop_delete("skey", 40000, 49999);
-assert_sop_get("skey 20000 drop", $flags, 20000, 10000, 29999);
+assert_sop_get("skey 0 drop", $flags, 20000, 10000, 29999);
 $cmd = "get skey"; $rst = "END";
 mem_cmd_is($sock, $cmd, "", $rst);
 
@@ -278,7 +276,7 @@ $cmd = "sop insert skey 6"; $val = "datum4"; $rst = "STORED";
 mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "sop insert skey 6"; $val = "datum5"; $rst = "STORED";
 mem_cmd_is($sock, $cmd, $val, $rst);
-sop_get_is($sock, "skey 5", $flags, 5,
+sop_get_is($sock, "skey 0", $flags, 5,
            "datum1,datum2,datum3,datum4,datum5");
 $cmd = "sop insert skey 6"; $val = "datum6"; $rst = "OVERFLOWED";
 mem_cmd_is($sock, $cmd, $val, $rst);
@@ -388,7 +386,7 @@ $cmd = "sop insert skey 6"; $val = "datum3"; $rst = "STORED";
 mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "setattr skey expiretime=2"; $rst = "OK";
 mem_cmd_is($sock, $cmd, "", $rst);
-sop_get_is($sock, "skey 5",  $flags, 3, "datum1,datum2,datum3");
+sop_get_is($sock, "skey 0",  $flags, 3, "datum1,datum2,datum3");
 sleep(2.1);
 $cmd = "sop get skey 5"; $rst = "NOT_FOUND";
 mem_cmd_is($sock, $cmd, "", $rst);
@@ -404,7 +402,7 @@ $cmd = "sop insert skey 6"; $val = "datum2"; $rst = "STORED";
 mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "sop insert skey 6"; $val = "datum3"; $rst = "STORED";
 mem_cmd_is($sock, $cmd, $val, $rst);
-sop_get_is($sock, "skey 5",  $flags, 3, "datum1,datum2,datum3");
+sop_get_is($sock, "skey 0",  $flags, 3, "datum1,datum2,datum3");
 $cmd = "flush_all"; $rst = "OK";
 mem_cmd_is($sock, $cmd, "", $rst);
 $cmd = "sop get skey 5"; $rst = "NOT_FOUND";


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- jam2in/arcus-works#571

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
`sop get` 연산에서 일부 element 조회 시 가능한 개수를 1000개로 제한합니다.

처음에는 core(memcached.c)에서 1000개 이하로 조회 개수를 제한하고 에러 메시지를 반환했으나,
이 경우, count가 1000을 초과하는 set에 대해 *전체 조회*가 불가능했습니다.
그래서 현재 PR은 count 정보를 가진 엔진에서 제한을 적용하고 있습니다.
