### PR TITLE
FIX: Increase gat command token count from 3 to 4

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -13919,11 +13919,11 @@ static void process_command_ascii(conn *c, char *command, int cmdlen)
     {
         process_get_command(c, tokens, ntokens, true, false);
     }
-    else if ((ntokens >= 3) && (strcmp(tokens[COMMAND_TOKEN].value, "gat") == 0))
+    else if ((ntokens >= 4) && (strcmp(tokens[COMMAND_TOKEN].value, "gat") == 0))
     {
         process_get_command(c, tokens, ntokens, false, true);
     }
-    else if ((ntokens >= 3) && (strcmp(tokens[COMMAND_TOKEN].value, "gats") == 0))
+    else if ((ntokens >= 4) && (strcmp(tokens[COMMAND_TOKEN].value, "gats") == 0))
     {
         process_get_command(c, tokens, ntokens, true, true);
     }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- jam2in/arcus-works#815

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- `gat/gats` 명령어에서의 잘못된 토큰 수를 고칩니다.
