### PR TITLE
CLEANUP: Add `default_sasl_authz()` callback on auth

### DIFF
--- a/sasl_defs.c
+++ b/sasl_defs.c
@@ -191,6 +191,15 @@ static int sasl_log(void *context, int level, const char *message)
 }
 #endif
 
+static void default_sasl_authz(const void *cookie,
+                               ENGINE_EVENT_TYPE type,
+                               const void *event_data,
+                               const void *cb_data)
+{
+    conn *c = (conn *)cookie;
+    c->authorized = AUTHZ_ALL;
+}
+
 static sasl_callback_t sasl_callbacks[5] = {
 #ifdef ENABLE_SASL_PWDB
    { SASL_CB_SERVER_USERDB_CHECKPASS, (int(*)(void))sasl_server_userdb_checkpass, NULL },
@@ -244,7 +253,11 @@ void init_sasl(void)
             exit(EXIT_FAILURE);
         }
         register_callback(NULL, ON_AUTH, arcus_sasl_authz, NULL);
+    } else {
+        register_callback(NULL, ON_AUTH, default_sasl_authz, NULL);
     }
+#else
+    register_callback(NULL, ON_AUTH, default_sasl_authz, NULL);
 #endif
 
     if (settings.verbose) {


### PR DESCRIPTION
### 🔗 Related Issue

- #871 

### ⌨️ What I did

- default auxprop plugin(== sasldb) 사용하는 경우에 인증에 성공했음에도 권한이 없는(`AUTHZ_NONE`) 문제를 수정합니다.
