### PR TITLE
CLEANUP: Extract all ASCII command handling into functions

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -14003,6 +14003,38 @@ static void process_touch_command(conn *c, token_t *tokens, const size_t ntokens
     }
 }
 
+static void process_version_command(conn *c, token_t *tokens, const size_t ntokens)
+{
+    CHECK_NTOKENS_EQ(ntokens, 2);
+
+    out_string(c, "VERSION " VERSION);
+}
+
+static void process_quit_command(conn *c, token_t *tokens, const size_t ntokens)
+{
+    CHECK_NTOKENS_EQ(ntokens, 2);
+
+    LOCK_STATS();
+    mc_stats.quit_conns++;
+    UNLOCK_STATS();
+    conn_set_state(c, conn_closing);
+}
+
+static void process_ready_command(conn *c, token_t *tokens, const size_t ntokens)
+{
+    CHECK_NTOKENS_EQ(ntokens, 2);
+
+    char *response = "READY";
+#ifdef ENABLE_ZK_INTEGRATION
+    if (arcus_zk_initalized()) {
+        arcus_zk_stats zk_stats;
+        arcus_zk_get_stats(&zk_stats);
+        if (!zk_stats.zk_ready) response = "NOT_READY";
+    }
+#endif
+    out_string(c, response);
+}
+
 static void process_command_ascii(conn *c, char *command, int cmdlen)
 {
     /* One more token is reserved in tokens strucure
@@ -14181,27 +14213,13 @@ static void process_command_ascii(conn *c, char *command, int cmdlen)
         }
 #endif
         else if (strcmp(cmd, "version") == 0) {
-            CHECK_NTOKENS_EQ(ntokens, 2);
-            out_string(c, "VERSION " VERSION);
+            process_version_command(c, tokens, ntokens);
         } else if (strcmp(cmd, "dump") == 0) {
             process_dump_command(c, tokens, ntokens);
         } else if (strcmp(cmd, "quit") == 0) {
-            CHECK_NTOKENS_EQ(ntokens, 2);
-            LOCK_STATS();
-            mc_stats.quit_conns++;
-            UNLOCK_STATS();
-            conn_set_state(c, conn_closing);
+            process_quit_command(c, tokens, ntokens);
         } else if (strcmp(cmd, "ready") == 0) {
-            CHECK_NTOKENS_EQ(ntokens, 2);
-            char *response = "READY";
-#ifdef ENABLE_ZK_INTEGRATION
-            if (arcus_zk_initalized()) {
-                arcus_zk_stats zk_stats;
-                arcus_zk_get_stats(&zk_stats);
-                if (!zk_stats.zk_ready) response = "NOT_READY";
-            }
-#endif
-            out_string(c, response);
+            process_ready_command(c, tokens, ntokens);
         } else if (strcmp(cmd, "shutdown") == 0) {
             process_shutdown_command(c, tokens, ntokens);
         } else if (strcmp(cmd, "help") == 0) {


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
-

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- version, ready, quit 함수를 각각 함수로 분리하여 공통화합니다.
- command 처리 로직을 다른 로직과 동일하게 `process_{}_command` 구조에서 처리하도록 변경하여 일관성을 높입니다.