### PR TITLE
INTERNAL: Randomize ACL refresh schedule and reduce period to 12 hours

### DIFF
--- a/docs/administration/sasl.md
+++ b/docs/administration/sasl.md
@@ -110,7 +110,7 @@ ARCUS_ACL_ZOOKEEPER="127.0.0.1:2181" ARCUS_ACL_GROUP="prod"\
 이 경우 `ARCUS_ACL_ZOOKEEPER`, `ARCUS_ACL_GROUP` 환경변수는 설정된 상태여야 정상 동작한다.
 반대로, SASL 인증을 동적으로 비활성화하는 기능은 제공하지 않는다.
 
-ARCUS Cache Server는 ZooKeeper에 저장된 인증/권한 정보를 가져와서 캐싱하여 사용하며, 24시간 주기로 갱신한다.
+ARCUS Cache Server는 ZooKeeper에 저장된 인증/권한 정보를 가져와서 캐싱하여 사용하며, 마지막 캐싱 시점으로부터 12-24시간 사이 랜덤한 시간이 지난 뒤 캐싱 작업을 재수행한다.
 따라서 ACL 사용자 정보를 추가/수정/제거하는 경우 캐시에 반영되어 사용되기까지 최대 24시간이 소요될 수 있다.
 필요 시 빠른 반영을 위해 `reload auth` 명령을 제공한다.
 

--- a/sasl_auxprop.c
+++ b/sasl_auxprop.c
@@ -13,7 +13,7 @@
 
 /* cache table's size */
 #define SASL_TABLE_SIZE 16
-#define REFRESH_PERIOD 24 * 60 * 60 /* sec */
+#define REFRESH_PERIOD 12 * 60 * 60 /* sec */
 #define GROUP_MAXLEN 32
 #define USERNAME_MAXLEN 32
 #define PROPNAME_MAXLEN 32
@@ -176,13 +176,14 @@ static void* acl_refresh_thread(void *arg)
 
     clock_gettime(CLOCK_REALTIME, &ts);
     srand(ts.tv_sec);
-    ts.tv_sec += rand() % REFRESH_PERIOD;
 
     mc_logger->log(EXTENSION_LOG_INFO, NULL, "ACL refresh thread is running.\n");
 
     acl_thread_running = true;
     while (!acl_thread_stopreq) {
-        ts.tv_sec += REFRESH_PERIOD;
+        clock_gettime(CLOCK_REALTIME, &ts);
+        ts.tv_sec += REFRESH_PERIOD + (rand() % REFRESH_PERIOD);
+
         pthread_mutex_lock(&acl_thread_lock);
         if (!acl_thread_stopreq) {
             pthread_cond_timedwait(&acl_thread_cond, &acl_thread_lock, &ts);


### PR DESCRIPTION
### 🔗 Related Issue

- https://github.com/naver/arcus-memcached/pull/921#discussion_r2469411259

### ⌨️ What I did

- 매 갱신마다 다음 갱신 시점을 랜덤하게 결정하도록 변경합니다.
- 12시간-24시간 사이 값을 사용합니다.
