### PR TITLE
INTERNAL: Add PREFIX_MAX_LENGTH validation check when update item

### DIFF
--- a/engines/default/prefix.c
+++ b/engines/default/prefix.c
@@ -341,6 +341,10 @@ ENGINE_ERROR_CODE prefix_link(hash_item *it, const uint32_t item_size, bool *int
     // prefix discovering: we don't even know prefix existence at this time
     while ((token = memchr(key+i+1, config->prefix_delimiter, nkey-i-1)) != NULL) {
         i = token - key;
+        if (i > PREFIX_MAX_LENGTH) {
+            return ENGINE_PREFIX_ENAME;
+        }
+
         prefix_list[prefix_depth].nprefix = i;
 
         prefix_depth++;

--- a/include/memcached/types.h
+++ b/include/memcached/types.h
@@ -41,6 +41,9 @@ struct iovec {
 #define JHPARK_OLD_SMGET_INTERFACE
 #define MULTI_NOTIFY_IO_COMPLETE
 
+/** Maximum length of a prefix */
+#define PREFIX_MAX_LENGTH 250
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/memcached.h
+++ b/memcached.h
@@ -46,9 +46,6 @@
 //#define KEY_MAX_LENGTH 250
 #define KEY_MAX_LENGTH 16000 /* long key support */
 
-/** Maximum length of a prefix */
-#define PREFIX_MAX_LENGTH 250
-
 /** Size of an incr buf. */
 #define INCR_MAX_STORAGE_LEN 24
 


### PR DESCRIPTION
### 🔗 Related Issue
- jam2in/arcus-works#786

### ⌨️ What I did
- prefix 추가 시 prefix의 길이를 PREFIX_MAX_LENGTH와 비교하는 로직을 추가했습니다.