### PR TITLE
FEATURE: Add sasl auth command

### DIFF
--- a/memcached.h
+++ b/memcached.h
@@ -280,7 +280,7 @@ struct conn {
     bool sasl_started;
     bool authenticated;
     char sasl_mech[MAX_SASL_MECH_LEN+1];
-    int sasl_auth_data_len;
+    uint32_t sasl_auth_data_len;
     char *sasl_auth_data;
     STATE_FUNC   state;
     enum bin_substates substate;


### PR DESCRIPTION
### 🔗 Related Issue

- jam2in/arcus-works#634

### ⌨️ What I did

- 인증 과정을 수행하는 `sasl auth` 명령을 추가합니다.

명령/응답 예시는 아래와 같습니다.
```
sasl auth SCRAM-SHA-256 70\r\n
n,a=testUser@arcus,n=testUser@arcus,r=KDGgMvgWKAesWV+XW1y+qzRAA7bxd2Ys\r\n

SASL_CONTINUE 100\r\n
r=KDGgMvgWKAesWV+XW1y+qzRAA7bxd2YsqKTQDjxlGg6PC+hnyzLJuZSHlf+z873C,s=qO/j4RQBJRttoagRvrwQkg==,i=4096\r\n
```

```
sasl auth 144\r\n
c=bixhPXRlc3RVc2VyQGFyY3VzLA==,r=KDGgMvgWKAesWV+XW1y+qzRAA7bxd2YsqKTQDjxlGg6PC+hnyzLJuZSHlf+z873C,p=M/TOzndLJnRD60+VicZSzmEFQ8u8v65nb3m0Czzzx7o=\r\n

SASL_CONTINUE 46\r\n
v=HoGV6rivvLX6zT+ktkcCnPxNLAlLGHiCvDLPRwla1tI=\r\n
```

```
sasl auth 0\r\n
\r\n

SASL_OK\r\n
```
