### PR TITLE
INTERNAL: Add support for specifying SASL path

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -109,6 +109,7 @@ endif
 
 if ENABLE_SASL
 memcached_SOURCES += sasl_defs.c
+memcached_LDADD += -lsasl2
 endif
 
 if ENABLE_ISASL
@@ -229,7 +230,7 @@ syslog_logger_la_SOURCES = syslog_logger.c
 syslog_logger_la_LDFLAGS = -avoid-version -shared -module -no-undefined
 
 # A logger using user log file
-userlog_logger_la_SOURCES = userlog_logger.c 
+userlog_logger_la_SOURCES = userlog_logger.c
 userlog_logger_la_LDFLAGS = -avoid-version -shared -module -no-undefined
 
 basic_engine_testsuite_la_SOURCES= basic_engine_testsuite.c

--- a/configure.ac
+++ b/configure.ac
@@ -112,6 +112,8 @@ AM_PROG_CC_C_O
 AC_PROG_INSTALL
 AC_C_BIGENDIAN
 
+AC_CHECK_HEADERS_ONCE(link.h dlfcn.h inttypes.h umem.h priv.h sysexits.h sys/wait.h sys/socket.h netinet/in.h netdb.h unistd.h sys/un.h sys/stat.h sys/resource.h sys/uio.h netinet/tcp.h pwd.h sys/mman.h syslog.h)
+
 AC_ARG_ENABLE(sasl,
   [AS_HELP_STRING([--enable-sasl],[Enable SASL authentication])])
 AC_ARG_ENABLE(isasl,
@@ -146,8 +148,6 @@ unsigned long val = SASL_CB_GETCONF;
                      [Set to nonzero if your SASL implementation supports SASL_CB_GETCONF])])
 ])
 
-AC_CHECK_HEADERS_ONCE(link.h dlfcn.h inttypes.h umem.h priv.h sasl/sasl.h sysexits.h sys/wait.h sys/socket.h netinet/in.h netdb.h unistd.h sys/un.h sys/stat.h sys/resource.h sys/uio.h netinet/tcp.h pwd.h sys/mman.h syslog.h)
-
 AM_CONDITIONAL(BUILD_SYSLOG_LOGGER, test "x$ac_cv_header_syslog_h" = "xyes")
 
 if test "x$enable_isasl" = "xyes"; then
