### PR TITLE
FEATURE: Refactor config file support for server configuration

### DIFF
--- a/arcus.conf
+++ b/arcus.conf
@@ -1,0 +1,165 @@
+# ============================================================
+# Arcus-memcached Configuration File
+#
+# This file is used to configure the Arcus-memcached server at startup.
+#
+# Usage:
+#   ./memcached arcus.conf
+#   ./memcached arcus.conf -p 20000 (CLI options override config file settings)
+#
+# Format:
+#   key=value
+#   Lines starting with '#' are treated as comments.
+#   Numeric values can use suffixes K, M, G, T (case-insensitive).
+# ============================================================
+
+# -----------------------------------------------------------------------------
+# General & Process
+# -----------------------------------------------------------------------------
+# [Required] Path to the storage engine library (.so).
+# This must be specified to start the server.
+engine_path=.libs/default_engine.so
+
+# Raw configuration string passed directly to the engine.
+# Format: param1=val1;param2=val2...
+# engine_config=conf/default_engine.conf
+
+# Run as a daemon (background process). (Default: false)
+# daemonize=false
+
+# File to write the Process ID (PID) to when running as a daemon.
+# pid_file=/var/run/memcached.pid
+
+# Assume the identity of <username> (drops root privileges).
+# Effectively switches the user after starting.
+# username=root
+
+# Set core file size limit to maximum (Default: 0)
+# Used for debugging purposes to allow core dumps.
+# It has value 0(false) or 1(true).
+# maxcore=0
+
+# -----------------------------------------------------------------------------
+# Network & Connection
+# -----------------------------------------------------------------------------
+# TCP port number to listen on. (Default: 11211)
+port=11211
+
+# UDP port number to listen on. (Default: 0)
+# 0 means off.
+# udpport=0
+
+# The IP address of the network interface to listen on.
+# 0.0.0.0 means listen on all available interfaces (Default: INADDR_ANY).
+# listen=0.0.0.0
+
+# Path to the UNIX socket file.
+# socketpath=/tmp/memcached.sock
+
+# Access mask for the UNIX socket in octal. (Default: 0700)
+# access=0700
+
+# Maximum number of simultaneous connections. (Default: 1024)
+# Connections exceeding this limit may be queued or rejected.
+# maxconns=1024
+
+# Backlog queue limit for pending connections. (Default: 1024)
+# backlog=1024
+
+# Protocol to use (auto, binary, ascii). (Default: auto)
+# protocol=auto
+
+# Require SASL authentication for connections. (Default: false)
+# Only available if compiled with SASL support.
+# require_sasl=false
+
+# -----------------------------------------------------------------------------
+# Memory & Storage
+# -----------------------------------------------------------------------------
+# Maximum memory to use for item storage. (Default: 64M)
+# Recommended to specify in megabytes (MB).
+memory_limit=64M
+
+# Maximum size of a single item. (Default: 1M)
+# Min: 20K, Max: 128M.
+# item_size_max=1M
+
+# Action to take when memory is exhausted. (Default: true)
+# true  = Evict old items (LRU) to make space.
+# false = Return an error instead of evicting items.
+# eviction=true
+
+# Chunk size growth factor between slab classes. (Default: 1.25)
+# Controls the size increase of chunks in subsequent slab classes.
+# factor set value bigger than 1.
+# factor=1.25
+
+# Minimum space allocated for key+value+flags. (Default: 48)
+# chunk_size=48
+
+# Maximum memory to use for sticky (gummed) item storage. (Default: 0)
+# Reserved memory for items that should not be evicted.
+# Recommended to specify in megabytes (MB).
+# sticky_limit=0
+
+# Use large memory pages if available. (Default: false)
+# Can improve performance by reducing TLB misses.
+# preallocate=false
+
+# Lock down all paged memory. (Default: false)
+# Prevents memory from being swapped out, but may fail if system limit is exceeded.
+# lock_memory=false
+
+# Enable CAS (Check-And-Set) feature. (Default: true)
+# Ensures data consistency. Set to false to disable.
+# use_cas=true
+
+# Character to use as a delimiter for key prefixes. (Default: :)
+# prefix_delimiter=:
+
+# -----------------------------------------------------------------------------
+# Performance & Tuning
+# -----------------------------------------------------------------------------
+# Number of worker threads to process incoming requests. (Default: 4)
+# Typically set to the number of CPU cores.
+# threads=4
+
+# Maximum number of requests per event. (Default: 20)
+# Limits the number of requests processed for a given connection to prevent starvation.
+# reqs_per_event=20
+
+# -----------------------------------------------------------------------------
+# Logging & Statistics
+# -----------------------------------------------------------------------------
+# Verbose logging level. (Default: 0)
+# 0 = Warning, 1 = Info, 2 = Debug, 3 = Detail
+# Higher values result in more detailed logging.
+verbosity=0
+
+# Allow the 'stats detail' command to be used. (Default: true)
+# allow_detailed=true
+
+# Enable detailed stats collection. (Default: false)
+# detail_enabled=true
+
+# -----------------------------------------------------------------------------
+# Extensions & Modules
+# -----------------------------------------------------------------------------
+# Load extension libraries (.so).
+# Used to load additional modules like loggers or management tools.
+# Multiple extensions can be specified.
+# extension=.libs/userlog_logger.so
+# extension=.libs/ascii_scrub.so
+
+# -----------------------------------------------------------------------------
+# ZooKeeper Support
+# -----------------------------------------------------------------------------
+# ZooKeeper ensemble server list.
+# Only available if compiled with ZooKeeper support.
+# Format: host1:port1,host2:port2,...
+# zookeeper=zk1.local:2181,zk2.local:2181,zk3.local:2181
+
+# ZooKeeper session timeout in seconds. (Default: 0 -> Uses internal default)
+# Only available if compiled with ZooKeeper support.
+# Recommended value: > 10 and < 2000 (check internal implementation limits).
+# zk_timeout=60

