### PR TITLE
INTERNAL: Fix overflow when parsing config

### DIFF
--- a/config_parser.c
+++ b/config_parser.c
@@ -147,7 +147,7 @@ int parse_config(const char *str, struct config_item *items, FILE *error) {
 
                   if (items[ii].datatype == DT_SIZE) {
                       uint64_t val;
-                      if (safe_strtoull(value, &val)) {
+                      if (safe_strtoull(value, &val) && val <= UINT64_MAX / multiplier) {
                           *items[ii].value.dt_size = (size_t)(val * multiplier);
                           items[ii].found = true;
                       } else {
@@ -155,7 +155,7 @@ int parse_config(const char *str, struct config_item *items, FILE *error) {
                       }
                   } else {
                       uint32_t val;
-                      if (safe_strtoul(value, &val)) {
+                      if (safe_strtoul(value, &val) && val <= UINT32_MAX / multiplier) {
                           *items[ii].value.dt_uint32 = val * multiplier;
                           items[ii].found = true;
                       } else {


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
-

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- config_parser 로직에서 값이 overflow 나는 경우에 대한 처리를 추가합니다.