@@ -157,14 +157,87 @@ if test "x$enable_isasl" = "xyes"; then
       AC_MSG_ERROR([You can't specify isasl and sasl at the same time])
   fi
 elif test "x$enable_sasl" = "xyes"; then
-  AC_PATH_PROG(ac_cv_saslpasswd2, saslpasswd2, ,/usr/sbin:/usr/bin:/usr/local/bin:/usr/opt/bin/:/opt/bin)
-  AC_C_DETECT_SASL_CB_GETCONF
   AC_DEFINE([ENABLE_SASL],1,[Set to nonzero if you want to include SASL])
-  AC_SEARCH_LIBS([sasl_server_init], [sasl2 sasl], [],
-    [
-      AC_MSG_ERROR([Failed to locate the library containing sasl_server_init])
-    ])
 
+  trysasldir=""
+  AC_ARG_WITH(sasl,
+    [  --with-sasl=PATH        specify path to sasl installation ],
+    [
+      if test "x$withval" != "xno" ; then
+        trysasldir=$withval
+      fi
+    ]
+  )
+
+  AC_CACHE_CHECK([for sasl directory], ac_cv_sasl_dir, [
+    saved_LIBS="$LIBS"
+    saved_LDFLAGS="$LDFLAGS"
+    saved_CPPFLAGS="$CPPFLAGS"
+    sasl_found=no
+    for sasldir in $trysasldir $prefix "" /usr/local ; do
+      LDFLAGS="$saved_LDFLAGS"
+      CPPFLAGS="$saved_CPPFLAGS"
+
+      # Skip the directory if it isn't there.
+      if test ! -z "$sasldir" -a ! -d "$sasldir" ; then
+         continue;
+      fi
+      if test ! -z "$sasldir" ; then
+        if test -d "$sasldir/lib" ; then
+          LDFLAGS="-L$sasldir/lib $LDFLAGS"
+        else
+          LDFLAGS="-L$sasldir $LDFLAGS"
+        fi
+        if test -d "$sasldir/include" ; then
+          CPPFLAGS="-I$sasldir/include $CPPFLAGS"
+        else
+          CPPFLAGS="-I$sasldir $CPPFLAGS"
+        fi
+      fi
+
+      if test ! -z "$sasldir" ; then
+        ac_cv_sasl_dir=$sasldir
+      else
+        ac_cv_sasl_dir="(system)"
+      fi
+
+      AC_SEARCH_LIBS(sasl_server_init, sasl2, [
+        sasl_found=yes
+      ],[
+        sasl_found=no
+      ])
+
+      if test $sasl_found = yes ; then
+        AC_C_DETECT_SASL_CB_GETCONF
+        break
+      fi
+    done
+    LIBS="$saved_LIBS"
+    LDFLAGS="$saved_LDFLAGS"
+    CPPFLAGS="$saved_CPPFLAGS"
+    if test $sasl_found = no ; then
+      AC_MSG_ERROR([
+
+        If it's already installed, specify its path using --with-sasl=/dir/
+      ])
+    fi
+  ])
+
+  if test $ac_cv_sasl_dir != "(system)"; then
+    if test -d "$ac_cv_sasl_dir/lib" ; then
+      LDFLAGS="-L$ac_cv_sasl_dir/lib $LDFLAGS"
+      sasl_libdir="$ac_cv_sasl_dir/lib"
+    else
+      LDFLAGS="-L$ac_cv_sasl_dir $LDFLAGS"
+      sasl_libdir="$ac_cv_sasl_dir"
+    fi
+      if test -d "$ac_cv_sasl_dir/include" ; then
+      CPPFLAGS="-I$ac_cv_sasl_dir/include $CPPFLAGS"
+    else
+      CPPFLAGS="-I$ac_cv_sasl_dir $CPPFLAGS"
+    fi
+  fi
+  AC_PATH_PROG(ac_cv_saslpasswd2, saslpasswd2, ,/usr/sbin:/usr/bin:/usr/local/bin:/usr/opt/bin/:/opt/bin)
   AS_IF([test "x$enable_sasl_pwdb" = "xyes"],
         [AC_DEFINE([ENABLE_SASL_PWDB], 1,
                    [Set to nonzero if you want to enable a SASL pwdb])])

--- a/sasl_defs.h
+++ b/sasl_defs.h
@@ -4,13 +4,7 @@
 // Longest one I could find was ``9798-U-RSA-SHA1-ENC''
 #define MAX_SASL_MECH_LEN 32
 
-#if defined(HAVE_SASL_SASL_H) || defined(ENABLE_ISASL)
-#define HAVE_SASL_HDR 1
-#else
-#define HAVE_SASL_HDR 0
-#endif /* have some kind of sasl header */
-
-#if defined(HAVE_SASL_SASL_H) && defined(ENABLE_SASL)
+#if defined(ENABLE_SASL)
 
 #include <sasl/sasl.h>
 void init_sasl(void);


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
-

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- `--with-sasl` 플래그를 통해 SASL 경로를 지정할 수 있도록 했습니다.
  - 구현 방식은 arcus-zookeeper와 최대한 유사하게 맞췄습니다.
  - SASL 버전에 따라 `-lsasl2` 또는 `-lsasl`로 링크해야 하므로, `AC_SEARCH_LIBS` 매크로를 사용해 `sasl2`, `sasl` 순으로 탐색한 뒤, 사용 가능한 라이브러리를 링크하도록 했습니다.
  - 탐색에 성공한 경우, 해당 라이브러리 링크 옵션(`-lsasl2` 또는 `-lsasl`)을 `LINK_SASL` 변수에 저장하고, 이를 `Makefile.am`에 전달해 빌드 시 사용할 수 있도록 했습니다.
- `--with-sasl` 옵션이 지정된 상태에서 SASL 라이브러리를 찾지 못하면 빌드가 실패합니다.
  - 단순히 `sasl/sasl.h`의 존재 여부를 확인하는 `AC_CHECK_HEADERS_ONCE`에서는 SASL을 제외했고,
그에 따라 코드 내 `HAVE_SASL_SASL_H` 관련 부분도 필요없다고 판단하여 모두 제거했습니다.
