### PR TITLE
FIX: Use dummy arcus_sasl_authz() when sasl is disabled

### DIFF
--- a/sasl_defs.h
+++ b/sasl_defs.h
@@ -4,25 +4,28 @@
 // Longest one I could find was ``9798-U-RSA-SHA1-ENC''
 #define MAX_SASL_MECH_LEN 32
 
-uint16_t arcus_sasl_authz(const char *username);
 
 #if defined(ENABLE_SASL)
 
 #include <sasl/sasl.h>
 int init_sasl(void);
 void shutdown_sasl(void);
+uint16_t arcus_sasl_authz(const char *username);
 
 #elif defined(ENABLE_ISASL)
 
 #include "isasl.h"
 int init_sasl(void);
 void shutdown_sasl(void);
+uint16_t arcus_sasl_authz(const char *username);
+
 #else /* End of SASL support */
 
 typedef void* sasl_conn_t;
 
 #define shutdown_sasl()
 #define init_sasl() 0
+#define arcus_sasl_authz(a) 0
 #define sasl_dispose(x) {}
 #define sasl_server_new(a, b, c, d, e, f, g, h) 1
 #define sasl_listmech(a, b, c, d, e, f, g, h) 1


### PR DESCRIPTION
### 🔗 Related Issue

- jam2in/arcus-works#768

### ⌨️ What I did

- sasl disabled 상태에서 `sasl_defs.c` 파일이 빌드에 포함되지 않으므로, dummy macro 를 사용하도록 합니다.
- 실제로 sasl disabled 상태에서 `arcus_sasl_authz()`가 불리는 일은 없으므로 반환값은 어떤 값으로 해도 무방하지만,
`0 (== AUTHZ_NONE)`으로 해 두었습니다.

