### PR TITLE
INTERNAL: Fix the undeclared sasl_getconf error

### DIFF
--- a/sasl_defs.c
+++ b/sasl_defs.c
@@ -210,7 +210,7 @@ static sasl_callback_t sasl_callbacks[5] = {
    { SASL_CB_GETCONF, (int(*)(void))sasl_getconf, NULL },
 #else
 #ifdef HAVE_SASL_CB_GETCONFPATH
-   { SASL_CB_GETCONFPATH, (sasl_callback_ft)sasl_getconf, NULL },
+   { SASL_CB_GETCONFPATH, (int(*)(void))sasl_getconf, NULL },
 #endif
 #endif
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
-

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- sasl_callback_ft 대신 해당 타입을 직접 정의하여 사용하도록 변경합니다.
- 일부 컴파일 환경(MacOS)에서 sasl_callback_ft 타입을 찾지 못하고 아래와 같은 에러가 발생합니다.
```js
sasl_defs.c:213:28: error: use of undeclared identifier 'sasl_callback_ft'
  213 |    { SASL_CB_GETCONFPATH, (sasl_callback_ft)sasl_getconf, NULL },
      |                            ^
1 error generated.
```
