### PR TITLE
INTERNAL: Change the response to invalid subcommand to print unknown command

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -65,6 +65,13 @@
 #include "cmdlog.h"
 #include "lqdetect.h"
 
+#define CHECK_NTOKENS(ntokens, min, max) \
+    if (ntokens < min || ntokens > max) { \
+        print_invalid_command(c, tokens, ntokens); \
+        out_string(c, "CLIENT_ERROR bad command line format"); \
+        return; \
+    }
+
 /* Lock for global stats */
 static pthread_mutex_t stats_lock = PTHREAD_MUTEX_INITIALIZER;
 
@@ -11091,16 +11098,10 @@ static void process_lop_command(conn *c, token_t *tokens, const size_t ntokens)
     c->coll_key = key;
     c->coll_nkey = nkey;
 
-    if (subcommand[0] == 'i' && strcmp(subcommand, "insert") == 0)
-    //if ((ntokens >= 6 && ntokens <= 13) && (strcmp(subcommand,"insert") == 0))
-    {
+    if (strcmp(subcommand, "insert") == 0) {
         int32_t index, vlen;
 
-        if (ntokens < 6 || ntokens > 13) {
-            print_invalid_command(c, tokens, ntokens);
-            out_string(c, "CLIENT_ERROR bad command line format");
-            return;
-        }
+        CHECK_NTOKENS(ntokens, 6, 13);
 
         set_pipe_noreply_maybe(c, tokens, ntokens);
 
@@ -11142,14 +11143,8 @@ static void process_lop_command(conn *c, token_t *tokens, const size_t ntokens)
             conn_set_state(c, conn_swallow);
         }
     }
