### PR TITLE
CLEANUP: Add `AUTHZ_DELETE` to auth_flag

### DIFF
--- a/include/memcached/types.h
+++ b/include/memcached/types.h
@@ -400,18 +400,19 @@ extern "C" {
     } item_attr;
 
     /* Command authorization flags (bitmask) */
-#define AUTHZ_NONE  0x0000
-#define AUTHZ_KV    0x0001
-#define AUTHZ_LIST  0x0002
-#define AUTHZ_SET   0x0004
-#define AUTHZ_MAP   0x0008
-#define AUTHZ_BTREE 0x0010
-#define AUTHZ_SCAN  0x0020
-#define AUTHZ_FLUSH 0x0040
-#define AUTHZ_ATTR  0x0080
-#define AUTHZ_ADMIN 0x0100
-#define AUTHZ_FAIL  0x8000
-#define AUTHZ_ALL   0x7FFF
+#define AUTHZ_NONE   0x0000
+#define AUTHZ_DELETE 0x0001
+#define AUTHZ_KV     0x0002
+#define AUTHZ_LIST   0x0004
+#define AUTHZ_SET    0x0008
+#define AUTHZ_MAP    0x0010
+#define AUTHZ_BTREE  0x0020
+#define AUTHZ_SCAN   0x0040
+#define AUTHZ_FLUSH  0x0080
+#define AUTHZ_ATTR   0x0100
+#define AUTHZ_ADMIN  0x0200
+#define AUTHZ_FAIL   0x8000
+#define AUTHZ_ALL    0x7FFF
 
     typedef struct {
         const char *username;

--- a/memcached.c
+++ b/memcached.c
@@ -8855,7 +8855,7 @@ static void process_delete_command(conn *c, token_t *tokens, const size_t ntoken
     size_t nkey = tokens[KEY_TOKEN].length;
 
 #ifdef ASCII_SASL
-    if (settings.require_sasl && !check_ascii_auth(c, key, AUTHZ_KV)) {
+    if (settings.require_sasl && !check_ascii_auth(c, key, AUTHZ_DELETE)) {
         out_string(c, "CLIENT_ERROR unauthorized");
         return;
     }

--- a/sasl_defs.c
+++ b/sasl_defs.c
@@ -139,11 +139,11 @@ static void arcus_sasl_authz(const void *cookie,
         char *token = strtok_r(value, ",", &saveptr);
         c->authorized = AUTHZ_NONE;
         while (token != NULL) {
-            if      (strcmp(token, "kv")    == 0) c->authorized |= AUTHZ_KV;
-            else if (strcmp(token, "list")  == 0) c->authorized |= AUTHZ_LIST;
-            else if (strcmp(token, "set")   == 0) c->authorized |= AUTHZ_SET;
-            else if (strcmp(token, "map")   == 0) c->authorized |= AUTHZ_MAP;
-            else if (strcmp(token, "btree") == 0) c->authorized |= AUTHZ_BTREE;
+            if      (strcmp(token, "kv")    == 0) c->authorized |= AUTHZ_KV | AUTHZ_DELETE;
+            else if (strcmp(token, "list")  == 0) c->authorized |= AUTHZ_LIST | AUTHZ_DELETE;
+            else if (strcmp(token, "set")   == 0) c->authorized |= AUTHZ_SET | AUTHZ_DELETE;
+            else if (strcmp(token, "map")   == 0) c->authorized |= AUTHZ_MAP | AUTHZ_DELETE;
+            else if (strcmp(token, "btree") == 0) c->authorized |= AUTHZ_BTREE | AUTHZ_DELETE;
             else if (strcmp(token, "scan")  == 0) c->authorized |= AUTHZ_SCAN;
             else if (strcmp(token, "flush") == 0) c->authorized |= AUTHZ_FLUSH;
             else if (strcmp(token, "attr")  == 0) c->authorized |= AUTHZ_ATTR;


### PR DESCRIPTION
### 🔗 Related Issue

- #864 

### ⌨️ What I did

- `kv` role 없이 collection role만 가진 경우 `delete` 명령 수행할 수 없던 문제를 수정합니다.
- 이를 위해 `delete` 명령 수행을 위한 `AUTHZ_DELETE` 플래그를 분리합니다.
