### PR TITLE
INTERNAL: Use /arcus_acl_mapping znode instead of ARCUS_ACL_GROUP env

### DIFF
--- a/arcus_zk.c
+++ b/arcus_zk.c
@@ -1820,6 +1820,11 @@ int arcus_zk_rejoin_ensemble(void)
     return ret;
 }
 
+char *arcus_zk_get_servicecode(void)
+{
+    return arcus_conf.svc;
+}
+
 void arcus_zk_set_failstop(bool failstop)
 {
     pthread_mutex_lock(&arcus_conf.lock);

--- a/arcus_zk.h
+++ b/arcus_zk.h
@@ -56,6 +56,8 @@ int  arcus_zk_set_ensemble(char *ensemble_list);
 int  arcus_zk_get_ensemble(char *buf, int size);
 int  arcus_zk_rejoin_ensemble(void);
 
+char *arcus_zk_get_servicecode(void);
+
 void arcus_zk_set_failstop(bool failstop);
 bool arcus_zk_get_failstop(void);
 void arcus_zk_get_confs(arcus_zk_confs *confs);

--- a/memcached.c
+++ b/memcached.c
@@ -9701,11 +9701,14 @@ static void* init_sasl_thread(void *arg)
 {
 #ifdef ENABLE_ZK_INTEGRATION
     char *acl_zookeeper = arcus_zk_cfg;
+    char *svc = arcus_zk_get_servicecode();
 #else
     char *acl_zookeeper = NULL;
+    char *svc = NULL;
 #endif
     pthread_mutex_lock(&require_sasl_lock);
-    if (settings.require_sasl == false && init_sasl(acl_zookeeper, mc_logger) == 0) {
+    if (settings.require_sasl == false &&
+        init_sasl(acl_zookeeper, svc, mc_logger) == 0) {
         settings.require_sasl = true;
     }
     pthread_mutex_unlock(&require_sasl_lock);
@@ -16402,17 +16405,6 @@ int main (int argc, char **argv)
         }
     }
 
-#ifdef SASL_ENABLED
-#ifdef ENABLE_ZK_INTEGRATION
-    char *acl_zookeeper = arcus_zk_cfg;
-#else
-    char *acl_zookeeper = NULL;
-#endif
-    if (settings.require_sasl && init_sasl(acl_zookeeper, mc_logger) != 0) {
-        exit(EXIT_FAILURE);
-    }
-#endif
-
     /* lock paged memory if needed */
     if (lock_memory) {
 #ifdef HAVE_MLOCKALL
@@ -16584,6 +16576,20 @@ int main (int argc, char **argv)
                       arcus_proxy_cfg,
 #endif
                       mc_engine.v1);
+    }
+#endif
+
+#ifdef SASL_ENABLED
+#ifdef ENABLE_ZK_INTEGRATION
+    char *acl_zookeeper = arcus_zk_cfg;
+    char *svc = arcus_zk_get_servicecode();
+#else
+    char *acl_zookeeper = NULL;
+    char *svc = NULL;
+#endif
+    if (settings.require_sasl &&
+        init_sasl(acl_zookeeper, svc, mc_logger) != 0) {
+        exit(EXIT_FAILURE);
     }
 #endif
 

--- a/sasl_auxprop.c
+++ b/sasl_auxprop.c
@@ -350,10 +350,39 @@ static void arcus_auxprop_free(void *glob_context,
     }
 }
 
