### PR TITLE
CLEANUP: Remove unused `auth_data_t.authz_flag`

### DIFF
--- a/include/memcached/types.h
+++ b/include/memcached/types.h
@@ -417,7 +417,6 @@ extern "C" {
     typedef struct {
         const char *username;
         const char *config;
-        const uint16_t *authz_flag;
     } auth_data_t;
 
     /* Forward declaration of the server handle -- to be filled in later */

--- a/memcached.c
+++ b/memcached.c
@@ -3207,7 +3207,6 @@ static void init_sasl_conn(conn *c)
 static void get_auth_data(const void *cookie, auth_data_t *data)
 {
     conn *c = (conn*)cookie;
-    data->authz_flag = (const uint16_t *)&c->authorized;
     if (c->sasl_conn) {
         sasl_getprop(c->sasl_conn, SASL_USERNAME, (void*)&data->username);
 #ifdef ENABLE_ISASL


### PR DESCRIPTION
### 🔗 Related Issue

- #864 

### ⌨️ What I did

- 현재 시점에서 사용하지 않는 `authz_flag`를 제거합니다.
