### PR TITLE
CLEANUP: Add null terminator to authz string

### DIFF
--- a/sasl_auxprop.c
+++ b/sasl_auxprop.c
@@ -22,6 +22,7 @@
 static EXTENSION_LOGGER_DESCRIPTOR *mc_logger = NULL;
 
 static const char *ensemble_list;
+// 16: buffer for "/arcus_acl", "/" separator, "\0" terminator, etc.
 static char group_zpath[16 + GROUP_MAXLEN];
 
 struct sasl_entry {
@@ -241,8 +242,9 @@ static int _arcus_getdata(const char *user,
             entry = entry->next;
         }
 
-        if (entry && entry->value_len <= max_out) {
+        if (entry && entry->value_len < max_out) {
             memcpy(out, entry->value, entry->value_len);
+            out[entry->value_len] = '\0';
             if (out_len) *out_len = entry->value_len;
             ret = SASL_OK;
         }


### PR DESCRIPTION
### 🔗 Related Issue

- #864

### ⌨️ What I did

- 권한 문자열 마지막에 null문자 포함하지 않아 마지막 토큰이 제대로 인식되지 않던 문제를 수정합니다.
