### PR TITLE
INTERNAL: Add command authorization support

### DIFF
--- a/ascii_scrub.c
+++ b/ascii_scrub.c
@@ -85,6 +85,12 @@ static bool execute_command(const void *cmd_cookie, const void *cookie,
         return response_handler(cookie, 29, "SERVER_ERROR internal error\r\n");
     }
 
+    auth_data_t data;
+    server->core->get_auth_data(cookie, &data);
+    if ((*data.authz_flag & AUTHZ_ADMIN) == 0) {
+        return response_handler(cookie, 28, "CLIENT_ERROR unauthorized\r\n");
+    }
+
     if (argc == 2 && strcmp(argv[1].value, "stale") == 0) {
         request.request.opcode = PROTOCOL_BINARY_CMD_SCRUB_STALE;
     }

--- a/include/memcached/types.h
+++ b/include/memcached/types.h
@@ -399,9 +399,24 @@ extern "C" {
         uint8_t  trimmed;
     } item_attr;
 
+    /* Command authorization flags (bitmask) */
+#define AUTHZ_NONE  0x0000
+#define AUTHZ_KV    0x0001
+#define AUTHZ_LIST  0x0002
+#define AUTHZ_SET   0x0004
+#define AUTHZ_MAP   0x0008
+#define AUTHZ_BTREE 0x0010
+#define AUTHZ_SCAN  0x0020
+#define AUTHZ_FLUSH 0x0040
+#define AUTHZ_ATTR  0x0080
+#define AUTHZ_ADMIN 0x0100
+#define AUTHZ_FAIL  0x8000
+#define AUTHZ_ALL   0x7FFF
+
     typedef struct {
         const char *username;
         const char *config;
+        const uint16_t *authz_flag;
     } auth_data_t;
 
     /* Forward declaration of the server handle -- to be filled in later */

--- a/memcached.h
+++ b/memcached.h
@@ -279,6 +279,7 @@ struct conn {
     sasl_conn_t *sasl_conn;
     bool sasl_started;
     bool authenticated;
+    uint16_t authorized;
     char sasl_mech[MAX_SASL_MECH_LEN+1];
     uint32_t sasl_auth_data_len;
     char *sasl_auth_data;

--- a/sasl_auxprop.c
+++ b/sasl_auxprop.c
@@ -206,9 +206,14 @@ static int _arcus_getdata(const char *user,
                           char *out, const size_t max_out,
                           size_t *out_len)
 {
-    int ret = SASL_NOUSER;
     char key[sizeof(group_zpath) + USERNAME_MAXLEN + PROPNAME_MAXLEN];
-    snprintf(key, sizeof(key), "%s/%s/%s", group_zpath, user, propName);
+    if (propName) {
+        snprintf(key, sizeof(key), "%s/%s/%s", group_zpath, user, propName);
+    } else {
+        snprintf(key, sizeof(key), "%s/%s", group_zpath, user);
+    }
+
+    int ret = SASL_NOUSER;
     unsigned long index = hash_function(key) % SASL_TABLE_SIZE;
     struct sasl_entry *entry;
 
@@ -381,6 +386,11 @@ int arcus_auxprop_plug_init(const sasl_utils_t *utils,
     }
 
     return SASL_OK;
+}
+
+int arcus_getdata(const char *user, char *out, const size_t max_out)
+{
+    return _arcus_getdata(user, NULL, out, max_out, NULL);
 }
 
 #endif /* ENABLE_ZK_INTEGRATION */

--- a/sasl_auxprop.h
+++ b/sasl_auxprop.h
@@ -13,6 +13,8 @@ int arcus_auxprop_plug_init(const sasl_utils_t *utils,
                             sasl_auxprop_plug_t **plug,
                             const char *plugname);
 
+int arcus_getdata(const char *user, char *out, const size_t max_out);
+
 #endif /* ENABLE_ZK_INTEGRATION */
 #endif /* ENABLE_SASL */
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- jam2in/arcus-works#748

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->

SASL 권한 부여 기능 추가를 위한 PR입니다.
이번 PR에서는 최종적으로 구현하고자 하는 구조를 먼저 공유드리기 위해, 전체적인 틀을 포함한 초기 구현을 올렸습니다.
리뷰를 위해 구조 위주로 확인 부탁드립니다.

### 주요 변경 사항

- 권한 플래그는 types.h에 `AUTHZ_{}` 형태로 정의하였습니다.
  - 기본값은 AUTHZ_ALL로 설정했습니다.
    - 이는 권한 부여 기능을 사용하지 않을 경우, 모든 권한을 가진 상태로 동작하도록 하기 위함입니다.
    - 기본적으로 전체 권한을 부여한 뒤, 권한 기능이 활성화된 경우에 한해 권한을 제한하는 방식이 구현 측면에서 간결하다고 판단했습니다.
- 권한 플래그 정의를 `sasl_defs.h`가 아닌 `types.h`에 위치시킨 이유는, 권한 기능이 memcached.c 뿐 아니라 향후 extension을 통해 추가되는 ASCII 명령어 등에도 적용될 수 있기 때문입니다.
- auth_data_t 구조체에 권한 정보를 포함하도록 아래와 같이 수정했습니다.
```diff
typedef struct {
   const char *username;
   const char *config;
+  const uint16_t *authz_flag;
} auth_data_t;
```
  - 이를 통해 memcached.c 뿐만 아니라 extension에서도 get_auth_data API를 통해 현재 커넥션의 사용자 권한 정보를 조회할 수 있습니다.
- 인증 성공 시 권한 플래그를 설정하는 방식은 ON_AUTH 이벤트에 대응하는 콜백 함수인 arcus_sasl_authz()를 등록하여 처리했습니다.
  - 기존 로직에서도 인증 성공 이후 ON_AUTH 콜백이 호출되도록 되어 있어, 이 지점을 활용하는 것이 적절하다고 판단했습니다.
  - 참고 사항으로 기존 로직에서는 ON_AUTH에 대한 콜백이 아무것도 걸려있지 않습니다.