### PR TITLE
FEATURE: Add cmdlog optional filtering

### DIFF
--- a/cmdlog.c
+++ b/cmdlog.c
@@ -38,6 +38,10 @@
 #define CMDLOG_FILENAME_LENGTH CMDLOG_DIRPATH_LENGTH + 128
 #define CMDLOG_FILENAME_FORMAT "%s/command_%d_%d_%d_%d.log"
 
+#define CMDLOG_FILTER_MAXNUM 10
+#define CMDLOG_FILTER_CMD_MAXLEN 30
+#define CMDLOG_FILTER_KEY_MAXLEN 1000
+
 /* cmdlog state */
 #define CMDLOG_NOT_STARTED   0  /* not started */
 #define CMDLOG_OVERFLOW_STOP 1  /* stop by command log overflow */
@@ -57,6 +61,13 @@ struct cmd_log_buffer {
     uint32_t head;
     uint32_t tail;
     uint32_t last;
+};
+
+/* command log filter structure */
+struct cmd_log_filter {
+    char command[CMDLOG_FILTER_CMD_MAXLEN + 1];
+    char subcommand[CMDLOG_FILTER_CMD_MAXLEN + 1];
+    char key[CMDLOG_FILTER_KEY_MAXLEN + 1];
 };
 
 /*command log flush structure */
@@ -85,6 +96,8 @@ struct cmd_log_global {
     struct cmd_log_buffer buffer;
     struct cmd_log_flush flush;
     struct cmd_log_stats stats;
+    struct cmd_log_filter filters[CMDLOG_FILTER_MAXNUM];
+    int nfilters;
     volatile bool reqstop;
 };
 struct cmd_log_global cmdlog;
@@ -397,27 +410,34 @@ char *cmdlog_stats(void)
     return str;
 }
 
