### PR TITLE
INTERNAL: Merge no matching command into unknown command

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -10095,7 +10095,7 @@ static void process_extension_command(conn *c, token_t *tokens, size_t ntokens)
         }
     }
     if (cmd == NULL) {
-        out_string(c, "ERROR no matching command");
+        out_string(c, "ERROR unknown command");
         return;
     }
 #ifdef SASL_ENABLED
@@ -13975,7 +13975,7 @@ static void process_command_ascii(conn *c, char *command, int cmdlen)
     {
         process_shutdown_command(c, tokens, ntokens);
     }
-    else /* no matching command */
+    else /* unknown command */
     {
         if (settings.extensions.ascii != NULL) {
             process_extension_command(c, tokens, ntokens);

--- a/t/ascii_ext_protocol.t
+++ b/t/ascii_ext_protocol.t
@@ -174,13 +174,13 @@ mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "set kvkey 0 0 10"; $val = "222222222222";
 $rst =
 "CLIENT_ERROR bad data chunk
-ERROR no matching command";
+ERROR unknown command";
 mem_cmd_is($sock, $cmd, $val, $rst);
 
 $cmd = "set kvkey 0 10"; $val = "0000000000";
 $rst =
-"ERROR no matching command
-ERROR no matching command";
+"ERROR unknown command
+ERROR unknown command";
 mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "set kvkey 0 0 10"; $val = "0000000000"; $rst = "STORED";
 mem_cmd_is($sock, $cmd, $val, $rst);
@@ -188,8 +188,8 @@ $cmd = "set kvkey 0 0 10 10"; $val = "0000000000"; $rst = "STORED";
 mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "set kvkey 0 0 10 10 10"; $val = "0000000000";
 $rst =
-"ERROR no matching command
-ERROR no matching command";
+"ERROR unknown command
+ERROR unknown command";
 mem_cmd_is($sock, $cmd, $val, $rst);
 
 $cmd = "bop insert bkey1 10 5 create 11 0 0"; $val = "datum"; $rst = "CREATED_STORED";
@@ -205,30 +205,30 @@ mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 17 5"; $val = "7777777";
 $rst =
 "CLIENT_ERROR bad data chunk
-ERROR no matching command";
+ERROR unknown command";
 mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 18 5"; $val = "88888888";
 $rst =
 "CLIENT_ERROR bad data chunk
-ERROR no matching command";
+ERROR unknown command";
 mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 19 5"; $val = "999999999";
 $rst =
 "CLIENT_ERROR bad data chunk
-ERROR no matching command";
+ERROR unknown command";
 mem_cmd_is($sock, $cmd, $val, $rst);
 
 $cmd = "bop insert bkey1 21"; $val = "0000000000";
 $rst =
 "CLIENT_ERROR bad command line format
-ERROR no matching command";
+ERROR unknown command";
 mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 22 10"; $val = "0000000000"; $rst = "STORED";
 mem_cmd_is($sock, $cmd, $val, $rst);
 $cmd = "bop insert bkey1 23 10 10"; $val = "0000000000";
 $rst =
 "CLIENT_ERROR bad command line format
-ERROR no matching command";
+ERROR unknown command";
 mem_cmd_is($sock, $cmd, $val, $rst);
 
 # Finalize


### PR DESCRIPTION
### 🔗 Related Issue

- https://github.com/jam2in/arcus-works/issues/754#issuecomment-3354873404

### ⌨️ What I did

- 존재하지 않는 명령의 에러 응답으로 `ERROR no matching command`와 `ERROR unknown command` 사용하던 것을
`ERROR unknown command`로 통합합니다.
