### PR TITLE
FEATURE: Add hard limit to max_stats_prefixes

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -9505,6 +9505,10 @@ static void process_config_maxstatsprefixes_command(conn *c, token_t *tokens, co
         sprintf(buf, "max_stats_prefixes %u\r\nEND", settings.max_stats_prefixes);
         out_string(c, buf);
     } else if (ntokens == 4 && safe_strtoul(config_val, &new_max_stats_prefixes)) {
+        if (new_max_stats_prefixes > STATS_PREFIXES_HARD_LIMIT) {
+            out_string(c, "CLIENT_ERROR cannot change the max_stats_prefixes over the hard limit(100)");
+            return;
+        }
         LOCK_SETTING();
         settings.max_stats_prefixes = new_max_stats_prefixes;
         UNLOCK_SETTING();

--- a/memcached.h
+++ b/memcached.h
@@ -207,6 +207,7 @@ union mc_engine {
     ENGINE_HANDLE_V1 *v1;
 };
 
+#define STATS_PREFIXES_HARD_LIMIT 100
 #define MAX_VERBOSITY_LEVEL 2
 
 /* When adding a setting, be sure to update process_stat_settings */


### PR DESCRIPTION
### 🔗 Related Issue
- [max_stats_prefixes 최대 설정 가능한 값을 100으로 규정](https://github.com/naver/arcus-memcached/pull/878#discussion_r2446592188)

### ⌨️ What I did
- config 명령으로 설정 가능한 max_stats_prefixes의 최댓값을 100으로 규정했습니다.
- config 명령과 추상화 단계를 맞춰 memcached.h에 최댓값을 매크로로 정의했습니다.