### PR TITLE
FIX: Avoid writing 1 byte into a zero-sized region

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -15947,10 +15947,11 @@ static bool load_extension(char *soname)
     }
 
     /* Optional configuration parameters */
-    char *config = strchr(soname, ',');
-    if (config != NULL) {
-        *config = '\0';
-        ++config;
+    char *config = NULL;
+    char *comma = strchr(soname, ',');
+    if (comma != NULL) {
+        *comma = '\0';
+        config = comma + 1;
     }
 
     /* Hack to remove the warning from C99 */
@@ -15993,8 +15994,8 @@ static bool load_extension(char *soname)
                 "Loaded extensions from: %s\n", soname);
     }
 
-    if (config != NULL) {
-        *(config - 1) = ',';
+    if (comma != NULL) {
+        *comma = ',';
     }
 
     return true;


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- Rockylinux9에서 발생한 컴파일 에러를 수정합니다.
```
memcached.c: In function ‘load_extension’:
memcached.c:15997:23: error: writing 1 byte into a region of size 0 [-Werror=stringop-overflow=]
15997 |         *(config - 1) = ',';
      |         ~~~~~~~~~~~~~~^~~~~
memcached.c:15943:34: note: destination object ‘soname’ of size [0, 9223372036854775807]
15943 | static bool load_extension(char *soname)
      |                            ~~~~~~^~~~~~
cc1: all warnings being treated as errors
```
