### PR TITLE
CLEANUP: Use copied string for strtok_r in arcus_check_domain_name()

### DIFF
--- a/arcus_zk.c
+++ b/arcus_zk.c
@@ -1402,7 +1402,7 @@ static int arcus_check_domain_name(char *ensemble_list)
             ret = 0; break;
         }
 
-        token = strtok_r(ensemble_list, ":", &save_ptr);
+        token = strtok_r(copy, ":", &save_ptr);
         if (inet_aton(token, NULL)) {
             ret = 0; break;
         }


### PR DESCRIPTION
### 🔗 Related Issue

> - #659 
> strtok은 인자로 받은 문자열을 변경하므로 main_zk->ensemble_list를 복사해 사용 후 free합니다.

- jam2in/arcus-works#741

### ⌨️ What I did

- 복사본 사용하지 않고 원본 직접 변경하던 문제를 수정합니다.