-void cmdlog_write(char *client_ip, char *command)
+void cmdlog_write(char *client_ip, token_t *tokens, size_t ntokens)
 {
     struct tm *ptm;
     struct timeval val;
     struct cmd_log_buffer *buffer = &cmdlog.buffer;
     char inputstr[CMDLOG_INPUT_SIZE];
     int inputlen;
-    int nwritten;
 
     gettimeofday(&val, NULL);
     ptm = localtime(&val.tv_sec);
 
-    nwritten = snprintf(inputstr, CMDLOG_INPUT_SIZE, "%02d:%02d:%02d.%06ld %s %s\n",
-                       ptm->tm_hour, ptm->tm_min, ptm->tm_sec, (long)val.tv_usec, client_ip, command);
-    /* truncated ? */
-    if (nwritten > CMDLOG_INPUT_SIZE) {
-        inputstr[CMDLOG_INPUT_SIZE-4] = '.';
-        inputstr[CMDLOG_INPUT_SIZE-3] = '.';
-        inputstr[CMDLOG_INPUT_SIZE-2] = '\n';
+    inputlen = snprintf(inputstr, CMDLOG_INPUT_SIZE, "%02d:%02d:%02d.%06ld %s ",
+                        ptm->tm_hour, ptm->tm_min, ptm->tm_sec, (long)val.tv_usec, client_ip);
+
+    for (int i = 0; i < ntokens - 1; i++) {
+        inputlen += snprintf(inputstr + inputlen, CMDLOG_INPUT_SIZE - inputlen, "%s", tokens[i].value);
+        if (i < ntokens - 2) inputstr[inputlen++] = ' ';
+
+        if (inputlen >= CMDLOG_INPUT_SIZE) {
+            inputstr[CMDLOG_INPUT_SIZE-4] = '.';
+            inputstr[CMDLOG_INPUT_SIZE-3] = '.';
+            inputlen = CMDLOG_INPUT_SIZE - 2;
+            break;
+        }
+
     }
-    inputlen = strlen(inputstr);
+    inputstr[inputlen++] = '\n';
+    inputstr[inputlen] = '\0';
 
     pthread_mutex_lock(&buffer->lock);
     cmdlog.stats.entered_commands += 1;
@@ -446,4 +466,131 @@ void cmdlog_write(char *client_ip, char *command)
         do_cmdlog_flush_wakeup(); /* wake up flush thread */
     }
     pthread_mutex_unlock(&buffer->lock);
+}
+
+bool is_cmdlog_filter_match(const token_t *cmd, const token_t *subcmd, const token_t *key, size_t ntokens)
+{
+    int mkey_idx = 0;
+    bool multi_key = false;
+    bool matched = false;
+
+    if (cmdlog.nfilters == 0) {
+        return true;
+    }
+
+    if (ntokens < 2) {
+        return false;
+    }
+
+    pthread_mutex_lock(&cmdlog.lock);
+    for (int i = 0; i < cmdlog.nfilters; ++i) {
+        struct cmd_log_filter *filter = &cmdlog.filters[i];
+
+        if (filter->command[0] == '\0') {
+            matched = true;
+        } else if (filter->subcommand[0] == '\0') {
+            matched = strcmp(cmd->value, filter->command) == 0 ? true : false;
+        } else if (subcmd) {
+            matched = strcmp(cmd->value, filter->command) == 0 && strcmp(subcmd->value, filter->subcommand) == 0 ?
+                      true : false;
+        } else {
+            continue;
+        }
+
+        if (matched) {
+            if (filter->key[0] == '\0') {
+                matched = true;
+            } else if (key) {
+                do {
+                    matched = string_pattern_match(key[mkey_idx].value, key[mkey_idx].length, filter->key, strlen(filter->key)) ?
+                        true : false;
+                    if (matched == false && multi_key) mkey_idx++;
+                } while (matched == false && multi_key && mkey_idx < ntokens - 1);
+            } else {
+                matched = false;
+            }
+        }
+
+        if (matched) break;
+    }
+    pthread_mutex_unlock(&cmdlog.lock);
+
+    return matched;
+}
+
+int cmdlog_filter_add(const token_t *cmd, const token_t *subcmd, const token_t *key)
+{
+    if (cmdlog.nfilters >= CMDLOG_FILTER_MAXNUM) {
+        return 0;
+    }
+
+    if ((cmd && cmd->length > CMDLOG_FILTER_CMD_MAXLEN) ||
+        (subcmd && subcmd->length > CMDLOG_FILTER_CMD_MAXLEN) ||
+        (key && key->length > CMDLOG_FILTER_KEY_MAXLEN)) {
+        return -1;
+    }
+
+    pthread_mutex_lock(&cmdlog.lock);
+    strcpy(cmdlog.filters[cmdlog.nfilters].command, cmd ? cmd->value : "");
+    strcpy(cmdlog.filters[cmdlog.nfilters].subcommand, subcmd ? subcmd->value : "");
+    strcpy(cmdlog.filters[cmdlog.nfilters].key, key ? key->value : "");
+    cmdlog.nfilters++;
+    pthread_mutex_unlock(&cmdlog.lock);
+
+    return 1;
+}
+
+int cmdlog_filter_remove(int idx, bool remove_all)
+{
+    if (remove_all == false && (idx < 0 || idx >= cmdlog.nfilters)) {
+        return -1;
+    }
+
+    pthread_mutex_lock(&cmdlog.lock);
+    if (remove_all) {
+        cmdlog.nfilters = 0;
+    } else {
+        for (int i = idx; i < cmdlog.nfilters - 1; ++i) {
+            cmdlog.filters[i] = cmdlog.filters[i + 1];
+        }
+        cmdlog.nfilters--;
+    }
+    pthread_mutex_unlock(&cmdlog.lock);
+
+    return 0;
+}
+
+char *cmdlog_filter_list(void)
+{
+    char *buf = (char *)malloc((cmdlog.nfilters + 1) * CMDLOG_INPUT_SIZE);
+    int nwritten = 0;
+
+    if (!buf) {
+        return NULL;
+    }
+
+    pthread_mutex_lock(&cmdlog.lock);
+    nwritten = snprintf(buf, CMDLOG_INPUT_SIZE, "\t(%d / %d)\n", cmdlog.nfilters, CMDLOG_FILTER_MAXNUM);
+    for (int i = 0; i < cmdlog.nfilters; ++i) {
+        struct cmd_log_filter *filter = &cmdlog.filters[i];
+
+        nwritten += snprintf(buf + nwritten, CMDLOG_INPUT_SIZE, "\t%d. ", i);
+        if (filter->command[0] != '\0') {
+            nwritten += snprintf(buf + nwritten, CMDLOG_INPUT_SIZE - nwritten, "command = %s%s%s",
+                                 filter->command,
+                                 filter->subcommand[0] != '\0' ? " " : "",
+                                 filter->subcommand[0] != '\0' ? filter->subcommand : "");
+        }
+
+        if (filter->key[0] != '\0') {
+            nwritten += snprintf(buf + nwritten, CMDLOG_INPUT_SIZE - nwritten, "%skey = %s",
+                                 filter->command[0] != '\0' ? ", " : "",
+                                 filter->key);
+        }
+
+        nwritten += snprintf(buf + nwritten, CMDLOG_INPUT_SIZE - nwritten, "\n");
+    }
+    pthread_mutex_unlock(&cmdlog.lock);
+
+    return buf;
 }

