### PR TITLE
INTERNAL: Add message to AUTH_ERROR

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -3287,7 +3287,9 @@ static void process_sasl_auth_complete(conn *c)
         }
         c->suffixcurr = c->suffixlist;
     } else {
-        out_string(c, "AUTH_ERROR");
+        char temp[512];
+        snprintf(temp, sizeof(temp), "AUTH_ERROR %s", sasl_errstring(result, NULL, NULL));
+        out_string(c, temp);
         STATS_ERRORS_NOKEY(c, auth);
     }
 }


### PR DESCRIPTION
### 🔗 Related Issue

- jam2in/arcus-works#752

### ⌨️ What I did

- 인증 실패 시 `AUTH_ERROR` 응답에 에러 메시지를 함께 전달합니다.
