### PR TITLE
INTERNAL: Add sasl_def.c to memcached_SOURCES always

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -77,8 +77,9 @@ memcached_SOURCES = \
                     daemon.c \
                     hash.c \
                     hash.h \
-                    memcached.c\
+                    memcached.c \
                     memcached.h \
+                    sasl_defs.c \
                     sasl_defs.h \
                     stats_prefix.c \
                     stats_prefix.h \
@@ -108,12 +109,11 @@ memcached_SOURCES += solaris_priv.c
 endif
 
 if ENABLE_SASL
-memcached_SOURCES += sasl_defs.c
 memcached_LDADD += -lsasl2
 endif
 
 if ENABLE_ISASL
-memcached_SOURCES += sasl_defs.c isasl.c isasl.h
+memcached_SOURCES += isasl.c isasl.h
 endif
 
 if INCLUDE_DEFAULT_ENGINE

--- a/memcached.c
+++ b/memcached.c
@@ -10419,16 +10419,12 @@ static void process_sasl_command(conn *c, token_t *tokens, const size_t ntokens)
 
     if (ntokens == 3 && strcmp(subcommand, "mech") == 0) {
         ascii_list_sasl_mechs(c);
-#if defined(ENABLE_SASL) && defined(ENABLE_ZK_INTEGRATION)
     } else if (ntokens == 3 && strcmp(subcommand, "reload") == 0) {
-        if (!settings.require_sasl) {
-          out_string(c, "NOT_SUPPORTED");
-          return;
+        if (settings.require_sasl && reload_sasl() == 0) {
+            out_string(c, "OK");
+        } else {
+            out_string(c, "NOT_SUPPORTED");
         }
-
-        reload_sasl();
-        out_string(c, "OK");
-#endif
     } else if ((ntokens == 4 || ntokens == 5) && strcmp(subcommand, "auth") == 0) {
         process_ascii_sasl_auth(c, tokens, ntokens);
     } else {

--- a/sasl_defs.c
+++ b/sasl_defs.c
@@ -116,13 +116,6 @@ static int sasl_getopt(void *context __attribute__((unused)),
 
     return SASL_FAIL;
 }
-
-void reload_sasl(void)
-{
-    if (use_acl_zookeeper) {
-        arcus_auxprop_wakeup();
-    }
-}
 #endif
 
 static int sasl_log(void *context, int level, const char *message)
@@ -244,5 +237,16 @@ int init_sasl(void)
 void shutdown_sasl(void)
 {
     sasl_done();
+}
+
+int reload_sasl(void)
+{
+#if defined(ENABLE_SASL) && defined(ENABLE_ZK_INTEGRATION)
+    if (use_acl_zookeeper) {
+        arcus_auxprop_wakeup();
+        return 0;
+    }
+#endif
+    return -1;
 }
 #endif

--- a/sasl_defs.c
+++ b/sasl_defs.c
@@ -18,6 +18,7 @@ const char *sasl_engine_string(void)
 #endif
 }
 
+#if defined(ENABLE_SASL) || defined(ENABLE_ISASL)
 void sasl_get_auth_data(sasl_conn_t *conn, auth_data_t *data)
 {
     data->username = "";
@@ -30,6 +31,7 @@ void sasl_get_auth_data(sasl_conn_t *conn, auth_data_t *data)
 #endif
     }
 }
+#endif
 
 #if defined(ENABLE_SASL) && defined(ENABLE_ZK_INTEGRATION)
 static bool use_acl_zookeeper = false;
@@ -190,6 +192,7 @@ uint16_t arcus_sasl_authz(const char *username)
     return ret;
 }
 
+#if defined(ENABLE_SASL) || defined(ENABLE_ISASL)
 static sasl_callback_t sasl_callbacks[5];
 
 int init_sasl(void)
@@ -242,3 +245,4 @@ void shutdown_sasl(void)
 {
     sasl_done();
 }
+#endif

--- a/sasl_defs.h
+++ b/sasl_defs.h
@@ -1,6 +1,10 @@
 #ifndef SASL_DEFS_H
 #define SASL_DEFS_H 1
 
+#include <stdint.h>
+const char *sasl_engine_string(void);
+uint16_t arcus_sasl_authz(const char *username);
+
 #if defined(ENABLE_SASL)
 
 #include <sasl/sasl.h>
@@ -8,8 +12,6 @@
 
 int init_sasl(void);
 void shutdown_sasl(void);
-uint16_t arcus_sasl_authz(const char *username);
-const char *sasl_engine_string(void);
 void sasl_get_auth_data(sasl_conn_t *conn, auth_data_t *data);
 
 #if defined(ENABLE_ZK_INTEGRATION)
@@ -23,31 +25,8 @@ void reload_sasl(void);
 
 int init_sasl(void);
 void shutdown_sasl(void);
-uint16_t arcus_sasl_authz(const char *username);
-const char *sasl_engine_string(void);
 void sasl_get_auth_data(sasl_conn_t *conn, auth_data_t *data);
 
-#else /* End of SASL support */
-
-typedef void* sasl_conn_t;
-
-#define shutdown_sasl()
-#define init_sasl() 0
-#define arcus_sasl_authz(a) 0
-#define sasl_engine_string() "none"
-#define sasl_get_auth_data(a, b) {}
-#define sasl_dispose(x) {}
-#define sasl_server_new(a, b, c, d, e, f, g, h) 1
-#define sasl_listmech(a, b, c, d, e, f, g, h) 1
-#define sasl_server_start(a, b, c, d, e, f) 1
-#define sasl_server_step(a, b, c, d, e) 1
-#define sasl_getprop(a, b, c) {}
-#define sasl_errstring(a, b, c) ""
-
-#define SASL_CONTINUE  1
-#define SASL_OK        0
-#define SASL_FAIL     -1
-
-#endif /* sasl compat */
+#endif /* End of SASL support */
 
 #endif /* SASL_DEFS_H */

--- a/sasl_defs.h
+++ b/sasl_defs.h
@@ -12,11 +12,9 @@ uint16_t arcus_sasl_authz(const char *username);
 
 int init_sasl(void);
 void shutdown_sasl(void);
+int reload_sasl(void);
 void sasl_get_auth_data(sasl_conn_t *conn, auth_data_t *data);
 
-#if defined(ENABLE_ZK_INTEGRATION)
-void reload_sasl(void);
-#endif
 
 #elif defined(ENABLE_ISASL)
 
@@ -25,6 +23,7 @@ void reload_sasl(void);
 
 int init_sasl(void);
 void shutdown_sasl(void);
+int reload_sasl(void);
 void sasl_get_auth_data(sasl_conn_t *conn, auth_data_t *data);
 
 #endif /* End of SASL support */


### PR DESCRIPTION
### 🔗 Related Issue

- jam2in/arcus-works#765
- jam2in/arcus-works#778

### ⌨️ What I did

- sasl_defs.c가 항상 빌드 대상에 포함되도록 변경
- sasl disabled 상태에서 호출되지 않는 코드 제거
- sasl_reload 구현 정리
