### PR TITLE
INTERNAL: Change evict_to_free/detail_enabled to boolean

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -309,7 +309,7 @@ static bool grow_dynamic_buffer(conn *c, size_t needed)
 
 static void disable_stats_detail(void)
 {
-    settings.detail_enabled = 0;
+    settings.detail_enabled = false;
     mc_logger->log(EXTENSION_LOG_WARNING, NULL,
                    "Detailed stats internally disabled.\n");
 }
@@ -387,13 +387,13 @@ static void settings_init(void)
     settings.sticky_limit = 0;        /* default: 0 MB */
     settings.verbose = 0;
     settings.oldest_live = 0;
-    settings.evict_to_free = 1;       /* push old items out of cache when memory runs out */
+    settings.evict_to_free = true;    /* push old items out of cache when memory runs out */
     settings.socketpath = NULL;       /* by default, not using a unix socket */
     settings.factor = 1.25;
     settings.chunk_size = 48;         /* space for a modest key and value */
     settings.num_threads = 4;         /* N workers */
     settings.prefix_delimiter = ':';
-    settings.detail_enabled = 0;
+    settings.detail_enabled = false;
     settings.allow_detailed = true;
     settings.reqs_per_event = DEFAULT_REQS_PER_EVENT;
     settings.backlog = 1024;
@@ -4228,9 +4228,9 @@ static void process_bin_stat(conn *c)
                 append_bin_stats("detailed", strlen("detailed"), dump_buf, len, c);
                 free(dump_buf);
             } else if (strncmp(subcmd_pos, " on", 3) == 0) {
-                settings.detail_enabled = 1;
+                settings.detail_enabled = true;
             } else if (strncmp(subcmd_pos, " off", 4) == 0) {
-                settings.detail_enabled = 0;
+                settings.detail_enabled = false;
             } else {
                 write_bin_packet(c, PROTOCOL_BINARY_RESPONSE_KEY_ENOENT, 0);
                 return;
@@ -8264,11 +8264,11 @@ inline static void process_stats_detail(conn *c, const char *command)
 
     if (settings.allow_detailed) {
         if (strcmp(command, "on") == 0) {
-            settings.detail_enabled = 1;
+            settings.detail_enabled = true;
             out_string(c, "OK");
         }
         else if (strcmp(command, "off") == 0) {
-            settings.detail_enabled = 0;
+            settings.detail_enabled = false;
             out_string(c, "OK");
         }
         else if (strcmp(command, "dump") == 0) {
@@ -16226,7 +16226,7 @@ int main (int argc, char **argv)
             settings.maxbytes = (size_t)cache_memory_limit * 1024 * 1024;
             break;
         case 'M':
-            settings.evict_to_free = 0;
+            settings.evict_to_free = false;
             break;
 #ifdef ENABLE_STICKY_ITEM
         case 'g':
@@ -16283,7 +16283,7 @@ int main (int argc, char **argv)
             break;
         case 'D':
             settings.prefix_delimiter = optarg[0];
-            settings.detail_enabled = 1;
+            settings.detail_enabled = true;
             break;
         case 'L' :
             settings.preallocate = true;
@@ -16387,7 +16387,7 @@ int main (int argc, char **argv)
     /* build options to pass to the cache/storage engine. */
     old_opts += sprintf(old_opts, "num_threads=%lu;", (unsigned long)settings.num_threads);
     old_opts += sprintf(old_opts, "cache_size=%llu;", (unsigned long long)settings.maxbytes);
-    if (settings.evict_to_free == 0) {
+    if (settings.evict_to_free == false) {
         old_opts += sprintf(old_opts, "eviction=false;");
     }
 #ifdef ENABLE_STICKY_ITEM

--- a/memcached.h
+++ b/memcached.h
@@ -234,14 +234,14 @@ struct settings {
     char *inter;
     int verbose;
     rel_time_t oldest_live; /* ignore existing items older than this */
-    int evict_to_free;
+    bool evict_to_free;
     char *socketpath;   /* path to unix socket if using local socket */
     int access;  /* access mask (a la chmod) for unix domain socket */
     double factor;          /* chunk size growth factor */
     int chunk_size;
     int num_threads;        /* number of worker (without dispatcher) libevent threads to run */
     char prefix_delimiter;  /* character that marks a key prefix (for stats) */
-    int detail_enabled;     /* nonzero if we're collecting detailed stats */
+    bool detail_enabled;     /* nonzero if we're collecting detailed stats */
     bool allow_detailed;    /* detailed stats commands are allowed */
     int reqs_per_event;     /* Maximum number of io to process on each io-event. */
     bool use_cas;


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- #945 

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- evict_to_free/detail_enabled의 타입을 boolean으로 변경합니다.
- 해당 값은 on/off 상태만을 표현하므로, int 타입보다 boolean 타입이 더 적합합니다.
- 추후 config file 기능이 추가될 경우, true/false 값을 별도의 변환 없이 해당 변수에 직접 저장할 수 있습니다.