### PR TITLE
CLEANUP: Move get_auth_data() to sasl_defs.c

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -8374,19 +8374,8 @@ static void process_stats_settings(ADD_STAT add_stats, void *c)
     APPEND_STAT("tcp_backlog", "%d", settings.backlog);
     APPEND_STAT("binding_protocol", "%s",
                 prot_text(settings.binding_protocol));
-#ifdef SASL_ENABLED
-    APPEND_STAT("auth_enabled_sasl", "%s", "yes");
-#else
-    APPEND_STAT("auth_enabled_sasl", "%s", "no");
-#endif
 
-#ifdef ENABLE_ISASL
-    APPEND_STAT("auth_sasl_engine", "%s", "isasl");
-#elif defined(ENABLE_SASL)
-    APPEND_STAT("auth_sasl_engine", "%s", "cyrus");
-#else
-    APPEND_STAT("auth_sasl_engine", "%s", "none");
-#endif
+    APPEND_STAT("auth_sasl_engine", "%s", sasl_engine_string());
     APPEND_STAT("auth_required_sasl", "%s", settings.require_sasl ? "yes" : "no");
     APPEND_STAT("item_size_max", "%llu", settings.item_size_max);
     APPEND_STAT("max_list_size", "%u", settings.max_list_size);

--- a/memcached.c
+++ b/memcached.c
@@ -3209,21 +3209,6 @@ static void init_sasl_conn(conn *c)
     }
 }
 
-static void get_auth_data(const void *cookie, auth_data_t *data)
-{
-    conn *c = (conn*)cookie;
-
-    data->username = "";
-    data->config = "";
-
-    if (c->sasl_conn) {
-        sasl_getprop(c->sasl_conn, SASL_USERNAME, (void*)&data->username);
-#ifdef ENABLE_ISASL
-        sasl_getprop(c->sasl_conn, ISASL_CONFIG, (void*)&data->config);
-#endif
-    }
-}
-
 #ifdef ASCII_SASL
 static void process_sasl_auth_complete(conn *c)
 {
@@ -3256,7 +3241,7 @@ static void process_sasl_auth_complete(conn *c)
     c->ritem = NULL;
 
     auth_data_t data;
-    get_auth_data(c, &data);
+    sasl_get_auth_data(c->sasl_conn, &data);
     c->sasl_username = data.username;
 
     if (result == SASL_OK) {
@@ -4493,7 +4478,7 @@ static void process_bin_complete_sasl_auth(conn *c)
     c->ritem = NULL;
 
     auth_data_t data;
-    get_auth_data(c, &data);
+    sasl_get_auth_data(c->sasl_conn, &data);
     c->sasl_username = data.username;
 
     if (result == SASL_OK) {

--- a/sasl_defs.c
+++ b/sasl_defs.c
@@ -17,6 +17,19 @@ const char *sasl_engine_string(void)
 #endif
 }
 
+void sasl_get_auth_data(sasl_conn_t *conn, auth_data_t *data)
+{
+    data->username = "";
+    data->config = "";
+
+    if (conn) {
+        sasl_getprop(conn, SASL_USERNAME, (void*)&data->username);
+#ifdef ENABLE_ISASL
+        sasl_getprop(conn, ISASL_CONFIG, (void*)&data->config);
+#endif
+    }
+}
+
 #if defined(ENABLE_SASL) && defined(ENABLE_ZK_INTEGRATION)
 static bool use_acl_zookeeper = false;
 #endif

--- a/sasl_defs.c
+++ b/sasl_defs.c
@@ -6,6 +6,17 @@
 #include <string.h>
 #include "sasl_auxprop.h"
 
+const char *sasl_engine_string(void)
+{
+#if defined(ENABLE_SASL)
+    return "cyrus";
+#elif defined (ENABLE_ISASL)
+    return "isasl";
+#else
+    return "none"; // unreachable, maybe
+#endif
+}
+
 #if defined(ENABLE_SASL) && defined(ENABLE_ZK_INTEGRATION)
 static bool use_acl_zookeeper = false;
 #endif

--- a/sasl_defs.h
+++ b/sasl_defs.h
@@ -11,6 +11,7 @@
 int init_sasl(void);
 void shutdown_sasl(void);
 uint16_t arcus_sasl_authz(const char *username);
+const char *sasl_engine_string(void);
 
 #if defined(ENABLE_ZK_INTEGRATION)
 void reload_sasl(void);
@@ -22,6 +23,7 @@ void reload_sasl(void);
 int init_sasl(void);
 void shutdown_sasl(void);
 uint16_t arcus_sasl_authz(const char *username);
+const char *sasl_engine_string(void);
 
 #else /* End of SASL support */
 
@@ -30,6 +32,7 @@ typedef void* sasl_conn_t;
 #define shutdown_sasl()
 #define init_sasl() 0
 #define arcus_sasl_authz(a) 0
+#define sasl_engine_string() "none"
 #define sasl_dispose(x) {}
 #define sasl_server_new(a, b, c, d, e, f, g, h) 1
 #define sasl_listmech(a, b, c, d, e, f, g, h) 1

--- a/sasl_defs.h
+++ b/sasl_defs.h
@@ -8,10 +8,13 @@
 #if defined(ENABLE_SASL)
 
 #include <sasl/sasl.h>
+#include "memcached/types.h"
+
 int init_sasl(void);
 void shutdown_sasl(void);
 uint16_t arcus_sasl_authz(const char *username);
 const char *sasl_engine_string(void);
+void sasl_get_auth_data(sasl_conn_t *conn, auth_data_t *data);
 
 #if defined(ENABLE_ZK_INTEGRATION)
 void reload_sasl(void);
@@ -20,10 +23,13 @@ void reload_sasl(void);
 #elif defined(ENABLE_ISASL)
 
 #include "isasl.h"
+#include "memcached/types.h"
+
 int init_sasl(void);
 void shutdown_sasl(void);
 uint16_t arcus_sasl_authz(const char *username);
 const char *sasl_engine_string(void);
+void sasl_get_auth_data(sasl_conn_t *conn, auth_data_t *data);
 
 #else /* End of SASL support */
 
@@ -33,6 +39,7 @@ typedef void* sasl_conn_t;
 #define init_sasl() 0
 #define arcus_sasl_authz(a) 0
 #define sasl_engine_string() "none"
+#define sasl_get_auth_data(a, b) {}
 #define sasl_dispose(x) {}
 #define sasl_server_new(a, b, c, d, e, f, g, h) 1
 #define sasl_listmech(a, b, c, d, e, f, g, h) 1


### PR DESCRIPTION
### 🔗 Related Issue

- jam2in/arcus-works#774
- jam2in/arcus-works#775

### ⌨️ What I did

2개 commit 입니다.

- sasl 관련 stat을 정리합니다.
- get_auth_data 구현을 sasl_defs.c 파일로 이동합니다.