--- a/cmdlog.h
+++ b/cmdlog.h
@@ -30,5 +30,9 @@ void cmdlog_final(void);
 int cmdlog_start(char *file_path, bool *already_started);
 void cmdlog_stop(bool *already_stopped);
 char *cmdlog_stats(void);
-void cmdlog_write(char *client_ip, char *command);
+void cmdlog_write(char *client_ip, token_t *tokens, size_t ntokens);
+bool is_cmdlog_filter_match(const token_t *cmd, const token_t *subcmd, const token_t *key, size_t ntokens);
+int cmdlog_filter_add(const token_t *cmd, const token_t *subcmd, const token_t *key);
+int cmdlog_filter_remove(int idx, bool remove_all);
+char *cmdlog_filter_list(void);
 #endif

--- a/docs/ascii-protocol/ch13-command-administration.md
+++ b/docs/ascii-protocol/ch13-command-administration.md
@@ -869,6 +869,7 @@ start 명령을 시작으로 logging이 종료될 때 까지의 모든 command�
 cmdlog start [<log_file_path>]\r\n
 cmdlog stop\r\n
 cmdlog stats\r\n
+cmdlog filter <args>\r\n
 ```
 
 \<log_file_path\>는 logging 정보를 저장할 file의 path이다.
@@ -908,6 +909,44 @@ The number of entered commands : 146783                              //entered_c
 The number of skipped commands : 0                                   //skipped_commands
 The number of log files : 1                                          //file_count
 The log file name: /Users/temp/command_11211_20160126_192729_{n}.log //path/file_name
+```
+
+filter 명령은 특정 command와 key만 logging 하도록 필터링할 수 있다.
+command는 exact matching, key는 glob matching 방식으로 필터링 한다.
+단, 성능 보장을 위해 key의 최대 길이를 1000자로 제한하고 있다.
+
+```
+add { command <cmd> [subcmd] | key <key> | command <cmd> [subcmd] key <key> }
+remove { all | <idx> }
+list
+```
+
+filter add 명령은 필터링할 명령어와 키 조합을 필터 목록에 추가한다.
+`mget`, `mgets`, `bop mget`, `bop smget` 명령은 key를 필터로 사용하지 않는다.
+`get`, `gets` 명령은 다수의 key에 대해 필터와 일치하는지 전부 검사한다.
+response string은 아래와 같다.
+
+| Response String                  | 설명                                                                  |
+| -------------------------------- | --------------------------------------------------------------------- |
+| OK                               | 성공                                                                  |
+| SERVER_ERROR filter list is full | 존재하는 필터 수가 이미 최대치이므로 더 추가할 수 없음                |
+| CLIENT_ERROR invalid parameters  | 인자로 입력한 command나 key가 유효하지 않은 문자거나 최대 길이를 넘음 |
+
+filter remove 명령은 필터 리스트에서 특정 인덱스의 필터를 삭제한다.
+인덱스 대신 all을 입력하면 존재하던 모든 필터를 삭제한다. response string은 아래와 같다.
+
+| Response String                  | 설명                                                 |
+| -------------------------------- | ---------------------------------------------------- |
+| OK                               | 성공                                                 |
+| CLIENT_ERROR invalid parameters  | 인자로 입력한 인덱스가 유효하지 않거나 존재하지 않음 |
+
+filter list 명령은 존재하는 필터 목록을 출력한다.
+
+```
+(3 / 10)
+0. command = add, key = 123
+1. key = kvkey:12
+2. command = bop insert
 ```
 
 <a id="long-query-detect"></a>

