### PR TITLE
INTERNAL: Remove the suffixcurr variable from conn structure

### DIFF
--- a/memcached.h
+++ b/memcached.h
@@ -380,7 +380,6 @@ struct conn {
 
     char   **suffixlist;
     int    suffixsize;
-    char   **suffixcurr;
     int    suffixleft;
 
     enum protocol protocol;   /* which protocol this connection speaks */


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- jam2in/arcus-works#736

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 불필요한 suffixcurr 변수를 conn 구조체에서 제거합니다.