### PR TITLE
INTERNAL: Return the result instead of exit() on init_sasl() failure

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -16136,8 +16136,8 @@ int main (int argc, char **argv)
     }
 
 #ifdef SASL_ENABLED
-    if (settings.require_sasl) {
-        init_sasl();
+    if (settings.require_sasl && init_sasl() != 0) {
+        exit(EXIT_FAILURE);
     }
 #endif
 

--- a/sasl_defs.h
+++ b/sasl_defs.h
@@ -9,20 +9,20 @@ uint16_t arcus_sasl_authz(const char *username);
 #if defined(ENABLE_SASL)
 
 #include <sasl/sasl.h>
-void init_sasl(void);
+int init_sasl(void);
 void shutdown_sasl(void);
 
 #elif defined(ENABLE_ISASL)
 
 #include "isasl.h"
-void init_sasl(void);
+int init_sasl(void);
 void shutdown_sasl(void);
 #else /* End of SASL support */
 
 typedef void* sasl_conn_t;
 
 #define shutdown_sasl()
-#define init_sasl() {}
+#define init_sasl() 0
 #define sasl_dispose(x) {}
 #define sasl_server_new(a, b, c, d, e, f, g, h) 1
 #define sasl_listmech(a, b, c, d, e, f, g, h) 1


### PR DESCRIPTION
### 🔗 Related Issue

- jam2in/arcus-works#759

### ⌨️ What I did

- `init_sasl()` 실패 시 exit()하는 대신 성공/실패 여부를 반환하도록 합니다.
- `init_sasl()`에서 `sasl_callbacks` 초기화를 멱등성 있는 구현으로 변경합니다.
