### PR TITLE
REFACTOR: Seperate engine config string(old_opts) generation from getopt

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -15825,7 +15825,7 @@ int main (int argc, char **argv)
     int c;
     bool lock_memory = false;
     bool do_daemonize = false;
-    //bool preallocate = false;
+    bool preallocate = false;
     int maxcore = 0;
     char *username = NULL;
     char *pid_file = NULL;
@@ -15933,12 +15933,9 @@ int main (int argc, char **argv)
                     "The value of memory limit must be greater than 0.\n");
                 return 1;
             }
-            old_opts += sprintf(old_opts, "cache_size=%llu;",
-                                 (unsigned long long)settings.maxbytes);
             break;
         case 'M':
             settings.evict_to_free = 0;
-            old_opts += sprintf(old_opts, "eviction=false;");
             break;
 #ifdef ENABLE_STICKY_ITEM
         case 'g':
@@ -15949,8 +15946,6 @@ int main (int argc, char **argv)
                     "The value of sticky(gummed) memory limit must be greater than 0.\n");
                 return 1;
             }
-            old_opts += sprintf(old_opts, "sticky_limit=%llu;",
-                                (unsigned long long)settings.sticky_limit);
             break;
 #endif
         case 'c':
@@ -15999,7 +15994,6 @@ int main (int argc, char **argv)
                         "Factor must be greater than 1\n");
                 return 1;
             }
-             old_opts += sprintf(old_opts, "factor=%f;", settings.factor);
            break;
         case 'n':
             settings.chunk_size = atoi(optarg);
@@ -16008,7 +16002,6 @@ int main (int argc, char **argv)
                         "Chunk size must be greater than 0\n");
                 return 1;
             }
-            old_opts += sprintf(old_opts, "chunk_size=%d;", settings.chunk_size);
             break;
         case 't':
             settings.num_threads = atoi(optarg);
@@ -16031,18 +16024,15 @@ int main (int argc, char **argv)
             break;
         case 'D':
             settings.prefix_delimiter = optarg[0];
-            old_opts += sprintf(old_opts, "prefix_delimiter=%c;", settings.prefix_delimiter);
             settings.detail_enabled = 1;
             break;
         case 'L' :
             if (enable_large_pages() == 0) {
-                //preallocate = true;
-                old_opts += sprintf(old_opts, "preallocate=true;");
+                preallocate = true;
             }
             break;
         case 'C' :
             settings.use_cas = false;
-            old_opts += sprintf(old_opts, "use_cas=false;");
             break;
         case 'b' :
             settings.backlog = atoi(optarg);
@@ -16095,8 +16085,6 @@ int main (int argc, char **argv)
                     " and will decrease your memory efficiency.\n"
                 );
             }
-            old_opts += sprintf(old_opts, "item_size_max=%llu;", (unsigned long long)
-                                settings.item_size_max);
             break;
         case 'E':
             engine = optarg;
@@ -16153,8 +16141,34 @@ int main (int argc, char **argv)
             return 1;
         }
     }
-
     old_opts += sprintf(old_opts, "num_threads=%lu;", (unsigned long)settings.num_threads);
+    old_opts += sprintf(old_opts, "cache_size=%llu;", (unsigned long long)settings.maxbytes);
+    if (settings.evict_to_free == 0) {
+        old_opts += sprintf(old_opts, "eviction=false;");
+    }
+    if (settings.sticky_limit > 0) {
+        old_opts += sprintf(old_opts, "sticky_limit=%llu;",
+                            (unsigned long long)settings.sticky_limit);
+    }
+    if (settings.factor != 1.25) {
+        old_opts += sprintf(old_opts, "factor=%f;", settings.factor);
+    }
+    if (settings.chunk_size != 48) {
+        old_opts += sprintf(old_opts, "chunk_size=%d;", settings.chunk_size);
+    }
+    if (settings.prefix_delimiter != ':') {
+        old_opts += sprintf(old_opts, "prefix_delimiter=%c;", settings.prefix_delimiter);
+    }
+    if (preallocate) {
+        old_opts += sprintf(old_opts, "preallocate=true;");
+    }
+    if (settings.use_cas == false) {
+        old_opts += sprintf(old_opts, "use_cas=false;");
+    }
+    if (settings.item_size_max != (1024 * 1024)) {
+        old_opts += sprintf(old_opts, "item_size_max=%llu;",
+                            (unsigned long long)settings.item_size_max);
+    }
     if (settings.verbose) {
         old_opts += sprintf(old_opts, "verbose=%lu;", (unsigned long)settings.verbose);
     }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/808

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- `getopt()` while 루프에서 구동옵션 파싱 및 `settings`(전역 구조체)를 확정짓는 역할만 담당하고, `old_opts`문자열을 생성하는 로직은 루프가 종료된 이후, 관리합니다.
    - `old_opts`: 엔진 설정 문자열을 모아둔 긴 문자열. 향후 이를 ;단위로 분리하여 엔진 파서에서 파싱합니다.
- 현재 PR이 반영된다면, https://github.com/naver/arcus-memcached/issues/663 을 더욱 효율적으로 처리할 수 있습니다.

---

`preallocate`는 구동옵션 내에서 `old_opts`문자열을 생성합니다. 이를 참고하여 리뷰 부탁드립니다.