### PR TITLE
Fix typo

### DIFF
--- a/docs/ascii-protocol/ch08-command-btree-collection.md
+++ b/docs/ascii-protocol/ch08-command-btree-collection.md
@@ -482,7 +482,7 @@ smget 수행의 실패 시의 response string은 다음과 같다.
 | "CLIENT_ERROR bad command line format"               | protocol syntax 틀림
 | "CLIENT_ERROR bad data chunk"                        | 주어진 key 리스트에 중복 key가 존재하거나 주어진 key 리스트의 길이가 \<lenkeys\> 길이와 다르거나 "\r\n"으로 끝나지 않음.
 | "CLIENT_ERROR bad value"                             | 앞서 기술한 smget 연산의 제약 조건을 위배
-| "SERVER_ERROR out of memory [writing get response"   | 메모리 부족
+| "SERVER_ERROR out of memory [writing get response]"  | 메모리 부족
 
 
 ## bop position

--- a/docs/ascii-protocol/ch12-command-administration.md
+++ b/docs/ascii-protocol/ch12-command-administration.md
@@ -395,10 +395,10 @@ END
 | auth_sasl_engine   | sasl 인증에 사용할 엔진                                      |
 | auth_required_sasl | sasl 인증 필수 여부                                          |
 | item_size_max      | 아이템의 최대 사이즈                                         |
-| max_list_size      | list collection의 최대 element 갯수                          |
-| max_set_size       | set collection의 최대 element 갯수                           |
-| max_map_size       | map collection의 최대 element 갯수                           |
-| max_btree_size     | btree collection의 최대 element 갯수                         |
+| max_list_size      | list collection의 최대 element 개수                          |
+| max_set_size       | set collection의 최대 element 개수                           |
+| max_map_size       | map collection의 최대 element 개수                           |
+| max_btree_size     | btree collection의 최대 element 개수                         |
 | max_element_bytes  | collection element 데이터의 최대 크기                        |
 | max_stats_prefixes | prefix stat 정보를 조회하는 명령이 가능한 prefix 최대 개수       |
 | topkeys            | 추적하고 있는 topkey 개수                                    |
@@ -1065,7 +1065,7 @@ shutdown [<seconds>]\r\n
 
 Response string과 그 의미는 아래와 같다.
 
-| Resposne String | 설명 |
+| Response String | 설명 |
 | - | - |
 | "OK" | 성공 |
 | "DENIED" | 거부됨 |

--- a/engines/default/coll_btree.c
+++ b/engines/default/coll_btree.c
@@ -2003,7 +2003,7 @@ static uint32_t do_btree_elem_delete(btree_meta_info *info,
             if (info->stotal > 0) { /* apply memory space */
                 /* The btree might have been unlinked from hash table.
                  * If then, the btree doesn't have prefix info and has stotal of 0.
-                 * So, do not need to descrese space total info.
+                 * So, do not need to decrease space total info.
                  */
                 assert(tot_space <= info->stotal);
                 do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_BTREE, tot_space);

--- a/engines/default/prefix.h
+++ b/engines/default/prefix.h
@@ -80,7 +80,7 @@ void              prefix_bytes_incr(prefix_t *pt, ENGINE_ITEM_TYPE item_type, co
 void              prefix_bytes_decr(prefix_t *pt, ENGINE_ITEM_TYPE item_type, const uint32_t bytes);
 bool              prefix_isvalid(hash_item *it, rel_time_t current_time);
 uint32_t          prefix_count(void);
-char *            prefix_dump_stats(token_t *tokenes, const size_t ntokens, int *length);
+char *            prefix_dump_stats(token_t *tokens, const size_t ntokens, int *length);
 #ifdef SCAN_COMMAND
 int               prefix_scan_direct(const char *cursor, int req_count,
                                      void **item_array, int item_arrsz);

--- a/include/memcached/engine.h
+++ b/include/memcached/engine.h
@@ -651,7 +651,7 @@ extern "C" {
          * Statistical information for each prefix
          */
         char *(*prefix_dump_stats)(ENGINE_HANDLE* handle, const void* cookie,
-            token_t *tokenes, const size_t ntokens, int *length);
+            token_t *tokens, const size_t ntokens, int *length);
 
         /**
          * Get number of prefixes in engine

--- a/memcached.c
+++ b/memcached.c
@@ -15636,7 +15636,7 @@ int main (int argc, char **argv)
 
     if (settings.maxconns <= nfiles) {
         mc_logger->log(EXTENSION_LOG_WARNING, NULL,
-                "Configuratioin error. \n"
+                "Configuration error. \n"
                 "You specified %d connections, but the system will use at "
                 "least %d\nconnection structures to start.\n",
                 settings.maxconns, nfiles);


### PR DESCRIPTION
### ⌨️ What I did

> @jeesup0103
> ### 오탈자
> - engine.h
>   - tokenes -> tokens
> - memcached.c
>   - Configuratioin -> Configuration
> - coll_btree.c
>   - descrese -> decrease
> - ch08-command-btree-collection.md
>   - `[` 없애기
> - ch12-command-administration.md
>   - 갯수 -> 개수
>   - Resposne -> Response

- 오탈자를 수정합니다.
  - 코드 상의 오탈자와 문서 오탈자 두 개 commit으로 분리했습니다.