### PR TITLE
FIX: Initialize inclusive bytes correctly

### DIFF
--- a/engines/default/prefix.c
+++ b/engines/default/prefix.c
@@ -150,7 +150,7 @@ static void _prefix_inclusive_stats_init(prefix_t* pt, bool isleaf)
             pt->items_bytes_inclusive[i] = pt->items_bytes_exclusive[i];
         }
         pt->total_count_inclusive = pt->total_count_exclusive;
-        pt->total_bytes_inclusive = pt->total_count_exclusive;
+        pt->total_bytes_inclusive = pt->total_bytes_exclusive;
     }
 }
 #endif


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- jam2in/arcus-works#824

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- total_bytes_inclusive 값이 total_count_exclusive로 잘못 초기화된 로직을 수정합니다.
