### PR TITLE
INTERNAL: Stop removing docker buildx builder to improve Docker image build speed

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -1,7 +1,7 @@
 VERSION ?= develop
 
+.PHONY: build
 build:
 	- docker buildx create --name project-v3-builder
 	docker buildx use project-v3-builder
-	- docker buildx build --push --platform=linux/arm64,linux/amd64 --tag jam2in/arcus-memcached:${VERSION} --progress tty .
-	- docker buildx rm project-v3-builder
+	docker buildx build --push --platform=linux/arm64,linux/amd64 --tag jam2in/arcus-memcached:${VERSION} --progress tty .


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 기존에는 도커 이미지를 빌드할 때마다 builder를 제거했다.
- builder 내에는 빌드 캐시가 포함되기 때문에, builder를 제거하면 이전에 빌드한 캐시가 제거된다.
- 빌드 캐시가 없으면 소스 코드에 변경이 없는 부분도 매번 다시 빌드를 해야 하기 때문에 빌드 속도가 크게 떨어진다.

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 도커 이미지를 빌드할 때 builder를 제거하지 않습니다.
- `.PHONY: build`는 `make build` 명령어 입력 시 소스 코드에 변경사항이 없어도 명령어 입력이 가능하게 해줍니다.
- `.PHONY: build`가 없으면 `make --always-make build` 명령어를 입력해야 합니다.