--- a/config_parser.c
+++ b/config_parser.c
@@ -26,9 +26,6 @@
 #include <memcached/config_parser.h>
 #include <memcached/util.h>
 
-static int read_config_file(const char *fname, struct config_item items[],
-                            FILE *error);
-
 /**
  * Copy a string and trim of leading and trailing white space characters.
  * Allow the user to escape out the stop character by putting a backslash before
@@ -229,8 +226,7 @@ int parse_config(const char *str, struct config_item *items, FILE *error) {
    return ret;
 }
 
-static int read_config_file(const char *fname, struct config_item items[],
-                            FILE *error) {
+int read_config_file(const char *fname, struct config_item items[], FILE *error) {
    FILE *fp = fopen(fname, "r");
    if (fp == NULL) {
       (void)fprintf(error, "Failed to open file: %s\n", fname);

--- a/include/memcached/config_parser.h
+++ b/include/memcached/config_parser.h
@@ -79,6 +79,7 @@ struct config_item {
  */
 MEMCACHED_PUBLIC_API int parse_config(const char *str, struct config_item items[], FILE *error);
 
+int read_config_file(const char *fname, struct config_item items[], FILE *error);
 #ifdef __cplusplus
 }
 #endif

--- a/memcached.c
+++ b/memcached.c
@@ -16064,11 +16064,19 @@ static int settings_check(void)
             "The value of memory limit must be greater than 0.\n");
         return -1;
     }
+    if (settings.maxbytes % (1024 * 1024) != 0) {
+        mc_logger->log(EXTENSION_LOG_WARNING, NULL,
+            "WARNING: The value of memory limit is recommended to be in MB!\n");
+    }
 #ifdef ENABLE_STICKY_ITEM
     if (settings.maxbytes < settings.sticky_limit) {
         mc_logger->log(EXTENSION_LOG_WARNING, NULL,
             "The value of memory limit cannot be smaller than sticky_limit.\n");
         return -1;
+    }
+    if (settings.sticky_limit % (1024 * 1024) != 0) {
+        mc_logger->log(EXTENSION_LOG_WARNING, NULL,
+            "WARNING: The value of sticky_limit is recommended to be in MB!\n");
     }
 #endif
     if (settings.reqs_per_event <= 0) {
@@ -16140,6 +16148,79 @@ static void close_listen_sockets(void)
     }
 }
 
