### PR TITLE
CLEANUP: Add sasl_errstring for non-cyrus-sasl feature

### DIFF
--- a/isasl.c
+++ b/isasl.c
@@ -386,3 +386,20 @@ int sasl_getprop(sasl_conn_t *conn, int propnum,
 
     return SASL_OK;
 }
+
+const char *sasl_errstring(int saslerr,
+                           const char *langlist __attribute__((unused)),
+                           const char **outlang)
+{
+    if (outlang) *outlang="en-us";
+
+    switch (saslerr) {
+        case SASL_CONTINUE: return "another step is needed in authentication";
+        case SASL_OK:       return "successful result";
+        case SASL_FAIL:     return "generic failure";
+        case SASL_NOMEM:    return "no memory available";
+        case SASL_BADPARAM: return "invalid parameter supplied";
+        case SASL_NOUSER:   return "user not found";
+        default:            return "undefined error!";
+    }
+}

--- a/isasl.h
+++ b/isasl.h
@@ -65,6 +65,10 @@ int sasl_server_step(sasl_conn_t *conn,
 int sasl_getprop(sasl_conn_t *conn, int propnum,
                  const void **pvalue);
 
+const char *sasl_errstring(int saslerr,
+                           const char *langlist __attribute__((unused)),
+                           const char **outlang);
+
 #define SASL_CONTINUE  1
 #define SASL_OK        0
 #define SASL_FAIL     -1        /* generic failure */

--- a/memcached.c
+++ b/memcached.c
@@ -3298,22 +3298,12 @@ static void process_sasl_auth_complete(conn *c)
         c->suffixcurr = c->suffixlist;
     } else {
         char temp[512];
-#ifdef ENABLE_SASL
         snprintf(temp, sizeof(temp), "AUTH_ERROR %s", sasl_errstring(result, NULL, NULL));
-#else
-        snprintf(temp, sizeof(temp), "AUTH_ERROR");
-#endif
         out_string(c, temp);
         STATS_ERRORS_NOKEY(c, auth);
-#ifdef ENABLE_SASL
         mc_logger->log(EXTENSION_LOG_WARNING, c,
                        "SECURITY_EVENT client=%s user=%s authentication failed(%s)\n",
                        c->client_ip, c->sasl_username, sasl_errstring(result, NULL, NULL));
-#else
-        mc_logger->log(EXTENSION_LOG_WARNING, c,
-                       "SECURITY_EVENT client=%s user=%s authentication failed\n",
-                       c->client_ip, c->sasl_username);
-#endif
     }
 }
 #endif

--- a/sasl_defs.h
+++ b/sasl_defs.h
@@ -36,6 +36,7 @@ typedef void* sasl_conn_t;
 #define sasl_server_start(a, b, c, d, e, f) 1
 #define sasl_server_step(a, b, c, d, e) 1
 #define sasl_getprop(a, b, c) {}
+#define sasl_errstring(a, b, c) ""
 
 #define SASL_CONTINUE  1
 #define SASL_OK        0


### PR DESCRIPTION
### 🔗 Related Issue

- jam2in/arcus-works#773

### ⌨️ What I did

- isasl에서 sasl_errstring 구현합니다.
- `ENABLE_SASL`, `ENABLE_ISASL` 모두 아닌 경우 dummy macro 선언합니다.
