### PR TITLE
CLEANUP: Revert `DENIED` to `CLIENT_ERROR`

### DIFF
--- a/docs/ascii-protocol/ch06-command-set-collection.md
+++ b/docs/ascii-protocol/ch06-command-set-collection.md
@@ -141,7 +141,7 @@ END|DELETED|DELETED_DROPPED\r\n
 | "TYPE_MISMATCH"                                      | 해당 item이 set collection이 아님
 | "UNREADABLE"                                         | 해당 item이 unreadable item임
 | "NOT_SUPPORTED"                                      | 지원하지 않음
-| "DENIED too many count"                              | count 제약 개수를 초과함
+| "CLIENT_ERROR invalid: too many count"               | count 제약 개수를 초과함
 | "CLIENT_ERROR bad command line format"               | protocol syntax 틀림
 | "SERVER_ERROR out of memory [writing get response]"  | 메모리 부족
 

--- a/docs/ascii-protocol/ch12-command-administration.md
+++ b/docs/ascii-protocol/ch12-command-administration.md
@@ -522,7 +522,7 @@ space_shortage_level이 10 이상으로 올라가면, background에서 아이템
 
 | Response String | 설명 |
 | --------------- | ---- |
-| "DENIED too many prefixes" | 조회하려는 prefix 개수가 제한을 초과함 |
+| "CLIENT_ERROR invalid: too many prefixes" | 조회하려는 prefix 개수가 제한을 초과함 |
 
 ```
 PREFIX <null> itm 2 kitm 1 litm 1 sitm 0 mitm 0 bitm 0 tsz 144 ktsz 64 ltsz 80 stsz 0 mtsz 0 btsz 0 time 20121105152422

--- a/memcached.c
+++ b/memcached.c
@@ -7877,7 +7877,7 @@ inline static void process_stats_detail(conn *c, const char *command)
         }
         else if (strcmp(command, "dump") == 0) {
             if (stats_prefix_count() > settings.max_stats_prefixes) {
-                out_string(c, "DENIED too many prefixes");
+                out_string(c, "CLIENT_ERROR invalid: too many prefixes");
                 return;
             }
             int len;
@@ -8286,7 +8286,7 @@ static void process_stats_command(conn *c, token_t *tokens, const size_t ntokens
             return;
         }
         if (mc_engine.v1->prefix_count(mc_engine.v0, c) > settings.max_stats_prefixes) {
-            out_string(c, "DENIED too many prefixes");
+            out_string(c, "CLIENT_ERROR invalid: too many prefixes");
             return;
         }
         stats = mc_engine.v1->prefix_dump_stats(mc_engine.v0, c, NULL, 0, &len);
@@ -8312,14 +8312,14 @@ static void process_stats_command(conn *c, token_t *tokens, const size_t ntokens
             if ((prefixes == NULL &&
                 mc_engine.v1->prefix_count(mc_engine.v0, c) > settings.max_stats_prefixes) ||
                 nprefixes > settings.max_stats_prefixes) {
-                out_string(c, "DENIED too many prefixes");
+                out_string(c, "CLIENT_ERROR invalid: too many prefixes");
                 return;
             }
             stats = mc_engine.v1->prefix_dump_stats(mc_engine.v0, c, prefixes, nprefixes, &len);
         } else if (strcmp(tokens[2].value, "operation") == 0) {
             if ((prefixes == NULL && stats_prefix_count() > settings.max_stats_prefixes) ||
                 nprefixes > settings.max_stats_prefixes) {
-                out_string(c, "DENIED too many prefixes");
+                out_string(c, "CLIENT_ERROR invalid: too many prefixes");
                 return;
             }
             stats = stats_prefix_dump(prefixes, nprefixes, &len);
@@ -10951,7 +10951,7 @@ static void process_sop_command(conn *c, token_t *tokens, const size_t ntokens)
             return;
         }
         if (count > MAX_SOP_GET_COUNT) {
-            out_string(c, "DENIED too many count");
+            out_string(c, "CLIENT_ERROR invalid: too many count");
             return;
         }
         if (ntokens == 6) {

--- a/t/flush-prefix.t
+++ b/t/flush-prefix.t
@@ -23,7 +23,7 @@ sub prefix_limit_test {
     mem_cmd_is($sock, $cmd, $val, $rst);
   }
 
-  $cmd = "stats detail dump"; $rst = "DENIED too many prefixes";
+  $cmd = "stats detail dump"; $rst = "CLIENT_ERROR invalid: too many prefixes";
   mem_cmd_is($sock, $cmd, "", $rst);
 
   for ($size = 0; $size < $big_prefix_size; $size++) {


### PR DESCRIPTION
### 🔗 Related Issue

- #710 

### ⌨️ What I did

- 클라이언트가 인식하지 못하는 `DENIED` 응답을 `CLIENT_ERROR` 응답으로 변경합니다.
- 이후 `INVALID` 응답으로 변경할 때 구분하기 쉽도록, message에 `invalid:` prefix를 임시로 추가해두었습니다.
