### PR TITLE
CLEANUP: Wrap SASL-related code with SASL_ENABLED

### DIFF
--- a/sasl_defs.c
+++ b/sasl_defs.c
@@ -1,5 +1,6 @@
 /* -*- Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
 #include "config.h"
+#include "sasl_defs.h"
 #include "memcached.h"
 #include <stdio.h>
 #include <stdlib.h>

--- a/sasl_defs.h
+++ b/sasl_defs.h
@@ -1,10 +1,6 @@
 #ifndef SASL_DEFS_H
 #define SASL_DEFS_H 1
 
-// Longest one I could find was ``9798-U-RSA-SHA1-ENC''
-#define MAX_SASL_MECH_LEN 32
-
-
 #if defined(ENABLE_SASL)
 
 #include <sasl/sasl.h>


### PR DESCRIPTION
### 🔗 Related Issue

- #814 
- #844 
- jam2in/arcus-works#765 
- jam2in/arcus-works#777

### ⌨️ What I did

- `memcached.h`에서 `sasl_defs.h` include하지 않도록 합니다.
- sasl 관련 코드를 SASL_ENABLED 매크로 정의된 경우에만 활성화하도록 합니다.
