### PR TITLE
FIX: Add handling for tokens exceeding max_stats_prefixes in process_stats_prefixlist()

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -147,6 +147,7 @@ static void update_stat_cas(conn *c, ENGINE_ERROR_CODE ret);
 static void process_stats_prefixes(conn *c, const size_t ntokens);
 static void process_stats_prefixlist(conn *c, token_t *tokens, const size_t ntokens);
 static void process_stats_engine(conn *c, token_t *tokens, const size_t ntokens);
+static size_t count_remained_tokens(const token_t *tokens);
 static void write_ascii_stats_buffer(conn *c);
 
 /* defaults */
@@ -8608,7 +8609,7 @@ static void process_stats_prefixlist(conn *c, token_t *tokens, const size_t ntok
     int len;
     char *stats;
     token_t *prefixes = ntokens > 4 ? &tokens[3] : NULL;
-    size_t nprefixes = ntokens > 4 ? ntokens-4 : 0;
+    size_t nprefixes = ntokens > 4 ? ntokens - 4 : 0;
     size_t prefix_cnt = nprefixes;
 
     if (ntokens < 4) {
@@ -8631,9 +8632,27 @@ static void process_stats_prefixlist(conn *c, token_t *tokens, const size_t ntok
         return;
     }
 
+    /* untokenized command reserved */
+    if (ntokens >= MAX_TOKENS) {
+        prefix_cnt += count_remained_tokens(&tokens[ntokens - 1]);
+    }
+
     if (prefix_cnt > settings.max_stats_prefixes) {
         out_string(c, "CLIENT_ERROR invalid: too many prefixes");
         return;
+    }
+
+    if (ntokens >= MAX_TOKENS && prefix_cnt > nprefixes) {
+        token_t *temp = (token_t *)malloc(sizeof(token_t) * (prefix_cnt + 2));
+        if (temp == NULL) {
+            out_string(c, "SERVER_ERROR no more memory");
+            return;
+        }
+        memcpy(temp, prefixes, sizeof(token_t) * nprefixes);
+        tokenize_command(prefixes[nprefixes].value, prefixes[nprefixes + 1].length,
+                         temp + nprefixes, (prefix_cnt - nprefixes + 1));
+        prefixes = temp;
+        nprefixes = prefix_cnt;
     }
 
     if (item_cmd == true) { /* item */
@@ -8641,6 +8660,11 @@ static void process_stats_prefixlist(conn *c, token_t *tokens, const size_t ntok
     } else {                /* operation */
         stats = stats_prefix_dump(prefixes, nprefixes, &len);
     }
+
+    if (ntokens > MAX_TOKENS && prefix_cnt > nprefixes) {
+        free(prefixes);
+    }
+
     if (stats != NULL) {
         write_and_free(c, stats, len);
     } else {
@@ -8680,6 +8704,27 @@ static void process_stats_engine(conn *c, token_t *tokens, const size_t ntokens)
             handle_unexpected_errorcode_ascii(c, __func__, ret);
             break;
     }
+}
+
+static size_t count_remained_tokens(const token_t *remained)
+{
+    assert(remained != NULL);
+    if (remained->value == NULL) return 0;
+
+    size_t count = 0;
+    const char *s = remained->value;
+    const char *e = s + (remained+1)->length;
+
+    while (s < e) {
+        if (*s == ' ') {
+            s++;
+        } else {
+            count++;
+            while (s < e && *s != ' ') s++;
+        }
+    }
+
+    return count;
 }
 
 static void write_ascii_stats_buffer(conn *c)
@@ -14014,12 +14059,11 @@ static int try_read_command_ascii(conn *c)
                 conn_set_state(c, conn_closing);
                 return 1;
             }
-            /* Check KEY_MAX_LENGTH and eflag filter length
-             *  - KEY_MAX_LENGTH : 16000
-             *  - IN eflag filter : > 6400 (64*100)
+            /* Check <KEY_MAX_LENGTH and IN eflag filter> or prefixlist max length : 26KB
+             *  - KEY_MAX_LENGTH(16000) + IN eflag filter(64*100) : 24KB
+             *  - prefixlist max length : max prefix count(100) * MAX_PREFIX_LENGTH(250) : 25KB
              */
-            if (c->rbytes > ((16+8)*1024)) {
-                /* The length of "stats prefixes" command cannot exceed 24 KB. */
+            if (c->rbytes > (26*1024)) {
                 if (strncmp(ptr, "get ", 4) && strncmp(ptr, "gets ", 5)) {
                     char buffer[16];
                     memcpy(buffer, ptr, 15); buffer[15] = '\0';


### PR DESCRIPTION
### 🔗 Related Issue

- [[Cache Server] stats prefixlist 다수 prefix 처리 불가 문제 #651](https://github.com/jam2in/arcus-works/issues/651)

### 기존 동작
- tokenize_command(cmd, cmdlen, tokens, max_tokens)의 동작 방식
문자열 변수 cmd를 순회하며 blank 발견 시 `\0`로 대체해 파싱합니다. 결과 값을 max_tokens개까지 tokens에 순서대로 저장하고, 남은 cmd를 처리하지 않고 전부 max_tokens번째의 value로 저장합니다. 남은 cmd의 길이를 max_tokens+1번째의 length에 저장합니다.

- get 명령어와 stats prefixlist 명령어의 동작 차이
get 명령어는 `process_get_command()`에서 key_token이라는 iterator를 사용하여 tokens의 끝에 도달할 때까지 `process_get_single()`을 호출합니다. 그리고 남은 token이 있다면 `tokenize_command()`를 호출해 다시 token을 생성해 위 과정을 반복합니다. 반면에 stats prefixlist 명령어는 `process_stats_prefixlist()`에서 `prefix_dump_stats()`에 prefixes를 전부 넘겨 처리합니다.

### ⌨️ What I did
- 처리되지 않고 남은 토큰 수를 확인하는 `count_remained_tokens()` 함수를 추가했습니다.
- `try_read_command_ascii()`에서 24KB을 넘는 too long command에 대한 에러 처리에 stats prefixlist 명령어를 예외로 추가했습니다.
- 총 토큰 수가 `max_stats_prefixes`를 넘는 경우는 CLINET_ERROR 처리했습니다.
- prefixes의 토큰 수가 max_tokens 이상인 경우 처리되지 않고 남은 토큰을 토큰화 후 기존 토큰에 합해 prefixes에 저장합니다. `prefix_dump_stats()` 또는 `stats_prefix_dump()`를 호출해 prefixes를 처리합니다.