### PR TITLE
CLEANUP: Use int instead of sized_t in _table_insert()

### DIFF
--- a/sasl_auxprop.c
+++ b/sasl_auxprop.c
@@ -47,7 +47,7 @@ static unsigned long hash_function(const char *str)
 }
 
 static bool _table_insert(struct sasl_entry **table, const char *key,
-                          const char* value, size_t value_len)
+                          const char* value, int value_len)
 {
     if (value_len < 0) {
         return false;


### PR DESCRIPTION
### 🔗 Related Issue

- #850 

### ⌨️ What I did

- `zoo_get`에서 반환하는 `value_len`은 int 타입이고, `-1`이 설정될 수 있습니다.
- `_table_insert()`에서 이를 고려하여 `value_len < 0` 비교하고 있는데,
`size_t` 타입이라서 `< 0` 비교가 의도한대로 동작하지 않는 상태입니다.
- zoo_get에서 반환하는 자료형과 일관된 타입을 갖고, 음수 비교가 가능하도록 타입을 `int`로 변경합니다.
