### PR TITLE
INTERNAL: Preprocess nested prefix variables

### DIFF
--- a/engines/default/prefix.c
+++ b/engines/default/prefix.c
@@ -546,10 +546,11 @@ static int _prefix_stats_write_buffer(char *buffer, const size_t buflen,
                                        const char *format, prefix_t *pt,
                                        const bool inclusive) {
 
-    int ret;
+    int ret = 0;
     struct tm *t;
     t = localtime(&pt->create_time);
     if (inclusive) {
+#ifdef NESTED_PREFIX
         ret = snprintf(buffer, buflen, format,
             pt == null_pt ? "<null>" : _get_prefix(pt),
             pt->total_count_inclusive,
@@ -571,6 +572,7 @@ static int _prefix_stats_write_buffer(char *buffer, const size_t buflen,
             */
             t->tm_year+1900, t->tm_mon+1, t->tm_mday,
             t->tm_hour, t->tm_min, t->tm_sec);
+#endif
     } else {
         ret = snprintf(buffer, buflen, format,
             pt == null_pt ? "<null>" : _get_prefix(pt),


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- jam2in/arcus-works#704

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- NESTED_PREFIX 전처리기에 의해 제외되는 변수임에도 제외되지 못한 부분을 수정합니다.
- `int ret = 0;` 처리는 unused variable 때문입니다.
- 현재 arcus-memcached 버전에서 NESTED_PREFIX를 제외하고 컴파일할 경우 아래의 에러가 발생합니다.
```js
engines/default/prefix.c:556:17: error: no member named 'items_count_inclusive' in 'struct _prefix_t'; did you mean 'items_count_exclusive'?
            pt->items_count_inclusive[ITEM_TYPE_KV],
                ^~~~~~~~~~~~~~~~~~~~~
                items_count_exclusive
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/secure/_stdio.h:57:62: note: expanded from macro 'snprintf'
  __builtin___snprintf_chk (str, len, 0, __darwin_obsz(str), __VA_ARGS__)
```
