### PR TITLE
INTERNAL: Always respond with `SASL_OK` when `require_sasl` is false …

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -4308,6 +4308,13 @@ static void process_ascii_sasl_auth(conn *c, token_t *tokens, const size_t ntoke
         return;
     }
 
+    if (!settings.require_sasl) {
+        out_string(c, "SASL_OK");
+        c->sbytes = c->sasl_auth_data_len + 2;
+        c->write_and_go = conn_swallow;
+        return;
+    }
+
     c->sasl_auth_data = malloc(c->sasl_auth_data_len + 2);
     if (!c->sasl_auth_data) {
         out_string(c, "SERVER_ERROR out of memory");


### PR DESCRIPTION
### ⌨️ What I did

- `-S` 옵션 없이 구동한 서버에 `sasl auth` 명령이 수신된 경우 무조건 `SASL_OK` 응답을 보내도록 합니다.
