### PR TITLE
FEATURE: Add `ARCUS_CACHE_HOSTNAME_OVERWRITE` environment variable

### DIFF
--- a/arcus_zk.c
+++ b/arcus_zk.c
@@ -801,22 +801,24 @@ static int arcus_build_znode_name(char *ensemble_list)
 #endif
 
     if (!arcus_conf.znode_name) {
-        char *hostp=NULL;
+        char *hostp=getenv("ARCUS_CACHE_HOSTNAME_OVERWRITE");
         char  hostbuf[256];
-        // Also get local hostname.
-        // We want IP and hostname to better identify this cache
-        hp = gethostbyaddr((char*)&myaddr.sin_addr.s_addr,
-                            sizeof(myaddr.sin_addr.s_addr), AF_INET);
-        if (hp) {
-            hostp = hp->h_name;
-        } else {
-            // if gethostbyaddr() doesn't work, try gethostname
-            if (gethostname((char *)&hostbuf, sizeof(hostbuf))) {
-                arcus_conf.logger->log(EXTENSION_LOG_WARNING, NULL,
-                        "cannot get hostname: %s\n", strerror(errno));
-                return EX_NOHOST;
+        if (!hostp) {
+            // Also get local hostname.
+            // We want IP and hostname to better identify this cache
+            hp = gethostbyaddr((char*)&myaddr.sin_addr.s_addr,
+                                sizeof(myaddr.sin_addr.s_addr), AF_INET);
+            if (hp) {
+                hostp = hp->h_name;
+            } else {
+                // if gethostbyaddr() doesn't work, try gethostname
+                if (gethostname((char *)&hostbuf, sizeof(hostbuf))) {
+                    arcus_conf.logger->log(EXTENSION_LOG_WARNING, NULL,
+                            "cannot get hostname: %s\n", strerror(errno));
+                    return EX_NOHOST;
+                }
+                hostp = hostbuf;
             }
-            hostp = hostbuf;
         }
         if (strlen(hostp) > MAX_HOSTNAME_LENGTH) {
             arcus_conf.logger->log(EXTENSION_LOG_WARNING, NULL,


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-operator/issues/137

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 캐시 서버가 자신의 hostname으로 반드시 사용하는 환경변수를 추가합니다.
- 환경변수의 값이 없으면 기존의 로직대로 hostname을 가져옵니다.