-    else if (subcommand[0] == 'c' && (strcmp(subcommand, "create") == 0))
-    //else if ((ntokens >= 7 && ntokens <= 10) && (strcmp(subcommand, "create") == 0))
-    {
-        if (ntokens < 7 || ntokens > 10) {
-            print_invalid_command(c, tokens, ntokens);
-            out_string(c, "CLIENT_ERROR bad command line format");
-            return;
-        }
+    else if (strcmp(subcommand, "create") == 0) {
+        CHECK_NTOKENS(ntokens, 7, 10);
 
         set_noreply_maybe(c, tokens, ntokens);
 
@@ -11166,17 +11161,11 @@ static void process_lop_command(conn *c, token_t *tokens, const size_t ntokens)
         c->coll_attrp = &c->coll_attr_space;
         process_lop_create(c, key, nkey, c->coll_attrp);
     }
-    else if (subcommand[0] == 'd' && (strcmp(subcommand, "delete") == 0))
-    //else if ((ntokens >= 5 && ntokens <= 7) && (strcmp(subcommand, "delete") == 0))
-    {
+    else if (strcmp(subcommand, "delete") == 0) {
         int32_t from_index, to_index;
         bool drop_if_empty = false;
 
-        if (ntokens < 5 || ntokens > 7) {
-            print_invalid_command(c, tokens, ntokens);
-            out_string(c, "CLIENT_ERROR bad command line format");
-            return;
-        }
+        CHECK_NTOKENS(ntokens, 5, 7);
 
         set_pipe_noreply_maybe(c, tokens, ntokens);
 
@@ -11203,18 +11192,12 @@ static void process_lop_command(conn *c, token_t *tokens, const size_t ntokens)
             conn_set_state(c, conn_new_cmd);
         }
     }
-    else if (subcommand[0] == 'g' && (strcmp(subcommand, "get") == 0))
-    //else if ((ntokens==5 || ntokens==6) && (strcmp(subcommand, "get") == 0))
-    {
+    else if (strcmp(subcommand, "get") == 0) {
         int32_t from_index, to_index;
         bool delete = false;
         bool drop_if_empty = false;
 
-        if (ntokens < 5 || ntokens > 6) {
-            print_invalid_command(c, tokens, ntokens);
-            out_string(c, "CLIENT_ERROR bad command line format");
-            return;
-        }
+        CHECK_NTOKENS(ntokens, 5, 6);
 
         if (get_list_range_from_str(tokens[LOP_KEY_TOKEN+1].value, &from_index, &to_index)) {
             print_invalid_command(c, tokens, ntokens);
@@ -11236,8 +11219,7 @@ static void process_lop_command(conn *c, token_t *tokens, const size_t ntokens)
 
         process_lop_get(c, key, nkey, from_index, to_index, delete, drop_if_empty);
     }
-    else
-    {
+    else {
         print_invalid_command(c, tokens, ntokens);
         out_string(c, "ERROR unknown command");
     }

--- a/memcached.c
+++ b/memcached.c
@@ -11091,9 +11091,16 @@ static void process_lop_command(conn *c, token_t *tokens, const size_t ntokens)
     c->coll_key = key;
     c->coll_nkey = nkey;
 
-    if ((ntokens >= 6 && ntokens <= 13) && (strcmp(subcommand,"insert") == 0))
+    if (subcommand[0] == 'i' && strcmp(subcommand, "insert") == 0)
+    //if ((ntokens >= 6 && ntokens <= 13) && (strcmp(subcommand,"insert") == 0))
     {
         int32_t index, vlen;
+
+        if (ntokens < 6 || ntokens > 13) {
+            print_invalid_command(c, tokens, ntokens);
+            out_string(c, "CLIENT_ERROR bad command line format");
+            return;
+        }
 
         set_pipe_noreply_maybe(c, tokens, ntokens);
 
@@ -11135,8 +11142,15 @@ static void process_lop_command(conn *c, token_t *tokens, const size_t ntokens)
             conn_set_state(c, conn_swallow);
         }
     }
-    else if ((ntokens >= 7 && ntokens <= 10) && (strcmp(subcommand, "create") == 0))
+    else if (subcommand[0] == 'c' && (strcmp(subcommand, "create") == 0))
+    //else if ((ntokens >= 7 && ntokens <= 10) && (strcmp(subcommand, "create") == 0))
     {
+        if (ntokens < 7 || ntokens > 10) {
+            print_invalid_command(c, tokens, ntokens);
+            out_string(c, "CLIENT_ERROR bad command line format");
+            return;
+        }
+
         set_noreply_maybe(c, tokens, ntokens);
 
         int read_ntokens = LOP_KEY_TOKEN+1;
@@ -11152,10 +11166,17 @@ static void process_lop_command(conn *c, token_t *tokens, const size_t ntokens)
         c->coll_attrp = &c->coll_attr_space;
         process_lop_create(c, key, nkey, c->coll_attrp);
     }
-    else if ((ntokens >= 5 && ntokens <= 7) && (strcmp(subcommand, "delete") == 0))
+    else if (subcommand[0] == 'd' && (strcmp(subcommand, "delete") == 0))
+    //else if ((ntokens >= 5 && ntokens <= 7) && (strcmp(subcommand, "delete") == 0))
     {
         int32_t from_index, to_index;
         bool drop_if_empty = false;
+
+        if (ntokens < 5 || ntokens > 7) {
+            print_invalid_command(c, tokens, ntokens);
+            out_string(c, "CLIENT_ERROR bad command line format");
+            return;
+        }
 
         set_pipe_noreply_maybe(c, tokens, ntokens);
 
@@ -11182,11 +11203,18 @@ static void process_lop_command(conn *c, token_t *tokens, const size_t ntokens)
             conn_set_state(c, conn_new_cmd);
         }
     }
-    else if ((ntokens==5 || ntokens==6) && (strcmp(subcommand, "get") == 0))
+    else if (subcommand[0] == 'g' && (strcmp(subcommand, "get") == 0))
+    //else if ((ntokens==5 || ntokens==6) && (strcmp(subcommand, "get") == 0))
     {
         int32_t from_index, to_index;
         bool delete = false;
         bool drop_if_empty = false;
+
+        if (ntokens < 5 || ntokens > 6) {
+            print_invalid_command(c, tokens, ntokens);
+            out_string(c, "CLIENT_ERROR bad command line format");
+            return;
+        }
 
         if (get_list_range_from_str(tokens[LOP_KEY_TOKEN+1].value, &from_index, &to_index)) {
             print_invalid_command(c, tokens, ntokens);
@@ -11211,7 +11239,7 @@ static void process_lop_command(conn *c, token_t *tokens, const size_t ntokens)
     else
     {
         print_invalid_command(c, tokens, ntokens);
-        out_string(c, "CLIENT_ERROR bad command line format");
+        out_string(c, "ERROR unknown command");
     }
 }
 


### PR DESCRIPTION
### 🔗 Related Issue
- https://github.com/issues/assigned?issue=jam2in%7Carcus-works%7C784

### ⌨️ What I did
- 잘못된 subcommand에 대해 `unknown command`를 출력하게 변경했습니다.
- command, subcommand가 일치하고 토큰 수가 일치하지 않는 경우 `CLIENT ERROR bad command line format`을 출력합니다.

- poc를 위해 lop 명령에 대해서만 수정했습니다. 완성된 코드가 아니니 참고 부탁드립니다.