### PR TITLE
INTERNAL: Add sasl related fields to `conn` and remove `sasl_tmp`

### DIFF
--- a/memcached.h
+++ b/memcached.h
@@ -32,6 +32,7 @@
 #include "topkeys.h"
 #include "mc_util.h"
 #include "engine_loader.h"
+#include "sasl_defs.h"
 
 /* This is the address we use for admin purposes.  For example, doing stats
  * and heart beats from arcus_zk.
@@ -275,9 +276,12 @@ typedef bool (*STATE_FUNC)(conn *);
 struct conn {
     int    sfd;
     short  nevents;
-    void *sasl_conn;
+    sasl_conn_t *sasl_conn;
     bool sasl_started;
     bool authenticated;
+    char sasl_mech[MAX_SASL_MECH_LEN+1];
+    int sasl_auth_data_len;
+    char *sasl_auth_data;
     STATE_FUNC   state;
     enum bin_substates substate;
     struct event event;

--- a/sasl_defs.c
+++ b/sasl_defs.c
@@ -5,8 +5,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "sasl_defs.h"
-
 #ifdef HAVE_SASL_CB_GETCONF
 /* The locations we may search for a SASL config file if the user didn't
  * specify one in the environment variable SASL_CONF_PATH


### PR DESCRIPTION
### 🔗 Related Issue

- #843 
- #814

### ⌨️ What I did

- conn 구조체에 sasl 인증 요청 시 사용할 필드를 추가합니다.
  - `char sasl_mech[MAX_SASL_MECH_LEN+1]`
  - `int sasl_auth_data_len`
  - `char *sasl_auth_data`

- 이에 따라 필요하지 않게 된 sasl_tmp 구조체를 제거하고, 관련 구현을 수정합니다.

- memcached.h에서 `MAX_SASL_MECH_LEN` 사용하기 위해, sasl_defs.h를 memcached.h에서 include하도록 이전 변경사항을 revert 합니다.
