### PR TITLE
CLEANUP: Set default username in get_auth_data()

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -3212,6 +3212,10 @@ static void init_sasl_conn(conn *c)
 static void get_auth_data(const void *cookie, auth_data_t *data)
 {
     conn *c = (conn*)cookie;
+
+    data->username = "";
+    data->config = "";
+
     if (c->sasl_conn) {
         sasl_getprop(c->sasl_conn, SASL_USERNAME, (void*)&data->username);
 #ifdef ENABLE_ISASL


### PR DESCRIPTION
### 🔗 Related Issue

- jam2in/arcus-works#766

```
memcached.c: In function ‘process_bin_complete_sasl_auth’:
memcached.c:4478:28: error: ‘data.username’ may be used uninitialized [-Werror=maybe-uninitialized]
 4478 |     c->sasl_username = data.username;
      |                        ~~~~^~~~~~~~~
memcached.c:4476:17: note: ‘data’ declared here
 4476 |     auth_data_t data;
      |                 ^~~~
```

### ⌨️ What I did

- get_auth_data() 수행 시 각 필드를 `""`으로 초기화합니다.
