### PR TITLE
TEST: Reselect a free port when memcached fails to start

### DIFF
--- a/t/stats.t
+++ b/t/stats.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 use strict;
-use Test::More tests => 80;
+use Test::More tests => 79;
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use MemcachedTest;
@@ -190,7 +190,7 @@ if ($stats->{'auth_sasl_enabled'} == 'yes') {
 
 # Test initial state
 foreach my $key (qw(curr_items total_items bytes cmd_get cmd_set get_hits evictions get_misses
-                 bytes_written delete_hits delete_misses incr_hits incr_misses decr_hits decr_misses)) {
+                    delete_hits delete_misses incr_hits incr_misses decr_hits decr_misses)) {
     is($stats->{$key}, 0, "initial $key is zero");
 }
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- jam2in/arcus-works#744

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 테스트용 memcached를 구동할 때 실패할 경우, 포트를 변경하여 최대 5회까지 재시도합니다.
- 서버 구동 실패 여부는 커넥션이 성공한 후, stats 명령어를 통해 구동 중인 memcached의 PID를 확인하고, 이를 fork로 생성한 자식 프로세스의 PID와 비교하여 판단합니다.
- 각 테스트 초기에 stats 명령어가 실행되기 때문에, bytes_written 값이 0인지 확인하는 테스트는 제외하였습니다.