+#define FREE_ONCE(p) do { static bool _f=0; if (!_f&&p) free(p); _f=1; } while(0)
+
+static int load_config_file(const char *path)
+{
+    char *access_mask_str = NULL;
+    const int CFG_PORT_IDX = 0;
+    const int CFG_UDPPORT_IDX = 1;
+    struct config_item config_items[] = {
+        { .key = "port",             .datatype = DT_UINT32,   .value.dt_uint32   = (uint32_t*)&settings.port },
+        { .key = "udpport",          .datatype = DT_UINT32,   .value.dt_uint32   = (uint32_t*)&settings.udpport },
+        { .key = "factor",           .datatype = DT_FLOAT,    .value.dt_float    = &settings.factor },
+        { .key = "socketpath",       .datatype = DT_STRING,   .value.dt_string   = &settings.socketpath },
+        { .key = "access",           .datatype = DT_STRING,   .value.dt_string   = &access_mask_str },
+        { .key = "listen",           .datatype = DT_STRING,   .value.dt_string   = &settings.inter },
+        { .key = "daemonize",        .datatype = DT_BOOL,     .value.dt_bool     = &settings.daemonize },
+        { .key = "maxcore",          .datatype = DT_UINT32,   .value.dt_uint32   = (uint32_t*)&settings.maxcore },
+        { .key = "username",         .datatype = DT_STRING,   .value.dt_string   = &settings.username },
+        { .key = "maxconns",         .datatype = DT_UINT32,   .value.dt_uint32   = (uint32_t*)&settings.maxconns },
+        { .key = "lock_memory",      .datatype = DT_BOOL,     .value.dt_bool     = &settings.lock_memory },
+        { .key = "memory_limit",     .datatype = DT_SIZE,     .value.dt_size     = &settings.maxbytes },
+#ifdef ENABLE_STICKY_ITEM
+        { .key = "sticky_limit",     .datatype = DT_SIZE,     .value.dt_size     = &settings.sticky_limit },
+#endif
+        { .key = "verbosity",        .datatype = DT_UINT32,   .value.dt_uint32   = (uint32_t*)&settings.verbose },
+        { .key = "pid_file",         .datatype = DT_STRING,   .value.dt_string   = &settings.pid_file },
+        { .key = "threads",          .datatype = DT_UINT32,   .value.dt_uint32   = (uint32_t*)&settings.num_threads },
+        { .key = "reqs_per_event",   .datatype = DT_UINT32,   .value.dt_uint32   = (uint32_t*)&settings.reqs_per_event },
+        { .key = "backlog",          .datatype = DT_UINT32,   .value.dt_uint32   = (uint32_t*)&settings.backlog },
+        { .key = "protocol",         .datatype = DT_CALLBACK, .value.dt_callback = (bool(*)(char*))parse_binding_protocol },
+        { .key = "engine_config",    .datatype = DT_STRING,   .value.dt_string   = &settings.engine_config },
+        { .key = "engine_path",      .datatype = DT_STRING,   .value.dt_string   = &settings.engine_path },
+        { .key = "eviction",         .datatype = DT_BOOL,     .value.dt_bool     = &settings.evict_to_free },
+        { .key = "chunk_size",       .datatype = DT_UINT32,   .value.dt_uint32   = (uint32_t*)&settings.chunk_size },
+        { .key = "prefix_delimiter", .datatype = DT_CHAR,     .value.dt_char     = &settings.prefix_delimiter },
+        { .key = "allow_detailed",   .datatype = DT_BOOL,     .value.dt_bool     = &settings.allow_detailed },
+        { .key = "detail_enabled",   .datatype = DT_BOOL,     .value.dt_bool     = &settings.detail_enabled },
+        { .key = "use_cas",          .datatype = DT_BOOL,     .value.dt_bool     = &settings.use_cas },
+        { .key = "item_size_max",    .datatype = DT_SIZE,     .value.dt_size     = &settings.item_size_max },
+        { .key = "preallocate",      .datatype = DT_BOOL,     .value.dt_bool     = &settings.preallocate },
+        { .key = "extension",        .datatype = DT_CALLBACK, .value.dt_callback = load_extension },
+#ifdef ENABLE_ZK_INTEGRATION
+        { .key = "zookeeper",        .datatype = DT_STRING,   .value.dt_string   = &arcus_zk_cfg },
+        { .key = "zk_timeout",       .datatype = DT_UINT32,   .value.dt_uint32   = (uint32_t*)&arcus_zk_to },
+#ifdef PROXY_SUPPORT
+        { .key = "proxy_config",     .datatype = DT_STRING,   .value.dt_string   = &arcus_proxy_cfg },
+#endif
+#endif
+#ifdef SASL_ENABLED
+        { .key = "require_sasl",     .datatype = DT_BOOL,     .value.dt_bool     = &settings.require_sasl },
+#endif
+        { .key = NULL }
+    };
+
+    if (read_config_file(path, config_items, stderr) == -1) {
+        mc_logger->log(EXTENSION_LOG_WARNING, NULL, "Error parsing config file. Aborting.\n");
+        return -1;
+    }
+
+    if (access_mask_str != NULL) {
+        settings.access = strtol(access_mask_str, NULL, 8);
+        free(access_mask_str);
+    }
+
+    tcp_specified = config_items[CFG_PORT_IDX].found;
+    udp_specified = config_items[CFG_UDPPORT_IDX].found;
+
+    if (settings.verbose > 0) {
+        perform_callbacks(ON_LOG_LEVEL, NULL, NULL);
+    }
+
+    return 0;
+}
+
 int main (int argc, char **argv)
 {
     int c;
@@ -16166,6 +16247,14 @@ int main (int argc, char **argv)
     if (memcached_initialize_stderr_logger(get_server_api) != EXTENSION_SUCCESS) {
         fprintf(stderr, "Failed to initialize log system\n");
         return EX_OSERR;
+    }
+
+    /* parse config file */
+    if (argc > 1 && argv[1][0] != '-') {
+        if (load_config_file(argv[1]) != 0) {
+            exit(EXIT_FAILURE);
+        }
+        optind++;
     }
 
     /* process arguments */
@@ -16225,6 +16314,7 @@ int main (int argc, char **argv)
             tcp_specified = true;
             break;
         case 's':
+            FREE_ONCE(settings.socketpath);
             settings.socketpath = optarg;
             break;
         case 'm':
@@ -16265,6 +16355,7 @@ int main (int argc, char **argv)
             perform_callbacks(ON_LOG_LEVEL, NULL, NULL);
             break;
         case 'l':
+            if (settings.inter) free(settings.inter);
             settings.inter = strdup(optarg);
             break;
         case 'd':
@@ -16277,9 +16368,11 @@ int main (int argc, char **argv)
             settings.reqs_per_event = atoi(optarg);
             break;
         case 'u':
+            FREE_ONCE(settings.username);
             settings.username = optarg;
             break;
         case 'P':
+            FREE_ONCE(settings.pid_file);
             settings.pid_file = optarg;
             break;
         case 'f':
@@ -16309,7 +16402,7 @@ int main (int argc, char **argv)
                 mc_logger->log(EXTENSION_LOG_WARNING, NULL,
                         "Invalid value for binding protocol: %s\n"
                         " -- should be one of auto, binary, or ascii\n", optarg);
-                exit(EX_USAGE);
+                exit(EXIT_FAILURE);
             }
             break;
         case 'I':