-void arcus_auxprop_init(const char *zk_addr, EXTENSION_LOGGER_DESCRIPTOR *logger)
+int arcus_auxprop_init(const char *zk_addr, const char *svc,
+                       EXTENSION_LOGGER_DESCRIPTOR *logger)
 {
+    zhandle_t *zh;
+    char zpath[256];
+    char buf[GROUP_MAXLEN];
+    int len = GROUP_MAXLEN;
+    int ret;
+
     ensemble_list = zk_addr;
     mc_logger = logger;
+
+    zh = zookeeper_init(ensemble_list, NULL, 10000, NULL, NULL, 0);
+    if (!zh) {
+        mc_logger->log(EXTENSION_LOG_WARNING, NULL, "ACL zookeeper init failed.\n");
+        return -1;
+    }
+
+    snprintf(zpath, sizeof(zpath), "/arcus_acl_mapping/%s", svc);
+    ret = zoo_get(zh, zpath, 0, buf, &len, NULL);
+    if (ret != ZOK) {
+        mc_logger->log(EXTENSION_LOG_WARNING, NULL,
+            "ACL zoo_get(%s) failed: %s\n", zpath, zerror(ret));
+        zookeeper_close(zh);
+        return -1;
+    }
+    buf[len] = '\0';
+
+    snprintf(group_zpath, sizeof(group_zpath), "/arcus_acl/%s", buf);
+    mc_logger->log(EXTENSION_LOG_INFO, NULL, "ACL group_zpath: %s\n", group_zpath);
+    zookeeper_close(zh);
+
+    return 0;
 }
 
 static sasl_auxprop_plug_t arcus_auxprop_plugin = {
@@ -385,13 +414,6 @@ int arcus_auxprop_plug_init(const sasl_utils_t *utils,
         utils->log(utils->conn, SASL_LOG_ERR, "mc_logger is not set");
         return SASL_FAIL;
     }
-
-    const char *acl_group = getenv("ARCUS_ACL_GROUP");
-    if (acl_group == NULL) {
-        mc_logger->log(EXTENSION_LOG_WARNING, NULL, "ARCUS_ACL_GROUP environment is not set\n");
-        return SASL_FAIL;
-    }
-    snprintf(group_zpath, sizeof(group_zpath), "/arcus_acl/%s", acl_group);
 
     g_sasltable = get_arcus_acl_table();
     if (!g_sasltable) {

--- a/sasl_auxprop.h
+++ b/sasl_auxprop.h
@@ -9,7 +9,8 @@
 #include <sasl/sasl.h>
 #include <sasl/saslplug.h>
 
-void arcus_auxprop_init(const char *zk_addr, EXTENSION_LOGGER_DESCRIPTOR *logger);
+int arcus_auxprop_init(const char *zk_addr, const char *svc,
+                       EXTENSION_LOGGER_DESCRIPTOR *logger);
 
 int arcus_auxprop_plug_init(const sasl_utils_t *utils,
                             int max_version,

--- a/sasl_defs.c
+++ b/sasl_defs.c
@@ -189,7 +189,7 @@ uint16_t arcus_sasl_authz(const char *username)
 #if defined(ENABLE_SASL) || defined(ENABLE_ISASL)
 static sasl_callback_t sasl_callbacks[5];
 
-int init_sasl(char *zk_addr, EXTENSION_LOGGER_DESCRIPTOR *logger)
+int init_sasl(char *zk_addr, char *svc, EXTENSION_LOGGER_DESCRIPTOR *logger)
 {
     int i = 0;
 #ifdef ENABLE_SASL
@@ -222,7 +222,9 @@ int init_sasl(char *zk_addr, EXTENSION_LOGGER_DESCRIPTOR *logger)
 
 #if defined(ENABLE_SASL) && defined(ENABLE_ZK_INTEGRATION)
     if (ensemble_list) {
-        arcus_auxprop_init(ensemble_list, logger);
+        if (arcus_auxprop_init(ensemble_list, svc, logger) != 0) {
+            return -1;
+        }
         if (sasl_auxprop_add_plugin("arcus", &arcus_auxprop_plug_init) != SASL_OK) {
             mc_logger->log(EXTENSION_LOG_WARNING, NULL, "Error to SASL auxprop plugin.\n");
             return -1;

--- a/sasl_defs.h
+++ b/sasl_defs.h
@@ -11,7 +11,7 @@ uint16_t arcus_sasl_authz(const char *username);
 #include "memcached/extension.h"
 #include "memcached/types.h"
 
-int init_sasl(char *zk_addr, EXTENSION_LOGGER_DESCRIPTOR *logger);
+int init_sasl(char *zk_addr, char *svc, EXTENSION_LOGGER_DESCRIPTOR *logger);
 void shutdown_sasl(void);
 int reload_sasl(void);
 void sasl_get_auth_data(sasl_conn_t *conn, auth_data_t *data);
@@ -23,7 +23,7 @@ void sasl_get_auth_data(sasl_conn_t *conn, auth_data_t *data);
 #include "memcached/extension.h"
 #include "memcached/types.h"
 
-int init_sasl(char *zk_addr, EXTENSION_LOGGER_DESCRIPTOR *logger);
+int init_sasl(char *zk_addr, char *svc, EXTENSION_LOGGER_DESCRIPTOR *logger);
 void shutdown_sasl(void);
 int reload_sasl(void);
 void sasl_get_auth_data(sasl_conn_t *conn, auth_data_t *data);


### PR DESCRIPTION
### 🔗 Related Issue

- jam2in/arcus-works#809

### ⌨️ What I did

- 구동 시 `ARCUS_ACL_GROUP` 전달하는 대신, `/arcus_acl_mapping/servicecode` 조회하여 acl group을 가져옵니다.
  - arcus_zk 모듈에 servicecode 조회하기 위한 함수를 추가합니다.
  - init_sasl() 시점을 arcus_zk_init 이후로 이동합니다.