### PR TITLE
INTERNAL: Return -1 on settings check failure

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -16052,7 +16052,7 @@ static int settings_check(void)
     if (settings.maxbytes == 0) {
         mc_logger->log(EXTENSION_LOG_WARNING, NULL,
             "The value of memory limit must be greater than 0.\n");
-        return 1;
+        return -1;
     }
 #ifdef ENABLE_STICKY_ITEM
     if (settings.maxbytes < settings.sticky_limit) {


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
-

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- settings_check 실패 시 1로 잘못 리턴되어 있던 값을 -1로 변경합니다.