@@ -16328,9 +16421,11 @@ int main (int argc, char **argv)
             }
             break;
         case 'E':
+            FREE_ONCE(settings.engine_path);
             settings.engine_path = optarg;
             break;
         case 'e':
+            FREE_ONCE(settings.engine_config);
             settings.engine_config = optarg;
             break;
         case 'q':
@@ -16354,6 +16449,7 @@ int main (int argc, char **argv)
         case 'z': /* configure for Arcus zookeeper cluster */
                   /* host_list in the form of
                      -z 10.0.0.1:2181,10.0.0.2:2181,10.0.0.3:2181 */
+            FREE_ONCE(arcus_zk_cfg);
             arcus_zk_cfg = optarg;
             break;
         case 'o': /* Arcus Zookeeper session timeout */
@@ -16361,6 +16457,7 @@ int main (int argc, char **argv)
             break;
 #ifdef PROXY_SUPPORT
         case 'x': /* configure for proxy server */
+            if (arcus_proxy_cfg) free(arcus_proxy_cfg);
             arcus_proxy_cfg = strdup(optarg);
             break;
 #endif


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- #663 
- https://github.com/jam2in/arcus-works/issues/808

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
기존에 engine 설정만 가능했던 config file 설정 기능을 확장하여, engine외의 다른 설정도 파일 형태로 가능하게 하도록 합니다. 
(`-e config_file=/config_file1.conf`)

1. 구동시 옵션을 직접 전달하는 대신, config file 경로를 인자로 넘겨 초기 설정을 자동으로 적용하도록 합니다. 
(대부분의 프로그램에서 차용하는 방식)
    - `main()`실행시, 구동옵션을 확인하기 전에 첫번째 인자를 config file경로를 인식하도록 기능을 확장합니다.
```Shell
./memcached /path/to/arcus.conf
```

2. `try_load_config_file()`을 구현하여, `.conf`파일을 라인 단위로 읽어서 모든 값을 설정합니다.
    - `getopt`의 `optind`를 동적으로 조정하여 config file과 구동옵션을 혼용할때, 구동 옵션값이 덮어씌어지도록 합니다.

3. https://github.com/jam2in/arcus-works/issues/808 를 통한 `old_opts` 중복 해결
    - 기존에는 `getopt`(구동옵션값 설정)루프 내에서 `settings` 전역 구조체와 `old_opts` 문자열 생성을 동시에 수행하기에, config file과 구동옵션을 동시에 수행하면 `old_opts`에 중복된 값이 들어갔습니다.
    - 이에 config_file과 구동옵션 모두 `settings` 전역 구조체만 업데이트를 수행하고, 파싱이후에 `old_opts` 문자열을 작성하도록 했습니다.