### PR TITLE
CLEANUP: Remove unused authenticated field from conn

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -679,10 +679,8 @@ conn *conn_new(const int sfd, STATE_FUNC init_state,
     c->sasl_username = "";
     c->sasl_started = false;
     if (settings.require_sasl) {
-        c->authenticated = false;
         c->authorized = AUTHZ_NONE;
     } else {
-        c->authenticated = true;
         c->authorized = AUTHZ_ALL;
     }
     c->sasl_auth_data = NULL;
@@ -3204,7 +3202,7 @@ static void init_sasl_conn(conn *c)
 {
     assert(c);
 
-    c->authenticated = false;
+    c->authorized = AUTHZ_NONE;
 
     if (!c->sasl_conn) {
         int result=sasl_server_new("memcached",
@@ -3256,9 +3254,7 @@ static void process_sasl_auth_complete(conn *c)
 
     if (result == SASL_OK) {
         c->authorized = arcus_sasl_authz(c->sasl_username);
-        if (c->authorized != AUTHZ_FAIL) {
-            c->authenticated = true;
-        } else {
+        if (c->authorized == AUTHZ_FAIL) {
             result = SASL_FAIL;
             if (settings.verbose) {
                 mc_logger->log(EXTENSION_LOG_WARNING, c,
@@ -4520,9 +4516,7 @@ static void process_bin_complete_sasl_auth(conn *c)
 
     if (result == SASL_OK) {
         c->authorized = arcus_sasl_authz(c->sasl_username);
-        if (c->authorized != AUTHZ_FAIL) {
-            c->authenticated = true;
-        } else {
+        if (c->authorized == AUTHZ_FAIL) {
             result = SASL_FAIL;
             if (settings.verbose) {
                 mc_logger->log(EXTENSION_LOG_WARNING, c,

--- a/memcached.h
+++ b/memcached.h
@@ -283,7 +283,6 @@ struct conn {
     void *sasl_conn;
     const char *sasl_username;
     bool sasl_started;
-    bool authenticated;
     uint16_t authorized;
     char sasl_mech[MAX_SASL_MECH_LEN+1];
     uint32_t sasl_auth_data_len;


### PR DESCRIPTION
### 🔗 Related Issue

- #882 

### ⌨️ What I did

- 사용하지 않는 authenticated 필드를 제거합니다.
- sasl mech, sasl auth 명령 수행 시 기존 부여된 권한을 초기화합니다.
