### PR TITLE
INTERNAL: Add a swallow handler for mop

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -12136,28 +12136,20 @@ static void process_mop_command(conn *c, token_t *tokens, const size_t ntokens)
         set_pipe_noreply_maybe(c, tokens, ntokens);
 
         if ((! safe_strtoul(tokens[MOP_KEY_TOKEN+1].value, &lenfields)) ||
-            (! safe_strtoul(tokens[MOP_KEY_TOKEN+2].value, &numfields))) {
+            (! safe_strtoul(tokens[MOP_KEY_TOKEN+2].value, &numfields)) ||
+            (lenfields > (UINT_MAX-2)) || (lenfields == 0 && numfields > 0) ||
+            (lenfields > 0 && numfields == 0)) {
             print_invalid_command(c, tokens, ntokens);
             out_string(c, "CLIENT_ERROR bad command line format");
             return;
         }
-        if (lenfields > 0) {
-            if (numfields == 0 ||
-                lenfields > (UINT_MAX-2) ||
-                lenfields > ((numfields*MAX_FIELD_LENG) + numfields-1)) {
-                print_invalid_command(c, tokens, ntokens);
-                out_string(c, "CLIENT_ERROR bad value");
-                return;
-            }
-        }
-        if (numfields > 0) {
-            if (lenfields == 0 ||
-                numfields > settings.max_map_size ||
-                numfields > ((lenfields/2) + 1)) {
-                print_invalid_command(c, tokens, ntokens);
-                out_string(c, "CLIENT_ERROR bad value");
-                return;
-            }
+        if (lenfields > ((numfields*MAX_FIELD_LENG) + numfields-1) ||
+            numfields > settings.max_map_size ||
+            numfields > ((lenfields/2) + 1)) {
+            out_string(c, "CLIENT_ERROR bad value");
+            c->sbytes = lenfields + 2;
+            c->write_and_go = conn_swallow;
+            return;
         }
 
         int read_ntokens = MOP_KEY_TOKEN + 3;
@@ -12202,28 +12194,20 @@ static void process_mop_command(conn *c, token_t *tokens, const size_t ntokens)
         bool drop_if_empty = false;
 
         if ((! safe_strtoul(tokens[MOP_KEY_TOKEN+1].value, &lenfields)) ||
-            (! safe_strtoul(tokens[MOP_KEY_TOKEN+2].value, &numfields))) {
+            (! safe_strtoul(tokens[MOP_KEY_TOKEN+2].value, &numfields)) ||
+            (lenfields > (UINT_MAX-2)) || (lenfields == 0 && numfields > 0) ||
+            (lenfields > 0 && numfields == 0)) {
             print_invalid_command(c, tokens, ntokens);
             out_string(c, "CLIENT_ERROR bad command line format");
             return;
         }
-        if (lenfields > 0) {
-            if (numfields == 0 ||
-                lenfields > (UINT_MAX-2) ||
-                lenfields > ((numfields*MAX_FIELD_LENG) + numfields-1)) {
-                print_invalid_command(c, tokens, ntokens);
-                out_string(c, "CLIENT_ERROR bad value");
-                return;
-            }
-        }
-        if (numfields > 0) {
-            if (lenfields == 0 ||
-                numfields > settings.max_map_size ||
-                numfields > ((lenfields/2) + 1)) {
-                print_invalid_command(c, tokens, ntokens);
-                out_string(c, "CLIENT_ERROR bad value");
-                return;
-            }
+        if (lenfields > ((numfields*MAX_FIELD_LENG) + numfields-1) ||
+            numfields > settings.max_map_size ||
+            numfields > ((lenfields/2) + 1)) {
+            out_string(c, "CLIENT_ERROR bad value");
+            c->sbytes = lenfields + 2;
+            c->write_and_go = conn_swallow;
+            return;
         }
 
         if (ntokens == 7) {


### PR DESCRIPTION
### 🔗 Related Issue
- jam2in/arcus-works#710

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- mop 명령어 중 swallow 처리가 필요한 명령어에 swallow 핸들링을 추가했습니다.
  - mop get
  - mop delete
- mget, bop mget, bop smget 등에는 이미 swallow 로직이 적용되어 있었으나, mop 명령어에는 빠져 있어 이를 보완했습니다.
