### PR TITLE
FEATURE: Enhance 'stats' command with new server/engine metrics

### DIFF
--- a/docs/ascii-protocol/ch13-command-administration.md
+++ b/docs/ascii-protocol/ch13-command-administration.md
@@ -144,6 +144,9 @@ STAT quit_connections 0
 STAT reject_connections 0
 STAT total_connections 3
 STAT connection_structures 3
+STAT accepting_connections 1
+STAT listen_disabled_connections 0
+STAT time_in_listen_disabled_us 0
 STAT cmd_get 0
 STAT cmd_set 0
 STAT cmd_incr 0
@@ -278,6 +281,8 @@ STAT sticky_bytes 0
 STAT bytes 0
 STAT sticky_limit 0
 STAT engine_maxbytes 8589934592
+STAT hash_bytes 524288
+STAT hash_is_expanding 0
 END
 ```
 
@@ -292,41 +297,46 @@ END
 
 다음은 그 외의 개별 통계이다.
 
-| stats                 | 설명                                                         |
-| --------------------- | ------------------------------------------------------------ |
-| pid                   | 캐시 노드의 프로세스 id                                      |
-| uptime                | 캐시 서버를 구동한 시간(초)                                  |
-| time                  | 현재 시간 (unix time)                                        |
-| version               | 현재 arcus-memcached 버전                                    |
-| libevent              | 사용중인 libevent 버전                                       |
-| pointer_size          | 포인터의 크기(bit 단위)                                      |
-| rusage_user           | 프로세스의 누적 user time.                                   |
-| rusage_system         | 프로세스의 누적 system time.                                 |
-| daemon_connections    | 서버가 사용하는 daemon connection 개수                       |
-| curr_connections      | 현재 열려있는 connection 개수                                |
-| quit_connections      | 클라이언트가 quit 명령을 이용해 연결을 끊은 횟수             |
-| reject_connections    | 클라이언트와의 연결을 거절한 횟수                            |
-| total_connections     | 서버 구동 이후 누적 connection 총합                          |
-| connection_structures | 서버가 할당한 connection 구조체 개수                         |
-| cmd_auth              | sasl 인증 횟수                                               |
-| auth_errors           | sasl 인증 실패 횟수                                          |
-| cas_badval            | 키는 찾았으나 cas 값이 맞지 않은 요청의 횟수                 |
-| bytes_read            | 서버가 네트워크에서 읽은 데이터 용량 총합(bytes)             |
-| bytes_written         | 서버가 네트워크에 쓴 데이터 용량 총합(bytes)                 |
-| limit_maxbytes        | 서버에 허용된 최대 메모리 용량(bytes)                        |
-| threads               | worker thread 개수                                           |
-| conn_yields           | 이벤트당 최대 요청 수의 제한                                 |
-| curr_prefixes         | 현재 저장된 prefix 개수                                      |
-| reclaimed             | expired된 아이템의 공간을 사용해 새로운 아이템을 저장한 횟수 |
-| evictions             | eviction 횟수                                                |
-| outofmemorys          | outofmemory (메모리가 부족한 상황에서 eviction이 허용되지 않거나 실패) 발생 횟수 |
-| sticky_items          | 현재 sticky 아이템의 개수                                    |
-| curr_items            | 현재 서버에 저장된 아이템의 개수                             |
-| total_items           | 서버 구동 후 저장한 아이템의 누적 개수                       |
-| sticky_bytes          | sticky 아이템이 차지하는 메모리 용량(bytes)                  |
-| bytes                 | 현재 사용중인 메모리 용량(bytes)                             |
-| sticky_limit          | sticky item을 저장할 수 있는 최대 메모리 용량(bytes)         |
-| engine_maxbytes       | 엔진에 허용된 최대 저장 용량                                 |
+| stats                   | 설명                                                      |
+|-------------------------|---------------------------------------------------------|
+| pid                     | 캐시 노드의 프로세스 id                                          |
+| uptime                  | 캐시 서버를 구동한 시간(초)                                        |
+| time                    | 현재 시간 (unix time)                                       |
+| version                 | 현재 arcus-memcached 버전                                   |
+| libevent                | 사용중인 libevent 버전                                        |
+| pointer_size            | 포인터의 크기(bit 단위)                                         |
+| rusage_user             | 프로세스의 누적 user time.                                     |
+| rusage_system           | 프로세스의 누적 system time.                                   |
+| daemon_connections      | 서버가 사용하는 daemon connection 개수                           |
+| curr_connections        | 현재 열려있는 connection 개수                                   |
+| quit_connections        | 클라이언트가 quit 명령을 이용해 연결을 끊은 횟수                           |
+| reject_connections      | 클라이언트와의 연결을 거절한 횟수                                      |
+| total_connections       | 서버 구동 이후 누적 connection 총합                               |
+| connection_structures   | 서버가 할당한 connection 구조체 개수                               |
+| accepting_conns         | 연결 가능 상태                                                |
+| listen_disabled_num     | 새로운 연결이 거부되었던 수                                         |
+| time_in_listen_disabled | 새로운 연결을 맺지 못한 시간                                        |
+| cmd_auth                | sasl 인증 횟수                                              |
+| auth_errors             | sasl 인증 실패 횟수                                           |
+| cas_badval              | 키는 찾았으나 cas 값이 맞지 않은 요청의 횟수                             |
+| bytes_read              | 서버가 네트워크에서 읽은 데이터 용량 총합(bytes)                          |
+| bytes_written           | 서버가 네트워크에 쓴 데이터 용량 총합(bytes)                            |
+| limit_maxbytes          | 서버에 허용된 최대 메모리 용량(bytes)                                |
+| threads                 | worker thread 개수                                        |
+| conn_yields             | 이벤트당 최대 요청 수의 제한                                        |
+| curr_prefixes           | 현재 저장된 prefix 개수                                        |
+| reclaimed               | expired된 아이템의 공간을 사용해 새로운 아이템을 저장한 횟수                   |
+| evictions               | eviction 횟수                                             |
+| outofmemorys            | outofmemory (메모리가 부족한 상황에서 eviction이 허용되지 않거나 실패) 발생 횟수 |
+| sticky_items            | 현재 sticky 아이템의 개수                                       |
+| curr_items              | 현재 서버에 저장된 아이템의 개수                                      |
+| total_items             | 서버 구동 후 저장한 아이템의 누적 개수                                  |
+| sticky_bytes            | sticky 아이템이 차지하는 메모리 용량(bytes)                          |
+| bytes                   | 현재 사용중인 메모리 용량(bytes)                                   |
+| sticky_limit            | sticky item을 저장할 수 있는 최대 메모리 용량(bytes)                  |
+| engine_maxbytes         | 엔진에 허용된 최대 저장 용량                                        |
+| hash_bytes              | 해시 테이블이 사용중인 메모리 용량(bytes)                              |
+| hash_is_expanding       | 해시 테이블의 확장 여부                                           |
 
 ### Settings 통계 정보
 

--- a/engines/default/assoc.c
+++ b/engines/default/assoc.c
@@ -255,6 +255,17 @@ static void assoc_expand(void)
             assocp->hashsize * assocp->rootsize / 2, assocp->hashsize * assocp->rootsize);
 }
 
+void assoc_stats(ADD_STAT add_stat, const void *cookie)
+{
+    char val[128];
+    int len;
+
+    len = sprintf(val, "%"PRIu64, (uint64_t)assocp->hashsize * (uint64_t)assocp->rootsize * sizeof(hash_item *));
+    add_stat("hash_bytes", 10, val, len, cookie);
+    len = sprintf(val, "%"PRIu64, (uint64_t)assocp->expanding);
+    add_stat("hash_is_expanding", 17, val, len, cookie);
+}
+
 /* Note: this isn't an assoc_update.  The key must not already exist to call this */
 int assoc_insert(hash_item *it, uint32_t hash)
 {

--- a/engines/default/assoc.h
+++ b/engines/default/assoc.h
@@ -71,6 +71,8 @@ int               assoc_insert(hash_item *item, uint32_t hash);
 void              assoc_replace(hash_item *old_it, hash_item *new_it);
 void              assoc_delete(const char *key, const uint32_t nkey, uint32_t hash);
 
+void              assoc_stats(ADD_STAT add_stat, const void *c);
+
 /* assoc scan functions */
 void              assoc_scan_init(struct assoc_scan *scan);
 int               assoc_scan_next(struct assoc_scan *scan, hash_item **item_array,
@@ -80,5 +82,4 @@ int               assoc_scan_direct(const char *cursor, int req_count, hash_item
 #endif
 bool              assoc_scan_in_visited_area(struct assoc_scan *scan, hash_item *it);
 void              assoc_scan_final(struct assoc_scan *scan);
-
 #endif

--- a/engines/default/items.c
+++ b/engines/default/items.c
@@ -628,6 +628,7 @@ void item_stats_global(ADD_STAT add_stat, const void *cookie)
     add_stat("curr_prefixes", 13, val, len, cookie);
 
     do_item_stat_get(add_stat, cookie);
+    assoc_stats(add_stat, cookie);
     UNLOCK_CACHE();
 }
 

--- a/memcached.c
+++ b/memcached.c
@@ -291,6 +291,9 @@ static void stats_init(void)
     mc_stats.rejected_conns = 0;
     mc_stats.quit_conns = 0;
     mc_stats.curr_conns = mc_stats.total_conns = mc_stats.conn_structs = 0;
+    mc_stats.accepting_conns = true;
+    mc_stats.listen_disabled_num = 0;
+    mc_stats.time_in_listen_disabled_us = 0;
 
     /* make the time we started always be 2 seconds before we really
        did, so time(0) - time.started is never zero.  if so, things
@@ -306,6 +309,8 @@ static void stats_reset(const void *cookie)
     mc_stats.rejected_conns = 0;
     mc_stats.quit_conns = 0;
     mc_stats.total_conns = 0;
+    mc_stats.listen_disabled_num = 0;
+    mc_stats.time_in_listen_disabled_us = 0;
     stats_prefix_clear();
     UNLOCK_STATS();
     threadlocal_stats_reset(default_thread_stats);
@@ -8354,6 +8359,9 @@ static void server_stats(ADD_STAT add_stats, conn *c, bool aggregate)
     APPEND_STAT("reject_connections", "%u", mc_stats.rejected_conns);
     APPEND_STAT("total_connections", "%u", mc_stats.total_conns);
     APPEND_STAT("connection_structures", "%u", mc_stats.conn_structs);
+    APPEND_STAT("accepting_connections", "%u", mc_stats.accepting_conns)
+    APPEND_STAT("listen_disabled_connections", "%"PRIu64, mc_stats.listen_disabled_num);
+    APPEND_STAT("time_in_listen_disabled_us", "%"PRIu64, mc_stats.time_in_listen_disabled_us);
     APPEND_STAT("cmd_get", "%"PRIu64, thread_stats.cmd_get);
     APPEND_STAT("cmd_set", "%"PRIu64, thread_stats.cmd_set);
     APPEND_STAT("cmd_incr", "%"PRIu64, thread_stats.cmd_incr);
@@ -14297,7 +14305,9 @@ bool conn_listening(conn *c)
 {
     int sfd, flags = 1;
     struct sockaddr_storage addr;
+    struct timeval tv;
     socklen_t addrlen = sizeof(addr);
+    static uint64_t listen_disabled_start_time = 0;
 
     if ((sfd = accept(c->sfd, (struct sockaddr *)&addr, &addrlen)) == -1) {
         if (errno == EMFILE) {
@@ -14305,6 +14315,14 @@ bool conn_listening(conn *c)
                 mc_logger->log(EXTENSION_LOG_INFO, c,
                                "Too many open connections\n");
             }
+            LOCK_STATS();
+            mc_stats.listen_disabled_num++;
+            if (mc_stats.accepting_conns) {
+                mc_stats.accepting_conns = false;
+                gettimeofday(&tv, NULL);
+                listen_disabled_start_time = (uint64_t)tv.tv_sec * 1000000 + tv.tv_usec;
+            }
+            UNLOCK_STATS();
         } else if (errno != EAGAIN && errno != EWOULDBLOCK) {
             mc_logger->log(EXTENSION_LOG_WARNING, c,
                     "Failed to accept new client: %s\n", strerror(errno));
@@ -14315,6 +14333,12 @@ bool conn_listening(conn *c)
 
     LOCK_STATS();
     int curr_conns = mc_stats.curr_conns++;
+    if (!mc_stats.accepting_conns) {
+        mc_stats.accepting_conns = true;
+        gettimeofday(&tv, NULL);
+        uint64_t duration = (uint64_t)tv.tv_sec * 1000000 + tv.tv_usec - listen_disabled_start_time;
+        mc_stats.time_in_listen_disabled_us += duration;
+    }
     UNLOCK_STATS();
 
     if (curr_conns >= settings.maxconns) {

--- a/memcached.h
+++ b/memcached.h
@@ -200,6 +200,9 @@ struct mc_stats {
     unsigned int  rejected_conns; /* number of times I reject a client */
     unsigned int  total_conns;
     unsigned int  conn_structs;
+    bool          accepting_conns;
+    unsigned int  listen_disabled_num;
+    unsigned int  time_in_listen_disabled_us;
 };
 
 union mc_engine {


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/628#issuecomment-2567437895

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- `stats`명령의 정보를 보강하고 모니터링에 추가적인 기능을 제공하고자 아래 5가지의 스탯 정보를 추가로 제공합니다. 각 스탯은 표준 memcached `stats` 명령, Redis `INFO` 명령을 참고했습니다.

**엔진 레벨 스탯**
- `hash_bytes`: 해시 테이블이 현재 사용중인 총 메모리 바이트 크기
- `hash_is_expanding`: 해시 테이블이 현재 확장 중인지 여부
- `hash_power_level`: 현재 해시 테이블 크기 레벨(배수)
- `store_too_large`: 아이템 크기가 최대 제한(`-I`옵션)을 초과하여 거부된 총 횟수
- `expired_items`: TTL이 만료된 이후 `get`시점에 만료되었다고 판단된 아이템의 총 횟수
- `flush_items`: `flush` 명령으로 무효화된 후, `get` 시점에서 만료되었다고 판단된 아이템의 총 횟수

**서버 레벨 스탯**
- `accepting_conns`: 서버가 연결 리스닝 시점에서 `EMFILE` 에러로 인해 리스닝이 중단되지 않고, 현재 새로운 연결을 수락할 수 있는 상태인지의 여부
- `listen_disabled_num`: 새로운 연결이 거부되었던 수
- `time_in_listen_disabled`: 새로운 연결이 거부되고 다시 가능해질 때까지의 총 시간합
- ~`read_buf_bytes`: 모든 connection에서 사용하는 read 버퍼 총 메모리 바이트.~

(`malloc_fails` 스탯은 코드 전반의 광범위한 수정때문에 이번 PR 범위에서는 제외하는 것으로 논의되었습니다.)