--- a/memcached.c
+++ b/memcached.c
@@ -10655,13 +10655,96 @@ static void process_scan_command(conn *c, token_t *tokens, const size_t ntokens)
 #endif
 
 #ifdef COMMAND_LOGGING
+static void process_cmdlog_filter(conn *c, token_t *tokens, const size_t ntokens)
+{
+    const char *subcommand;
+    int ret = 0;
+
+    CHECK_NTOKENS(ntokens, 4, 9);
+
+    subcommand = tokens[2].value;
+
+    if (strcmp(subcommand, "add") == 0) {
+        token_t *fcmd = NULL;
+        token_t *fsub = NULL;
+        token_t *fkey = NULL;
+        int read_ntokens = 3;
+
+        CHECK_NTOKENS(ntokens, 6, 9);
+
+        if (strcmp(tokens[read_ntokens].value, "command") == 0) {
+            fcmd = &tokens[++read_ntokens];
+            read_ntokens++;
+
+            if (ntokens == 7 || ntokens == 9) {
+                fsub = &tokens[read_ntokens];
+                read_ntokens++;
+            }
+        }
+
+        if (read_ntokens < ntokens - 2 && strcmp(tokens[read_ntokens].value, "key") == 0) {
+            fkey = &tokens[++read_ntokens];
+            read_ntokens++;
+        }
+
+        if ((read_ntokens != ntokens - 1) || (fcmd == NULL && fkey == NULL)) {
+            print_invalid_command(c, tokens, ntokens);
+            out_string(c, "CLIENT_ERROR bad command line format");
+            return;
+        }
+
+        ret = cmdlog_filter_add(fcmd, fsub, fkey);
+
+        if (ret > 0) {
+            out_string(c, "OK");
+        } else if (ret == 0) {
+            out_string(c, "SERVER_ERROR filter list is full");
+        } else {
+            out_string(c, "CLIENT_ERROR invalid parameters");
+        }
+    } else if (strcmp(subcommand, "remove") == 0) {
+        int idx = 0;
+        bool remove_all = false;
+
+        CHECK_NTOKENS_EQ(ntokens, 5);
+
+        if (strcmp(tokens[3].value, "all") == 0) {
+            remove_all = true;
+        } else if (!safe_strtol(tokens[3].value, &idx)) {
+            idx = -1;
+        }
+
+        ret = cmdlog_filter_remove(idx, remove_all);
+
+        if (ret == 0) {
+            out_string(c, "OK");
+        } else {
+            out_string(c, "CLIENT_ERROR invalid parameters");
+        }
+    } else if (strcmp(subcommand, "list") == 0) {
+        char *ret_str;
+
+        CHECK_NTOKENS_EQ(ntokens, 4);
+
+        ret_str = cmdlog_filter_list();
+
+        if (ret_str) {
+            write_and_free(c, ret_str, strlen(ret_str));
+        } else {
+            out_string(c, "SERVER_ERROR out of memory");
+        }
+    } else {
+        out_string(c, "ERROR unknown command");
+    }
+}
+
 static void process_cmdlog_command(conn *c, token_t *tokens, const size_t ntokens)
 {
     char *subcommand;
     bool already_check = false;
 
-    if (ntokens < 3 || ntokens > 4) {
-        out_string(c, "\t* Usage: cmdlog [start [path] | stop | stats]\n");
+    if (ntokens < 3) {
+        out_string(c, "\t* Usage: cmdlog {start [path] | stop | stats | filter {add | remove | list} }\n");
         return;
     }
 
@@ -10674,7 +10757,7 @@ static void process_cmdlog_command(conn *c, token_t *tokens, const size_t ntoken
 
     subcommand = tokens[SUBCOMMAND_TOKEN].value;
 
-    if (strcmp(subcommand, "start") == 0) {
+    if (ntokens <= 4 && strcmp(subcommand, "start") == 0) {
         char *fpath = NULL;
         if (ntokens == 4) {
             fpath = tokens[SUBCOMMAND_TOKEN+1].value;
@@ -10703,8 +10786,10 @@ static void process_cmdlog_command(conn *c, token_t *tokens, const size_t ntoken
         } else {
             out_string(c, "\tcommand logging failed to get stats memory.\n");
         }
+    } else if (ntokens > 3 && strcmp(subcommand, "filter") == 0) {
+        process_cmdlog_filter(c, tokens, ntokens);
     } else {
-        out_string(c, "\t* Usage: cmdlog [start [path] | stop | stats]\n");
+        out_string(c, "\t* Usage: cmdlog {start [path] | stop | stats | filter {add | remove | list} }\n");
     }
 }
 #endif
@@ -14012,6 +14097,9 @@ static void process_command_ascii(conn *c, char *command, int cmdlen)
     size_t ntokens;
     char *cmd;
     int clen;
+    int cidx = 0;
+    int sidx = -1;
+    int kidx = -1;
     bool unknown_command = false;
 
     MEMCACHED_PROCESS_COMMAND_START(c->sfd, c->rcurr, c->rbytes);
@@ -14034,14 +14122,7 @@ static void process_command_ascii(conn *c, char *command, int cmdlen)
         return;
     }
 
-#ifdef COMMAND_LOGGING
-    if (cmdlog_in_use) {
-        cmdlog_write(c->client_ip, command);
-    }
-#endif
-
     ntokens = tokenize_command(command, cmdlen, tokens, MAX_TOKENS);
-
     if (ntokens < 2 || tokens[COMMAND_TOKEN].length < 3) {
         out_string(c, "ERROR unknown command");
         return;
@@ -14052,14 +14133,19 @@ static void process_command_ascii(conn *c, char *command, int cmdlen)
 
     if (cmd[0] == 'g') {
         if (clen == 3 && strcmp(cmd, "get") == 0) {
+            kidx = 1;
             process_get_command(c, tokens, ntokens, false, false);
         } else if (clen == 4 && strcmp(cmd, "gets") == 0) {
+            kidx = 1;
             process_get_command(c, tokens, ntokens, true, false);
         } else if (clen == 3 && strcmp(cmd, "gat") == 0) {
+            kidx = 2;
             process_get_command(c, tokens, ntokens, false, true);
         } else if (clen == 4 && strcmp(cmd, "gats") == 0) {
+            kidx = 2;
             process_get_command(c, tokens, ntokens, true, true);
         } else if (clen == 7 && strcmp(cmd, "getattr") == 0) {
+            kidx = 1;
             process_getattr_command(c, tokens, ntokens);
         } else {
             unknown_command = true;
@@ -14074,66 +14160,83 @@ static void process_command_ascii(conn *c, char *command, int cmdlen)
         }
     } else if (cmd[0] == 's' && cmd[1] == 'e') {
         if (strcmp(cmd, "set") == 0) {
+            kidx = 1;
             process_update_command(c, tokens, ntokens, OPERATION_SET, false);
         } else if (strcmp(cmd, "setattr") == 0) {
+            kidx = 1;
             process_setattr_command(c, tokens, ntokens);
         } else {
             unknown_command = true;
         }
     } else if (cmd[0] == 't') {
         if (strcmp(cmd, "touch") == 0) {
+            kidx = 1;
             process_touch_command(c, tokens, ntokens);
         } else {
             unknown_command = true;
         }
     } else if (cmd[1] == 'o' && cmd[2] == 'p') {
         if (strcmp(cmd, "bop") == 0) {
+            sidx = 1;
+            if (strcmp(tokens[SUBCOMMAND_TOKEN].value, "mget") == 0 || strcmp(tokens[SUBCOMMAND_TOKEN].value, "smget") == 0) kidx = -1;
+            else kidx = 2;
             process_bop_command(c, tokens, ntokens);
         } else if (strcmp(cmd, "mop") == 0) {
+            sidx = 1; kidx = 2;
             process_mop_command(c, tokens, ntokens);
         } else if (strcmp(cmd, "sop") == 0) {
+            sidx = 1; kidx = 2;
             process_sop_command(c, tokens, ntokens);
         } else if (strcmp(cmd, "lop") == 0) {
+            sidx = 1; kidx = 2;
             process_lop_command(c, tokens, ntokens);
         } else {
             unknown_command = true;
         }
     } else if (cmd[0] == 'a') {
         if (strcmp(cmd, "add") == 0) {
+            kidx = 1;
             process_update_command(c, tokens, ntokens, OPERATION_ADD, false);
         } else if (strcmp(cmd, "append") == 0) {
+            kidx = 1;
             process_update_command(c, tokens, ntokens, OPERATION_APPEND, false);
         } else {
             unknown_command = true;
         }
     } else if (cmd[0] == 'p') {
         if (strcmp(cmd, "prepend") == 0) {
+            kidx = 1;
             process_update_command(c, tokens, ntokens, OPERATION_PREPEND, false);
         } else {
             unknown_command = true;
         }
     } else if (cmd[0] == 'c' && cmd[1] == 'a') {
         if (strcmp(cmd, "cas") == 0) {
+            kidx = 1;
             process_update_command(c, tokens, ntokens, OPERATION_CAS, true);
         } else {
             unknown_command = true;
         }
     } else if (cmd[0] == 'r' && cmd[2] == 'p') {
         if (strcmp(cmd, "replace") == 0) {
+            kidx = 1;
             process_update_command(c, tokens, ntokens, OPERATION_REPLACE, false);
         } else {
             unknown_command = true;
         }
     } else if (cmd[0] == 'i') {
         if (strcmp(cmd, "incr") == 0) {
+            kidx = 1;
             process_arithmetic_command(c, tokens, ntokens, 1);
         } else {
             unknown_command = true;
         }
     } else if (cmd[0] == 'd' && cmd[1] == 'e') {
         if (strcmp(cmd, "delete") == 0) {
+            kidx = 1;
             process_delete_command(c, tokens, ntokens);
         } else if (strcmp(cmd, "decr") == 0) {
+            kidx = 1;
             process_arithmetic_command(c, tokens, ntokens, 0);
         } else {
             unknown_command = true;
@@ -14152,31 +14255,38 @@ static void process_command_ascii(conn *c, char *command, int cmdlen)
         }
 #ifdef SASL_ENABLED
         else if (strcmp(cmd, "sasl") == 0) {
+            sidx = 1;
             process_sasl_command(c, tokens, ntokens);
         } else if (strcmp(cmd, "reload") == 0) {
+            sidx = 1;
             process_reload_command(c, tokens, ntokens);
         }
 #endif
 #ifdef SCAN_COMMAND
         else if (strcmp(cmd, "scan") == 0) {
+            sidx = 1;
             process_scan_command(c, tokens, ntokens);
         }
 #endif
 #ifdef COMMAND_LOGGING
         else if (strcmp(cmd, "cmdlog") == 0) {
+            sidx = 1;
             process_cmdlog_command(c, tokens, ntokens);
         }
 #endif
 #ifdef DETECT_LONG_QUERY
         else if (strcmp(cmd, "lqdetect") == 0) {
+            sidx = 1;
             process_lqdetect_command(c, tokens, ntokens);
         }
 #endif
         else if (strcmp(cmd, "config") == 0) {
+            sidx = 1;
             process_config_command(c, tokens, ntokens);
         }
 #ifdef ENABLE_ZK_INTEGRATION
         else if (strcmp(cmd, "zkensemble") == 0) {
+            sidx = 1;
             process_zkensemble_command(c, tokens, ntokens);
         }
 #endif
@@ -14184,6 +14294,7 @@ static void process_command_ascii(conn *c, char *command, int cmdlen)
             CHECK_NTOKENS_EQ(ntokens, 2);
             out_string(c, "VERSION " VERSION);
         } else if (strcmp(cmd, "dump") == 0) {
+            sidx = 1;
             process_dump_command(c, tokens, ntokens);
         } else if (strcmp(cmd, "quit") == 0) {
             CHECK_NTOKENS_EQ(ntokens, 2);
@@ -14218,6 +14329,18 @@ static void process_command_ascii(conn *c, char *command, int cmdlen)
             out_string(c, "ERROR unknown command");
         }
     }
+
+#ifdef COMMAND_LOGGING
+    if (cmdlog_in_use) {
+        token_t *cmd = &tokens[cidx];
+        token_t *subcmd = sidx > 0 ? &tokens[sidx] : NULL;
+        token_t *key = kidx > 0 ? &tokens[kidx] : NULL;
+
+        if (is_cmdlog_filter_match(cmd, subcmd, key, ntokens)) {
+            cmdlog_write(c->client_ip, tokens, ntokens);
+        }
+    }
+#endif
 }
 
 static int try_read_command_ascii(conn *c)


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/626

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- `cmdlog filter` 명령을 처리하는 `process_cmdlog_filter()` 함수를 추가했습니다.
- 필터링 검사를 수행하는 `is_cmdlog_filter_match()` 함수를 추가했습니다.
- `cmdlog_write()`가 기존과 동일한 동작을 하게끔 command에 대한 로직을 수정했습니다.
- `cmdlog_add(), cmdlog_remove(), cmdlog_list()` 함수를 추가했습니다.
- cmd_log_global의 멤버 변수로 필터 리스트 `struct cmd_log_filter filters[CMDLOG_FILTER_MAXNUM]`을 추가했습니다.

### 명세
1. 필터 추가 명령어
`cmdlog filter add (command <cmd> | key <key> | command <cmd> key <key>)`로 필터를 등록한다. command, key 옵션 중 하나는 생략할 수 있다. 생략된 옵션은 필터링하지 않는다. 문자 유효성 검사는 수행하지만, 명령어와 키의 존재 여부를 검사하진 않는다. 필터 수에는 제한이 존재한다.
<details>
<summary>예시</summary>

```
$ cmdlog start
$ cmdlog filter add command add key 01
    0. Filter: command = add, key = 01
$ add 01 0 0 2  // 로깅
$ add 01:02 0 5 1  // 로깅x(키 불일치)

$ cmdlog filter add command bop_insert
    1. Filter: command = bop_insert, key =
$ bop insert  // 필터가 일치해 명령의 결과와 상관없이 로깅
    CLIENT_ERROR bad command line format

// 옵션 모두 생략 시 에러
$ cmdlog filter add
    CLIENT_ERROR bad command line format

// 파라미터가 유효한지 검사
$ cmdlog filter add key \t\n
    CLIENT_ERROR bad command line format
$ cmdlog filter add command add key
    CLIENT_ERROR bad command line format
$ cmdlog filter add key a:b:d!#-^
    2. Filter: command = , key = a:b:d!#-^

// 단 파라미터의 존재 여부를 검사하진 않음
$ cmdlog filter add command dumm1
    2. Filter: command = dumm1, key =

// 필터 최대 개수에 제한 존재
$ cmdlog filter add key a
    3. Filter: command = , key = a
...
$ cmdlog filter add key b
    CLIENT_ERROR filter list is full
```

</details>


2. 필터 삭제 명령어
`cmdlog filter remove (index)`로 필터를 삭제한다. 인덱스를 입력하면 찾아 삭제하고, 생략 시 모든 필터를 삭제한다.
<details>
<summary>예시</summary>

```
$ cmdlog filter remove 99
    CLIENT_ERROR  invalid parameters
$ cmdlog filter remove 2
    1 filters removed
$ cmdlog filter remove
    9 filters removed
$ cmdlog filter remove
    0 filters removed
$ cmdlog filter remove 1
    CLIENT_ERROR invalid parameters
```

</details>


3. 필터 출력 명령어
`cmdlog filter list`로 필터 목록을 출력한다. 현재 필터 수와 최대 필터 수를 같이 출력한다.
<details>
<summary>예시</summary>

```
$ cmdlog filter list
    (2/10)
    1. command=     key=01
    2. command=add  key=02:02
```

</details>

