### PR TITLE
CLEANUP: Call shutdown_sasl() in shutdown process

### DIFF
--- a/isasl.c
+++ b/isasl.c
@@ -228,7 +228,7 @@ static void* check_isasl_db_thread(void* arg)
     return NULL;
 }
 
-void shutdown_sasl(void)
+void sasl_done(void)
 {
    pthread_mutex_lock(&sasl_db_thread_lock);
    run_sasl_db_thread = false;

--- a/isasl.h
+++ b/isasl.h
@@ -26,6 +26,8 @@ typedef struct user_db_entry {
 
 void sasl_dispose(sasl_conn_t **pconn);
 
+void sasl_done(void);
+
 int sasl_server_init(const sasl_callback_t *callbacks,
                      const char *appname);
 

--- a/memcached.c
+++ b/memcached.c
@@ -16052,6 +16052,10 @@ int main (int argc, char **argv)
     }
 #endif
 
+#ifdef SASL_ENABLED
+    shutdown_sasl();
+#endif /* SASL */
+
     /* 3) close listen sockes not to accept new connections */
     close_listen_sockets();
     mc_logger->log(EXTENSION_LOG_INFO, NULL, "Listen sockets closed.\n");

--- a/sasl_defs.c
+++ b/sasl_defs.c
@@ -178,3 +178,7 @@ void init_sasl(void) {
         }
     }
 }
+
+void shutdown_sasl(void) {
+    sasl_done();
+}

--- a/sasl_defs.h
+++ b/sasl_defs.h
@@ -14,7 +14,7 @@
 
 #include <sasl/sasl.h>
 void init_sasl(void);
-#define shutdown_sasl()
+void shutdown_sasl(void);
 
 #elif defined(ENABLE_ISASL)
 


### PR DESCRIPTION
### ⌨️ What I did

- shutdown 과정에서 `shutdown_sasl()` 호출하도록 합니다.
- `isasl.c`에서 `shutdown_sasl()`을 직접 구현하는 대신, `sasl_done()`을 구현하도록 합니다.
- `sasl_defs.c`에서 `sasl_done()`을 호출하는 `shutdown_sasl()`을 구현합니다.