### PR TITLE
CLEANUP: Do not use sasl_getconf callback

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -124,53 +124,6 @@ AC_ARG_ENABLE(sasl_pwdb,
 AS_IF([test "x$enable_sasl_pwdb" = "xyes"],
       [enable_sasl=yes ])
 
-
-dnl **********************************************************************
-dnl DETECT_SASL_CB_GETCONF
-dnl
-dnl check if we can use SASL_CB_GETCONF
-dnl **********************************************************************
-AC_DEFUN([AC_C_DETECT_SASL_CB_GETCONF],
-[
-    AC_CACHE_CHECK([for SASL_CB_GETCONF],
-        [ac_cv_c_sasl_cb_getconf],
-        [AC_TRY_COMPILE(
-            [
-#include <sasl/sasl.h>
-            ], [
-unsigned long val = SASL_CB_GETCONF;
-            ],
-            [ ac_cv_c_sasl_cb_getconf=yes ],
-            [ ac_cv_c_sasl_cb_getconf=no ])
-        ])
-    AS_IF([test "$ac_cv_c_sasl_cb_getconf" = "yes"],
-          [AC_DEFINE([HAVE_SASL_CB_GETCONF], 1,
-                     [Set to nonzero if your SASL implementation supports SASL_CB_GETCONF])])
-])
-
-dnl **********************************************************************
-dnl DETECT_SASL_CB_GETCONFPATH
-dnl
-dnl check if we can use SASL_CB_GETCONFPATH
-dnl **********************************************************************
-AC_DEFUN([AC_C_DETECT_SASL_CB_GETCONFPATH],
-[
-    AC_CACHE_CHECK([for SASL_CB_GETCONFPATH],
-        [ac_cv_c_sasl_cb_getconfpath],
-        [AC_TRY_COMPILE(
-            [
-#include <sasl/sasl.h>
-            ], [
-unsigned long val = SASL_CB_GETCONFPATH;
-            ],
-            [ ac_cv_c_sasl_cb_getconfpath=yes ],
-            [ ac_cv_c_sasl_cb_getconfpath=no ])
-        ])
-    AS_IF([test "$ac_cv_c_sasl_cb_getconfpath" = "yes"],
-          [AC_DEFINE([HAVE_SASL_CB_GETCONFPATH], 1,
-                     [Set to nonzero if your SASL implementation supports SASL_CB_GETCONFPATH])])
-])
-
 AM_CONDITIONAL(BUILD_SYSLOG_LOGGER, test "x$ac_cv_header_syslog_h" = "xyes")
 
 if test "x$enable_isasl" = "xyes"; then
@@ -229,12 +182,6 @@ elif test "x$enable_sasl" = "xyes"; then
       ],[
         sasl_found=no
       ])
-
-      if test $sasl_found = yes ; then
-        AC_C_DETECT_SASL_CB_GETCONF
-        AC_C_DETECT_SASL_CB_GETCONFPATH
-        break
-      fi
     done
     LIBS="$saved_LIBS"
     LDFLAGS="$saved_LDFLAGS"


### PR DESCRIPTION
### 🔗 Related Issue

- jam2in/arcus-works#767

### ⌨️ What I did

- `AC_C_DETECT_SASL_CB_GETCONF[PATH]` 콜백을 제거합니다.
