### PR TITLE
INTERNAL: Do not use ARCUS_ACL_ZOOKEEPER

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -9699,8 +9699,13 @@ static pthread_mutex_t require_sasl_lock = PTHREAD_MUTEX_INITIALIZER;
 
 static void* init_sasl_thread(void *arg)
 {
+#ifdef ENABLE_ZK_INTEGRATION
+    char *acl_zookeeper = arcus_zk_cfg;
+#else
+    char *acl_zookeeper = NULL;
+#endif
     pthread_mutex_lock(&require_sasl_lock);
-    if (settings.require_sasl == false && init_sasl(mc_logger) == 0) {
+    if (settings.require_sasl == false && init_sasl(acl_zookeeper, mc_logger) == 0) {
         settings.require_sasl = true;
     }
     pthread_mutex_unlock(&require_sasl_lock);
@@ -16384,7 +16389,12 @@ int main (int argc, char **argv)
     }
 
 #ifdef SASL_ENABLED
-    if (settings.require_sasl && init_sasl(mc_logger) != 0) {
+#ifdef ENABLE_ZK_INTEGRATION
+    char *acl_zookeeper = arcus_zk_cfg;
+#else
+    char *acl_zookeeper = NULL;
+#endif
+    if (settings.require_sasl && init_sasl(acl_zookeeper, mc_logger) != 0) {
         exit(EXIT_FAILURE);
     }
 #endif

--- a/sasl_auxprop.c
+++ b/sasl_auxprop.c
@@ -350,8 +350,9 @@ static void arcus_auxprop_free(void *glob_context,
     }
 }
 
-void arcus_auxprop_init_logger(EXTENSION_LOGGER_DESCRIPTOR *logger)
+void arcus_auxprop_init(const char *zk_addr, EXTENSION_LOGGER_DESCRIPTOR *logger)
 {
+    ensemble_list = zk_addr;
     mc_logger = logger;
 }
 
@@ -382,12 +383,6 @@ int arcus_auxprop_plug_init(const sasl_utils_t *utils,
 
     if (mc_logger == NULL) {
         utils->log(utils->conn, SASL_LOG_ERR, "mc_logger is not set");
-        return SASL_FAIL;
-    }
-
-    ensemble_list = getenv("ARCUS_ACL_ZOOKEEPER");
-    if (ensemble_list == NULL) {
-        mc_logger->log(EXTENSION_LOG_WARNING, NULL, "ARCUS_ACL_ZOOKEEPER environment is not set\n");
         return SASL_FAIL;
     }
 

--- a/sasl_auxprop.h
+++ b/sasl_auxprop.h
@@ -9,7 +9,7 @@
 #include <sasl/sasl.h>
 #include <sasl/saslplug.h>
 
-void arcus_auxprop_init_logger(EXTENSION_LOGGER_DESCRIPTOR *logger);
+void arcus_auxprop_init(const char *zk_addr, EXTENSION_LOGGER_DESCRIPTOR *logger);
 
 int arcus_auxprop_plug_init(const sasl_utils_t *utils,
                             int max_version,

--- a/sasl_defs.c
+++ b/sasl_defs.c
@@ -34,7 +34,7 @@ void sasl_get_auth_data(sasl_conn_t *conn, auth_data_t *data)
 #endif
 
 #if defined(ENABLE_SASL) && defined(ENABLE_ZK_INTEGRATION)
-static bool use_acl_zookeeper = false;
+static const char *ensemble_list;
 #endif
 
 #ifdef ENABLE_SASL_PWDB
@@ -158,7 +158,7 @@ uint16_t arcus_sasl_authz(const char *username)
     uint16_t ret = AUTHZ_ALL;
 
 #if defined(ENABLE_SASL) && defined(ENABLE_ZK_INTEGRATION)
-    if (use_acl_zookeeper) {
+    if (ensemble_list) {
         char value[1024];
         if (arcus_getdata(username, value, sizeof(value)) == SASL_OK) {
             char *saveptr;
@@ -189,7 +189,7 @@ uint16_t arcus_sasl_authz(const char *username)
 #if defined(ENABLE_SASL) || defined(ENABLE_ISASL)
 static sasl_callback_t sasl_callbacks[5];
 
-int init_sasl(EXTENSION_LOGGER_DESCRIPTOR *logger)
+int init_sasl(char *zk_addr, EXTENSION_LOGGER_DESCRIPTOR *logger)
 {
     int i = 0;
 #ifdef ENABLE_SASL
@@ -207,8 +207,8 @@ int init_sasl(EXTENSION_LOGGER_DESCRIPTOR *logger)
         sasl_callbacks[i++] = (sasl_callback_t){ SASL_CB_SERVER_USERDB_CHECKPASS, (int(*)(void))sasl_server_userdb_checkpass, NULL };
     }
 #elif defined(ENABLE_ZK_INTEGRATION)
-    use_acl_zookeeper = (getenv("ARCUS_ACL_ZOOKEEPER") != NULL);
-    if (use_acl_zookeeper) {
+    ensemble_list = zk_addr;
+    if (ensemble_list) {
         sasl_callbacks[i++] = (sasl_callback_t){ SASL_CB_GETOPT, (int(*)(void))&sasl_getopt, NULL };
     }
 #endif
@@ -221,8 +221,8 @@ int init_sasl(EXTENSION_LOGGER_DESCRIPTOR *logger)
     }
 
 #if defined(ENABLE_SASL) && defined(ENABLE_ZK_INTEGRATION)
-    if (use_acl_zookeeper) {
-        arcus_auxprop_init_logger(logger);
+    if (ensemble_list) {
+        arcus_auxprop_init(ensemble_list, logger);
         if (sasl_auxprop_add_plugin("arcus", &arcus_auxprop_plug_init) != SASL_OK) {
             mc_logger->log(EXTENSION_LOG_WARNING, NULL, "Error to SASL auxprop plugin.\n");
             return -1;
@@ -244,7 +244,7 @@ void shutdown_sasl(void)
 int reload_sasl(void)
 {
 #if defined(ENABLE_SASL) && defined(ENABLE_ZK_INTEGRATION)
-    if (use_acl_zookeeper) {
+    if (ensemble_list) {
         arcus_auxprop_wakeup();
         return 0;
     }

--- a/sasl_defs.h
+++ b/sasl_defs.h
@@ -11,7 +11,7 @@ uint16_t arcus_sasl_authz(const char *username);
 #include "memcached/extension.h"
 #include "memcached/types.h"
 
-int init_sasl(EXTENSION_LOGGER_DESCRIPTOR *logger);
+int init_sasl(char *zk_addr, EXTENSION_LOGGER_DESCRIPTOR *logger);
 void shutdown_sasl(void);
 int reload_sasl(void);
 void sasl_get_auth_data(sasl_conn_t *conn, auth_data_t *data);
@@ -23,7 +23,7 @@ void sasl_get_auth_data(sasl_conn_t *conn, auth_data_t *data);
 #include "memcached/extension.h"
 #include "memcached/types.h"
 
-int init_sasl(EXTENSION_LOGGER_DESCRIPTOR *logger);
+int init_sasl(char *zk_addr, EXTENSION_LOGGER_DESCRIPTOR *logger);
 void shutdown_sasl(void);
 int reload_sasl(void);
 void sasl_get_auth_data(sasl_conn_t *conn, auth_data_t *data);


### PR DESCRIPTION
### 🔗 Related Issue

- #850 
- jam2in/arcus-works#809

### ⌨️ What I did

- arcus acl 정보를 조회할 zookeeper 주소를 `ARCUS_ACL_ZOOKEEPER` 환경변수로 전달하는 대신, `-z` 옵션으로 전달한 주소를 사용합니다.
즉, 클러스터 메타 정보를 보관하는 zookeeper에 인증 관련 정보를 함께 보관합니다.