### PR TITLE
CLEANUP: Refactor shard key extraction out of hash_ketama

### DIFF
--- a/cluster_config.c
+++ b/cluster_config.c
@@ -87,21 +87,23 @@ struct cluster_config {
 
 static const char *get_shard_key(const char *key, uint32_t nkey, uint32_t *nshardkey)
 {
+    *nshardkey = nkey;
+
     const char *left = memchr(key, '{', nkey);
     if (left == NULL) {
-        return NULL;
+        return key;
     }
 
     const char *right = memchr(left + 1, '}', nkey - (left - key) - 1);
     if (right == NULL) {
-        return NULL;
+        return key;
+    }
+
+    if (left + 1 == right) {
+        return key;
     }
 
     *nshardkey = right - left - 1;
-    if (*nshardkey == 0) {
-        return NULL;
-    }
-
     return left + 1;
 }
 
@@ -114,18 +116,9 @@ static void hash_md5(const char *key, uint32_t nkey, unsigned char *result)
     MD5Final(result, &ctx);
 }
 
-static uint32_t hash_ketama(const char *key, uint32_t nkey, bool enable_shard_key)
+static uint32_t hash_ketama(const char *key, uint32_t nkey)
 {
     unsigned char digest[16];
-
-    if (enable_shard_key) {
-        uint32_t nshardkey;
-        const char *shardkey = get_shard_key(key, nkey, &nshardkey);
-        if (shardkey) {
-            key = shardkey;
-            nkey = nshardkey;
-        }
-    }
 
     hash_md5(key, nkey, digest);
     return (uint32_t)((digest[3] << 24)
@@ -716,7 +709,11 @@ int cluster_config_key_is_mine(struct cluster_config *config,
                                uint32_t *key_id, uint32_t *self_id)
 {
     assert(config && config->continuum);
-    uint32_t digest = hash_ketama(key, nkey, config->enable_shard_key);
+
+    if (config->enable_shard_key) {
+        key = get_shard_key(key, nkey, &nkey);
+    }
+    uint32_t digest = hash_ketama(key, nkey);
     int ret = 0;
 
     pthread_mutex_lock(&config->ketama_lock);


### PR DESCRIPTION
### 🔗 Related Issue

- #919 

### ⌨️ What I did

- `get_shard_key()`에서 유효한 shard key를 찾을 수 없는 경우 NULL 대신 전체 key를 반환합니다.
- `hash_ketama()` 외부에서 `config->enable_shard_key`에 따라 shard key를 계산하여 전달합니다.
  - 현재 PR이 EE에 반영되면 기존에 `hash_ketama()` 호출하던 로직 추가 수정해야 합니다.

#919와 이번 PR의 변경사항을 통합하여 보면 아래와 같이 됩니다.
https://github.com/naver/arcus-memcached/compare/77e795038cd5e48a33c684b4ee67eb076338528e..namsic:shard_key

