### PR TITLE
INTERNAL: Add a callback type for config_parser

### DIFF
--- a/config_parser.c
+++ b/config_parser.c
@@ -194,6 +194,11 @@ int parse_config(const char *str, struct config_item *items, FILE *error) {
                   ret = -1;
                }
                break;
+            case DT_CALLBACK:
+               if (!items[ii].value.dt_callback(value)) {
+                  ret = -1;
+               }
+               break;
             case DT_CONFIGFILE:
                {
                   int r = read_config_file(value, items, error);

--- a/include/memcached/config_parser.h
+++ b/include/memcached/config_parser.h
@@ -35,7 +35,8 @@ enum config_datatype {
    DT_BOOL,
    DT_STRING,
    DT_CONFIGFILE,
-   DT_CHAR
+   DT_CHAR,
+   DT_CALLBACK
 };
 
 /**
@@ -48,6 +49,7 @@ union config_value {
    bool *dt_bool;
    char **dt_string;
    char *dt_char;
+   bool (*dt_callback)(char *);
 };
 
 /**


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- #945

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- parse_config에 콜백 함수를 등록할 수 있는 dt_callback 타입을 추가합니다.
- 콜백 함수는 문자열(char *)을 인자로 받고, 성공 여부를 나타내는 bool 값을 반환하는 함수 포인터입니다.
- 설정(config) 파일에서 읽어온 값이 콜백 함수의 인자로 전달되며, 함수는 처리 성공 여부를 반환합니다.
