### PR TITLE
INTERNAL: Use logger in init_sasl for acl_refresh_thread

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -9647,7 +9647,7 @@ static pthread_mutex_t require_sasl_lock = PTHREAD_MUTEX_INITIALIZER;
 static void* init_sasl_thread(void *arg)
 {
     pthread_mutex_lock(&require_sasl_lock);
-    if (settings.require_sasl == false && init_sasl() == 0) {
+    if (settings.require_sasl == false && init_sasl(mc_logger) == 0) {
         settings.require_sasl = true;
     }
     pthread_mutex_unlock(&require_sasl_lock);
@@ -16310,7 +16310,7 @@ int main (int argc, char **argv)
     }
 
 #ifdef SASL_ENABLED
-    if (settings.require_sasl && init_sasl() != 0) {
+    if (settings.require_sasl && init_sasl(mc_logger) != 0) {
         exit(EXIT_FAILURE);
     }
 #endif

--- a/sasl_auxprop.h
+++ b/sasl_auxprop.h
@@ -4,8 +4,12 @@
 #ifdef ENABLE_SASL
 #ifdef ENABLE_ZK_INTEGRATION
 
+#include "memcached/extension.h"
+
 #include <sasl/sasl.h>
 #include <sasl/saslplug.h>
+
+void arcus_auxprop_init_logger(EXTENSION_LOGGER_DESCRIPTOR *logger);
 
 int arcus_auxprop_plug_init(const sasl_utils_t *utils,
                             int max_version,

--- a/sasl_defs.c
+++ b/sasl_defs.c
@@ -188,7 +188,7 @@ uint16_t arcus_sasl_authz(const char *username)
 #if defined(ENABLE_SASL) || defined(ENABLE_ISASL)
 static sasl_callback_t sasl_callbacks[5];
 
-int init_sasl(void)
+int init_sasl(EXTENSION_LOGGER_DESCRIPTOR *logger)
 {
     int i = 0;
 #ifdef ENABLE_SASL
@@ -221,6 +221,7 @@ int init_sasl(void)
 
 #if defined(ENABLE_SASL) && defined(ENABLE_ZK_INTEGRATION)
     if (use_acl_zookeeper) {
+        arcus_auxprop_init_logger(logger);
         if (sasl_auxprop_add_plugin("arcus", &arcus_auxprop_plug_init) != SASL_OK) {
             mc_logger->log(EXTENSION_LOG_WARNING, NULL, "Error to SASL auxprop plugin.\n");
             return -1;

--- a/sasl_defs.h
+++ b/sasl_defs.h
@@ -8,9 +8,10 @@ uint16_t arcus_sasl_authz(const char *username);
 #if defined(ENABLE_SASL)
 
 #include <sasl/sasl.h>
+#include "memcached/extension.h"
 #include "memcached/types.h"
 
-int init_sasl(void);
+int init_sasl(EXTENSION_LOGGER_DESCRIPTOR *logger);
 void shutdown_sasl(void);
 int reload_sasl(void);
 void sasl_get_auth_data(sasl_conn_t *conn, auth_data_t *data);
@@ -19,9 +20,10 @@ void sasl_get_auth_data(sasl_conn_t *conn, auth_data_t *data);
 #elif defined(ENABLE_ISASL)
 
 #include "isasl.h"
+#include "memcached/extension.h"
 #include "memcached/types.h"
 
-int init_sasl(void);
+int init_sasl(EXTENSION_LOGGER_DESCRIPTOR *logger);
 void shutdown_sasl(void);
 int reload_sasl(void);
 void sasl_get_auth_data(sasl_conn_t *conn, auth_data_t *data);


### PR DESCRIPTION
### 🔗 Related Issue

- #850
- jam2in/arcus-works#781

### ⌨️ What I did

- acl 백그라운드 스레드에서 로그 기록하기 위해 logger 사용합니다.
- `arcus_auxprop_init_logger(logger)` 호출한 뒤
`sasl_auxprop_add_plugin("arcus", &arcus_auxprop_plug_init)` 호출해야 합니다.
- logger 사용하여 로그 기록합니다.
