### PR TITLE
INTERNAL: Converted the cmdlog file storage scheme

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -180,9 +180,15 @@ default_engine_la_SOURCES= \
                     engines/default/coll_btree.c \
                     engines/default/coll_btree.h \
                     engines/default/slabs.c \
-                    engines/default/slabs.h
+                    engines/default/slabs.h \
+		    engines/default/produce.c \
+		    engines/default/produce.h \
+		    engines/default/disk.c \
+		    engines/default/disk.h \
+		    engines/default/cdclogfile.c \
+		    engines/default/cdclogfile.h 
 default_engine_la_DEPENDENCIES= libmcd_util.la
-default_engine_la_LIBADD= libmcd_util.la $(LIBM)
+default_engine_la_LIBADD= libmcd_util.la $(LIBM) -lrdkafka
 default_engine_la_LDFLAGS= -avoid-version -shared -module -no-undefined
 dist_conf_DATA += engines/default/default_engine.conf
 

--- a/consumer.c
+++ b/consumer.c
@@ -1,0 +1,423 @@
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <dirent.h>
+#include <unistd.h>
+#include <stdarg.h>
+#include <sys/stat.h>
+#include <signal.h>
+#include <sys/time.h>
+
+#include "rdkafka.h"
+#include <libmemcached/memcached.h>
+
+#define ENABLE_PERSISTENCE 1
+#include <memcached/engine.h>
+#include "engines/default/default_engine.h"
+#include "engines/default/item_base.h"
+#include "engines/default/cmdlogrec.h"
+
+#define BTREE_REAL_NBKEY(nbkey) ((nbkey)==0 ? sizeof(uint64_t) : (nbkey))
+#define EXPIRED_REL_EXPTIME(exptime) ((exptime) == 1)
+
+typedef struct _kafka_st {
+    rd_kafka_t *rk;
+    char *topic;
+    char *brokers;
+} kafka_st;
+
+typedef struct snapshot_ctx {
+    char keybuf[1024];
+    uint16_t keylen;
+    uint8_t ittype;
+} snapshot_ctx;
+
+/* global data */
+static kafka_st kafka_anch;
+
+static int CONVERT_REL_EXPTIME(rel_time_t exptime)
+{
+    if (exptime == 0 || exptime == (rel_time_t)(-1)) {
+        return exptime; /* 0 (never), -1 (sticky) */
+    }
+
+    rel_time_t abstime = time(NULL);
+    if (exptime > abstime) {
+        return 2; /* not expired */
+    } else {
+        /* expired. */
+        return 1;
+    }
+}
+
+void kafka_st_init(char *topic, char *broker)
+{
+    kafka_anch.topic = "test-topic";
+    kafka_anch.brokers = "localhost";
+}
+
+void consumer_init(int argc, char **argv) {
+    rd_kafka_t *rk;
+    rd_kafka_conf_t *conf;
+    rd_kafka_topic_partition_list_t *subscription;
+    char errstr[512];
+
+    conf = rd_kafka_conf_new();
+
+    if (rd_kafka_conf_set(conf, "bootstrap.servers", kafka_anch.brokers, errstr,
+                            sizeof(errstr)) != RD_KAFKA_CONF_OK) {
+        rd_kafka_conf_destroy(conf);
+        return;
+    }
+
+    if (rd_kafka_conf_set(conf, "group.id", argv[2], errstr,
+                            sizeof(errstr)) != RD_KAFKA_CONF_OK) {
+        rd_kafka_conf_destroy(conf);
+        return;
+    }
+
+    if (rd_kafka_conf_set(conf, "group.protocol", argv[3], errstr,
+                            sizeof(errstr)) != RD_KAFKA_CONF_OK) {
+        rd_kafka_conf_destroy(conf);
+        return;
+    }
+
+    if (rd_kafka_conf_set(conf, "auto.offset.reset", "earliest", errstr,
+                            sizeof(errstr)) != RD_KAFKA_CONF_OK) {
+        rd_kafka_conf_destroy(conf);
+        return;
+    }
+
+    if (rd_kafka_conf_set(conf, "enable.auto.commit", "false",
+                            errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK) {
+        rd_kafka_conf_destroy(conf);
+        return;
+    }
+
+    rk = rd_kafka_new(RD_KAFKA_CONSUMER, conf, errstr, sizeof(errstr));
+    if (!rk) {
+        fprintf(stderr, "%% Failed to create new consumer: %s\n", errstr);
+        exit(1);
+    }
+    conf = NULL;
+    kafka_anch.rk = rk;
+
+    rd_kafka_poll_set_consumer(rk);
+    subscription = rd_kafka_topic_partition_list_new(argc-4);
+    for (int i = 4; i<argc; i++)
+        rd_kafka_topic_partition_list_add(subscription, argv[i], RD_KAFKA_PARTITION_UA);
+
+    rd_kafka_resp_err_t err;
+    err = rd_kafka_subscribe(rk, subscription);
+    if (err) {
+        fprintf(stderr, "%% Failed to subscribe to %d topics: %s\n",
+                        subscription->cnt, rd_kafka_err2str(err));
+        rd_kafka_topic_partition_list_destroy(subscription);
+        rd_kafka_destroy(rk);
+    }
+}
+
+static int lrec_to_it_link(memcached_st *mc, LogRec *logrec)
+{
+    memcached_return_t rc;
+    ITLinkLog *log = (ITLinkLog*)logrec;
+    ITLinkData *body = &log->body;
+    struct lrec_item_common *cm = &body->cm;
+    char *keyptr = body->data;
+
+    if (CONVERT_REL_EXPTIME(cm->exptime) == 1) {
+       fprintf(stderr, "expried tiem. key=%.*s\n", cm->keylen, keyptr);
+       return 0;
+    }
+
+    if (cm->ittype == ITEM_TYPE_KV) {
+        char *valptr = keyptr + cm->keylen;
+        uint32_t bytes = cm->vallen-2;
+
+        rc = memcached_set(mc, keyptr, cm->keylen, valptr, bytes, cm->exptime, cm->flags);
+        if (memcached_failed(rc)) {
+            fprintf(stderr, "Failed to memcached_set: %d(%s)\n",
+                    rc, memcached_strerror(mc, rc));
+            return -1;
+        }
+        // fprintf(stderr, "KV key=%.*s\n", cm->keylen, keyptr);
+    } else {
+        struct lrec_coll_meta *meta = (struct lrec_coll_meta*)&body->ptr.meta;
+        memcached_coll_create_attrs_st attributes;
+        memcached_coll_create_attrs_init(&attributes, cm->flags, cm->exptime, meta->mcnt);
+
+        if (cm->ittype == ITEM_TYPE_LIST) {
+            rc = memcached_lop_create(mc, keyptr, cm->keylen, &attributes);
+            if (memcached_failed(rc)) {
+                fprintf(stderr, "Failed to memcached_lop_create: %d(%s)\n",
+                        rc, memcached_strerror(mc, rc));
+                return -1;
+            }
+        } else if (cm->ittype == ITEM_TYPE_SET) {
+
+        } else if (cm->ittype == ITEM_TYPE_MAP) {
+
+        } else if (cm->ittype == ITEM_TYPE_BTREE) {
+
+        }
+
+    }
+    assert(rc == MEMCACHED_SUCCESS);
+    return 0;
+}
+
+static int lrec_to_it_unlink(memcached_st *mc, LogRec *logrec)
+{
+    memcached_return_t rc;
+    ITUnlinkLog *log = (ITUnlinkLog*)logrec;
+    ITUnlinkData *body = &log->body;
+    char *keyptr = body->data;
+
+    rc = memcached_delete(mc, keyptr, body->keylen, 0);
+    if (memcached_failed(rc)) {
+        fprintf(stderr, "Failed to memcached_delete: %d(%s)\n",
+                rc, memcached_strerror(mc, rc));
+        return -1;
+    }
+
+    assert(rc == MEMCACHED_SUCCESS);
+    return 0;
+}
+
+static int lrec_to_list_elem_insert(memcached_st *mc, LogRec *logrec)
+{
+    memcached_return_t rc;
+    memcached_coll_attrs_st attrs;
+    ListElemInsLog *log = (ListElemInsLog*)logrec;
+    ListElemInsData *body = &log->body;
+    char *keyptr = body->data;
+    char *valptr = keyptr+body->keylen;
+    uint32_t bytes = body->vallen-2;
+
+    rc = memcached_get_attrs(mc, keyptr, body->keylen, &attrs);
+    if (body->create) {
+        if (rc == MEMCACHED_SUCCESS) {
+            fprintf(stderr, "Exist key\n");
+            return 0;
+        }
+
+        memcached_coll_create_attrs_st attributes;
+        lrec_attr_info *attrs_info = (lrec_attr_info*)(keyptr+body->keylen+body->vallen);
+        memcached_coll_create_attrs_init(&attributes, attrs_info->flags,
+                                         attrs_info->exptime, attrs_info->maxcount);
+        rc = memcached_lop_create(mc, keyptr,body->keylen, &attributes);
+        if (memcached_failed(rc)) {
+            fprintf(stderr, "Failed to memcached_lop_create: %d(%s)\n",
+                rc, memcached_strerror(mc, rc));
+            return -1;
+        }
+    }
+
+    if (rc == MEMCACHED_SUCCESS) {
+        rc = memcached_lop_insert(mc, keyptr, body->keylen, body->eindex,
+                                  valptr, bytes, NULL);
+        if (memcached_failed(rc)) {
+                fprintf(stderr, "Failed to memcached_lop_insert: %d(%s)\n",
+                        rc, memcached_strerror(mc, rc));
+                return -1;
+        }
+        assert(rc == MEMCACHED_SUCCESS);
+    } else {
+        fprintf(stderr, "Failed to memcached_lop_insert: %d(%s)\n",
+                rc, memcached_strerror(mc, rc));
+        return -1;
+    }
+    assert(rc == MEMCACHED_SUCCESS);
+    return 0;
+}
+
+static int lrec_to_list_elem_delete(memcached_st *mc, LogRec *logrec)
+{
+    memcached_return_t rc;
+    ListElemDelLog *log = (ListElemDelLog*)logrec;
+    ListElemDelData *body = &log->body;
+    char *keyptr = body->data;
+    int32_t bgn_idx = body->eindex;
+    int32_t end_idx = body->eindex+body->delcnt-1;
+
+    if (body->delcnt > 1) {
+        rc = memcached_lop_delete_by_range(mc, keyptr, body->keylen, bgn_idx, end_idx, body->drop);
+    } else {
+        rc = memcached_lop_delete(mc, keyptr, body->keylen, bgn_idx, body->drop);
+    }
+
+    if (memcached_failed(rc)) {
+        fprintf(stderr, "Failed to memcached_lop_elem_delete: %d(%s)\n",
+                rc, memcached_strerror(mc, rc));
+        return -1;
+    }
+    assert(rc == MEMCACHED_SUCCESS);
+    return 0;
+}
+
+static int lrec_to_ascii_command(memcached_st *mc, LogRec *logrec)
+{
+    int ret = -1;
+    LogHdr *loghdr = &logrec->header;
+
+    if (loghdr->logtype == LOG_IT_LINK) {
+        ret = lrec_to_it_link(mc, logrec);
+    } else if (loghdr->logtype == LOG_IT_UNLINK) {
+        ret = lrec_to_it_unlink(mc, logrec);
+    } else if (loghdr->logtype == LOG_LIST_ELEM_INSERT) {
+        ret = lrec_to_list_elem_insert(mc, logrec);
+    } else if (loghdr->logtype == LOG_LIST_ELEM_DELETE) {
+        ret = lrec_to_list_elem_delete(mc, logrec);
+    }
+    return ret;
+}
+
+static int snapshot_elem_to_ascii(memcached_st *mc, snapshot_ctx *ctx, LogRec *logrec)
+{
+    memcached_return_t rc;
+    memcached_coll_attrs_st attrs;
+    SnapshotElemLog *log = (SnapshotElemLog*)logrec;
+    SnapshotElemData *body = &log->body;
+    char *valptr = body->data;
+    int index;
+    if (ctx->ittype == ITEM_TYPE_LIST) {
+        rc = memcached_get_attrs(mc, ctx->keybuf, ctx->keylen, &attrs);
+        index = attrs.count;
+        rc = memcached_lop_insert(mc, ctx->keybuf, ctx->keylen, index, valptr, body->nbytes-2, NULL);
+        if (memcached_failed(rc)) {
+            fprintf(stderr, "Failed to memcached_lop_create: %d(%s)\n",
+                rc, memcached_strerror(mc, rc));
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static void update_snapshot_ctx(snapshot_ctx *ctx, LogRec *logrec)
+{
+    ITLinkLog *log = (ITLinkLog*)logrec;
+    const ITLinkData *body = &log->body;
+    const struct lrec_item_common *cm = (const struct lrec_item_common *)&body->cm;
+    const char *keyptr = body->data;
+
+    if (cm->ittype == ITEM_TYPE_BTREE) {
+        const struct lrec_coll_meta *meta = (const struct lrec_coll_meta *)&body->ptr.meta;
+        if (meta->maxbkrlen != BKEY_NULL) {
+            keyptr += BTREE_REAL_NBKEY(meta->maxbkrlen);
+        }
+    }
+
+    if (cm->ittype != ITEM_TYPE_KV) {
+        ctx->keylen = cm->keylen;
+        ctx->ittype = cm->ittype;
+        if (cm->keylen > 0 && cm->keylen < sizeof(ctx->keybuf)) {
+            memcpy(ctx->keybuf, keyptr, cm->keylen);
+            ctx->keybuf[cm->keylen] = '\0';
+        }
+    }
+}
+
+static void commit_pending(rd_kafka_t *rk, rd_kafka_topic_partition_list_t **ppending)
+{
+    if (*ppending == NULL || (*ppending)->cnt == 0) return;
+    rd_kafka_resp_err_t err = rd_kafka_commit(rk, *ppending, 1);
+    if (err != RD_KAFKA_RESP_ERR_NO_ERROR) {
+        fprintf(stderr, "Kafka batch commit failed: %s\n", rd_kafka_err2str(err));
+    }
+
+    rd_kafka_topic_partition_list_destroy(*ppending);
+    *ppending = rd_kafka_topic_partition_list_new(0);
+}
+
+static int do_consum(memcached_st *mc) {
+    kafka_st *ks = &kafka_anch;
+
+    snapshot_ctx ctx;
+    memset(&ctx, 0, sizeof(snapshot_ctx));
+
+    rd_kafka_topic_partition_list_t *pending = rd_kafka_topic_partition_list_new(0);
+    int success_since_commit = 0;
+
+    while(1) {
+        rd_kafka_message_t *rkm;
+
+        // 메세지 큐에서 메세지를 하나 소비
+        rkm = rd_kafka_consumer_poll(ks->rk, 500);
+
+        if (rkm == NULL) {
+            continue; // timeout
+        }
+
+        if (rkm->err) {
+            rd_kafka_message_destroy(rkm);
+            continue;
+        }
+
+        char buf[4096];
+        memcpy(buf, rkm->payload, rkm->len);
+        LogRec *logrec = (LogRec*)buf;
+        LogHdr *loghdr = &logrec->header;
+
+        if (rkm->len < sizeof(LogHdr) + loghdr->body_length) {
+            rd_kafka_message_destroy(rkm);
+            continue;
+        }
+
+        int ret = -1;
+        if (loghdr->logtype == LOG_IT_LINK) {
+            update_snapshot_ctx(&ctx, logrec);
+            ret = lrec_to_ascii_command(mc, logrec);
+        } else if (loghdr->logtype == LOG_SNAPSHOT_ELEM) {
+            ret = snapshot_elem_to_ascii(mc, &ctx, logrec);
+        } else if(loghdr->logtype == LOG_SNAPSHOT_DONE) {
+            ret = 0;
+        } else {
+            ret = lrec_to_ascii_command(mc, logrec);
+        }
+
+        if (ret == 0) {
+            const char *topic = rd_kafka_topic_name(rkm->rkt);
+            int32_t partition = rkm->partition;
+            int64_t next_offset = rkm->offset+1;
+
+            rd_kafka_topic_partition_t *tp = rd_kafka_topic_partition_list_find(pending, topic, partition);
+            if (tp == NULL) {
+                tp = rd_kafka_topic_partition_list_add(pending, topic, partition);
+            }
+            tp->offset = next_offset;
+
+            success_since_commit++;
+            if (success_since_commit >= 200) {
+                commit_pending(ks->rk, &pending);
+                success_since_commit = 0;
+            }
+        } else {
+            fprintf(stderr, "Skip commit (conversion/write failure).\n");
+        }
+
+        rd_kafka_message_destroy(rkm);
+    }
+}
+
+int main(int argc, char **argv)
+{
+    memcached_st *mc = memcached_create(NULL);
+    assert(mc);
+
+    if (memcached_server_add(mc, "dev-3", 21212) != MEMCACHED_SUCCESS) {
+        fprintf(stderr, "Fail to add memcached server. Port=%d\n", 21212);
+        return 0;
+    }
+
+    kafka_st_init(NULL, NULL);
+    consumer_init(argc, argv);
+
+    do_consum(mc);
+
+    rd_kafka_consumer_close(kafka_anch.rk);
+    rd_kafka_destroy(kafka_anch.rk);
+    memcached_free(mc);
+    return 0;
+}

--- a/engines/default/cdclogfile.c
+++ b/engines/default/cdclogfile.c
@@ -1,0 +1,459 @@
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <dirent.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <sys/time.h>
+
+#include "default_engine.h"
+
+#ifdef ENABLE_PERSISTENCE
+#include "cmdlogbuf.h"
+#include "cmdlogfile.h"
+#include "cdclogfile.h"
+#include "disk.h"
+
+#define ENABLE_DEBUG 0
+#define MAX_FILE_SIZE (1024*1024)
+#define MAX_FILE_INDEX 999999
+
+/* log file structure */
+typedef struct _log_file {
+    char      path[MAX_FILEPATH_LENGTH];
+    char      next_path[MAX_FILEPATH_LENGTH];
+    int       prev_fd;
+    int       fd;
+    int       next_fd;
+    size_t    size;
+    size_t    next_size;
+} log_FILE;
+
+/* cdc log file global struct */
+struct cdc_file_global {
+    log_FILE log_file;
+    LogSN nxt_fsync_lsn;
+    int fidx_bgn;
+    int fidx_end;
+    int fidx_dw_bgn;
+    int fidx_dw_end;
+    pthread_mutex_t log_fsync_lock;
+    pthread_mutex_t fsync_lsn_lock;
+    pthread_mutex_t file_access_lock;
+    volatile bool initialized;
+};
+
+/* global data */
+static struct engine_config *config = NULL;
+static EXTENSION_LOGGER_DESCRIPTOR *logger = NULL;
+static struct cdc_file_global cdc_file_gl;
+
+bool next_cdclog_path(char *path, char *next_path)
+{
+    char *slash = strrchr(path, '/');
+    if (!slash || slash == path) return false;
+
+    char *base = slash + 1;
+
+    // cdclog_<time>_<number>
+    // base: "cdclog_"(7) + time(14) + '_'(1) + num(6)
+    char *time = base+ 7;
+    char *num = base + 22;
+
+    int n = atoi(num)+1;
+    size_t dirlen = (size_t)(slash - path);
+
+    memcpy(next_path, path, dirlen);
+    next_path[dirlen] = '\0';
+
+    snprintf(next_path+dirlen, MAX_FILEPATH_LENGTH-dirlen, "/cdclog_%.14s_%06d", time, n);
+    return true;
+}
+
+bool cdclog_file_deletable()
+{
+    bool ret;
+    pthread_mutex_lock(&cdc_file_gl.file_access_lock);
+    ret = (cdc_file_gl.fidx_bgn < cdc_file_gl.fidx_end);
+    pthread_mutex_unlock(&cdc_file_gl.file_access_lock);
+    return ret;
+}
+
+void cdclog_file_delete(const char *path)
+{
+    if (unlink(path) < 0) {
+        logger->log(EXTENSION_LOG_WARNING, NULL,
+                    "Failed to remove cdclog file. path: %s, error: %s\n",
+                    path, strerror(errno));
+        return;
+    }
+
+    pthread_mutex_lock(&cdc_file_gl.file_access_lock);
+    cdc_file_gl.fidx_bgn += 1;
+    if (cdc_file_gl.fidx_bgn > MAX_FILE_INDEX)
+        cdc_file_gl.fidx_bgn = 1;
+    pthread_mutex_unlock(&cdc_file_gl.file_access_lock);
+}
+
+static int create_new_cdclog(log_FILE **logfile, int next_fidx, bool dual_write)
+{
+    int fd;
+    char newtime[15];
+    const char *logfile_path = (dual_write ? (*logfile)->next_path : (*logfile)->path);
+    const char *slash = strrchr(logfile_path, '/');
+    const char *base  = (slash ? slash + 1 : logfile_path);
+    const char *time = base + 7;
+    char newpath[MAX_FILEPATH_LENGTH];
+
+    memcpy(newtime, time, 14);
+    newtime[14] = '\0';
+
+    snprintf(newpath, MAX_FILEPATH_LENGTH,"%.*s/%s%s_%06d",
+            (int)(slash-logfile_path), logfile_path,"cdclog_", newtime, next_fidx);
+
+    if ((fd = open(newpath, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR | S_IRGRP))<0) {
+        logger->log(EXTENSION_LOG_WARNING, "Fail to open file : %s\n", newpath);
+        return -1;
+    }
+
+    if (dual_write) {
+        (*logfile)->next_fd = fd;
+        (*logfile)->next_size = 0;
+        snprintf((*logfile)->next_path, MAX_FILEPATH_LENGTH, "%s", newpath);
+    } else {
+        (*logfile)->fd = fd;
+        (*logfile)->size = 0;
+        snprintf((*logfile)->path, MAX_FILEPATH_LENGTH, "%s", newpath);
+    }
+    return 0;
+}
+
+static size_t cdclog_file_fit(log_FILE *logfile, char **log_ptr, uint32_t log_size)
+{
+    size_t bytes_to_write = 0;
+    ssize_t nwrite;
+    while (bytes_to_write < log_size) {
+        LogRec *logrec = (LogRec*)(*log_ptr + bytes_to_write);
+        LogHdr *loghdr = &logrec->header;
+        size_t log_len = sizeof(LogHdr)+loghdr->body_length;
+
+        if (logfile->size+bytes_to_write+log_len > MAX_FILE_SIZE) {
+            break;
+        }
+        bytes_to_write += log_len;
+    }
+
+    if (bytes_to_write > 0) {
+        nwrite = disk_write(logfile->fd, *log_ptr, bytes_to_write);
+        if (nwrite != bytes_to_write) {
+            logger->log(EXTENSION_LOG_WARNING, NULL,
+                "curr log file(%d) write - write(%ld!=%ld) error=(%d:%s)\n",
+                logfile->fd, nwrite, (ssize_t)bytes_to_write,
+                errno, strerror(errno));
+        }
+
+        *log_ptr += bytes_to_write;
+        log_size -= bytes_to_write;
+        logfile->size += bytes_to_write;
+    }
+
+    return log_size;
+}
+
+void cdclog_file_write(char *log_ptr, uint32_t log_size, bool dual_write)
+{
+    log_FILE *logfile = &cdc_file_gl.log_file;
+    ssize_t nwrite;
+    uint32_t dual_log_size = log_size;
+    char *dual_log_ptr = log_ptr;
+    if (logfile->fd == -1)
+        return;
+
+    pthread_mutex_lock(&cdc_file_gl.file_access_lock);
+    while (logfile->size+log_size > MAX_FILE_SIZE) {
+        log_size = cdclog_file_fit(logfile, &log_ptr, log_size);
+        pthread_mutex_lock(&cdc_file_gl.log_fsync_lock);
+        pthread_mutex_unlock(&cdc_file_gl.file_access_lock);
+        if (!config->async_logging)
+            disk_fsync(logfile->fd);
+        disk_close(logfile->fd);
+        pthread_mutex_lock(&cdc_file_gl.file_access_lock);
+        cdc_file_gl.fidx_end+=1;
+        if (cdc_file_gl.fidx_end > MAX_FILE_INDEX)
+            cdc_file_gl.fidx_end = 1;
+        create_new_cdclog(&logfile, cdc_file_gl.fidx_end, false);
+        pthread_mutex_unlock(&cdc_file_gl.log_fsync_lock);
+    }
+    nwrite = disk_write(logfile->fd, log_ptr, log_size);
+    if (nwrite != log_size) {
+        logger->log(EXTENSION_LOG_WARNING, NULL,
+                    "curr log file(%d) write - write(%ld!=%ld) error=(%d:%s)\n",
+                    logfile->fd, nwrite, (ssize_t)log_size,
+                    errno, strerror(errno));
+    }
+    /* FIXME::need error handling */
+    assert(nwrite == log_size);
+    logfile->size += log_size;
+
+    if (dual_write && logfile->next_fd != -1) {
+        while (logfile->next_size+dual_log_size > MAX_FILE_SIZE) {
+            dual_log_size = cdclog_file_fit(logfile, &dual_log_ptr, dual_log_size);
+            pthread_mutex_unlock(&cdc_file_gl.file_access_lock);
+            if (!config->async_logging)
+                disk_fsync(logfile->next_fd);
+            disk_close(logfile->next_fd);
+            pthread_mutex_lock(&cdc_file_gl.file_access_lock);
+            cdc_file_gl.fidx_dw_end += 1;
+            create_new_cdclog(&logfile, cdc_file_gl.fidx_dw_end, true);
+        }
+        /* The log data is appended */
+        nwrite = disk_write(logfile->next_fd, dual_log_ptr, dual_log_size);
+        if (nwrite != dual_log_size) {
+            logger->log(EXTENSION_LOG_WARNING, NULL,
+                        "next log file(%d) write - write(%ld!=%ld) error=(%d:%s)\n",
+                        logfile->next_fd, nwrite, (ssize_t)dual_log_size,
+                        errno, strerror(errno));
+        }
+        /* FIXME::need error handling */
+        assert(nwrite == dual_log_size);
+        logfile->next_size += dual_log_size;
+    }
+    pthread_mutex_unlock(&cdc_file_gl.file_access_lock);
+}
+
+void cdclog_file_complete_dual_write(void)
+{
+    log_FILE *logfile = &cdc_file_gl.log_file;
+
+    pthread_mutex_lock(&cdc_file_gl.file_access_lock);
+    if (logfile->next_fd != -1) {
+        logfile->prev_fd   = logfile->fd;
+        logfile->fd        = logfile->next_fd;
+        logfile->size      = logfile->next_size;
+        logfile->next_fd   = -1;
+        logfile->next_size = 0;
+        snprintf(logfile->path, MAX_FILEPATH_LENGTH, "%s", logfile->next_path);
+        logfile->next_path[0] = '\0';
+        cdc_file_gl.fidx_bgn = cdc_file_gl.fidx_dw_bgn;
+        cdc_file_gl.fidx_end = cdc_file_gl.fidx_dw_end;
+        cdc_file_gl.fidx_dw_bgn = -1;
+        cdc_file_gl.fidx_dw_end = -1;
+
+        if (config->async_logging) {
+            (void)disk_close(logfile->prev_fd);
+            logfile->prev_fd = -1;
+        }
+    }
+    pthread_mutex_unlock(&cdc_file_gl.file_access_lock);
+}
+
+bool cdclog_file_dual_write_finished(void)
+{
+    log_FILE *logfile = &cdc_file_gl.log_file;
+    bool finished = false;
+    pthread_mutex_lock(&cdc_file_gl.file_access_lock);
+    if (logfile->next_fd == -1 && logfile->prev_fd == -1) {
+        finished = true;
+    }
+    pthread_mutex_unlock(&cdc_file_gl.file_access_lock);
+    return finished;
+}
+
+int cdclog_file_sync(void)
+{
+    log_FILE *logfile = &cdc_file_gl.log_file;
+    LogSN now_flush_lsn;
+    int fd;
+    int prev_fd = -1;
+    int next_fd = -1;
+    int ret = 0;
+
+    pthread_mutex_lock(&cdc_file_gl.log_fsync_lock);
+
+    /* get current flush lsn */
+    cmdlog_get_flush_lsn(&now_flush_lsn);
+
+    /* get current fd info */
+    pthread_mutex_lock(&cdc_file_gl.file_access_lock);
+    if (logfile->prev_fd != -1) {
+        prev_fd = logfile->prev_fd;
+        logfile->prev_fd = -1;
+    }
+    fd = logfile->fd;
+    if (logfile->next_fd != -1) {
+        next_fd = logfile->next_fd;
+    }
+    pthread_mutex_unlock(&cdc_file_gl.file_access_lock);
+
+    if (prev_fd != -1) {
+        (void)disk_fsync(prev_fd);
+        (void)disk_close(prev_fd);
+    }
+
+    if (LOGSN_IS_GT(&now_flush_lsn, &cdc_file_gl.nxt_fsync_lsn)) {
+        do {
+            /* fsync curr fd */
+            ret = disk_fsync(fd);
+            if (ret < 0) {
+                logger->log(EXTENSION_LOG_WARNING, NULL,
+                            "log file fsync error (%d:%s)\n",
+                            errno, strerror(errno));
+                break;
+            }
+
+            if (next_fd != -1) {
+                ret = disk_fsync(next_fd);
+                if (ret < 0) {
+                    logger->log(EXTENSION_LOG_WARNING, NULL,
+                                "log file fsync error (%d:%s)\n",
+                                errno, strerror(errno));
+                    break;
+                }
+            }
+
+            /* update nxt_fsync_lsn */
+            pthread_mutex_lock(&cdc_file_gl.fsync_lsn_lock);
+            cdc_file_gl.nxt_fsync_lsn = now_flush_lsn;
+            pthread_mutex_unlock(&cdc_file_gl.fsync_lsn_lock);
+        } while(0);
+    }
+    pthread_mutex_unlock(&cdc_file_gl.log_fsync_lock);
+
+    return ret;
+}
+
+int cdclog_file_open(char *path)
+{
+    log_FILE *logfile = &cdc_file_gl.log_file;
+    int fd, ret = 0;
+
+    pthread_mutex_lock(&cdc_file_gl.file_access_lock);
+    do {
+        fd = disk_open(path, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR | S_IRGRP);
+        if (fd < 0) {
+            logger->log(EXTENSION_LOG_WARNING, NULL,
+                        "Failed to open the cmdlog file. path=%s err=%s\n",
+                        logfile->path, strerror(errno));
+            ret = -1; break;
+        }
+        if (logfile->fd == -1) {
+            logfile->fd = fd;
+            cdc_file_gl.fidx_bgn = 1;
+            cdc_file_gl.fidx_end = 1;
+            snprintf(logfile->path, MAX_FILEPATH_LENGTH, "%s", path);
+        } else {
+            /* fd != -1 means that a new cdclog file is created by checkpoint */
+            logfile->next_fd = fd;
+            cdc_file_gl.fidx_dw_bgn = 1;
+            cdc_file_gl.fidx_dw_end = 1;
+            snprintf(logfile->next_path, MAX_FILEPATH_LENGTH, "%s", path);
+        }
+    } while(0);
+    pthread_mutex_unlock(&cdc_file_gl.file_access_lock);
+
+    return ret;
+}
+
+void cdclog_file_close(void)
+{
+    log_FILE *logfile = &cdc_file_gl.log_file;
+    int remove_fd;
+
+    /* We hold log_fsync_lock to prevent fsync() call
+     * on the file being closed. See cmdlog_file_sync().
+     */
+    pthread_mutex_lock(&cdc_file_gl.log_fsync_lock);
+    pthread_mutex_lock(&cdc_file_gl.file_access_lock);
+    if (logfile->next_fd != -1) {
+        remove_fd = logfile->next_fd;
+        logfile->next_fd = -1;
+        logfile->next_size = 0;
+        logfile->next_path[0] = '\0';
+    } else { /* the first checkpoint */
+        assert(logfile->fd != -1);
+        remove_fd = logfile->fd;
+        logfile->fd = -1;
+    }
+    pthread_mutex_unlock(&cdc_file_gl.file_access_lock);
+    pthread_mutex_unlock(&cdc_file_gl.log_fsync_lock);
+
+    assert(remove_fd != -1);
+    (void)disk_close(remove_fd);
+}
+
+void cdclog_file_init(struct default_engine* engine)
+{
+    config = &engine->config;
+    logger = engine->server.log->get_logger();
+
+    /* cdc file global init */
+    memset(&cdc_file_gl, 0, sizeof(cdc_file_gl));
+
+    cdc_file_gl.nxt_fsync_lsn.filenum = 1;
+    cdc_file_gl.nxt_fsync_lsn.roffset = 0;
+
+    pthread_mutex_init(&cdc_file_gl.log_fsync_lock, NULL);
+    pthread_mutex_init(&cdc_file_gl.fsync_lsn_lock, NULL);
+    pthread_mutex_init(&cdc_file_gl.file_access_lock, NULL);
+
+    /* cdc file init */
+    log_FILE *logfile = &cdc_file_gl.log_file;
+    logfile->path[0]   = '\0';
+    logfile->next_path[0] = '\0';
+    logfile->prev_fd   = -1;
+    logfile->fd        = -1;
+    logfile->next_fd   = -1;
+    logfile->size      = 0;
+    logfile->next_size = 0;
+
+    cdc_file_gl.fidx_bgn = -1;
+    cdc_file_gl.fidx_end = -1;
+    cdc_file_gl.fidx_dw_bgn = -1;
+    cdc_file_gl.fidx_dw_end = -1;
+    cdc_file_gl.initialized = true;
+    logger->log(EXTENSION_LOG_INFO, NULL, "CDCLOG FILE module initialized.\n");
+}
+
+void cdclog_file_final(void)
+{
+    log_FILE *logfile = &cdc_file_gl.log_file;
+
+    if (cdc_file_gl.initialized == false) {
+        return;
+    }
+
+    if (logfile->fd != -1) {
+        (void)disk_fsync(logfile->fd);
+        (void)disk_close(logfile->fd);
+        logfile->fd = -1;
+    }
+    if (logfile->next_fd != -1) {
+        (void)disk_close(logfile->next_fd);
+        logfile->fd = -1;
+    }
+
+    pthread_mutex_destroy(&cdc_file_gl.log_fsync_lock);
+    pthread_mutex_destroy(&cdc_file_gl.fsync_lsn_lock);
+    pthread_mutex_destroy(&cdc_file_gl.file_access_lock);
+
+    cdc_file_gl.initialized = false;
+    logger->log(EXTENSION_LOG_INFO, NULL, "CDCLOG FILE module destroyed.\n");
+}
+size_t cdclog_file_getsize(void)
+{
+    log_FILE *logfile = &cdc_file_gl.log_file;
+    size_t size;
+    pthread_mutex_lock(&cdc_file_gl.file_access_lock);
+    size = logfile->size;
+    pthread_mutex_unlock(&cdc_file_gl.file_access_lock);
+
+    return size;
+}
+
+void cdclog_get_fsync_lsn(LogSN *lsn)
+{
+    pthread_mutex_lock(&cdc_file_gl.fsync_lsn_lock);
+    *lsn = cdc_file_gl.nxt_fsync_lsn;
+    pthread_mutex_unlock(&cdc_file_gl.fsync_lsn_lock);
+}
+#endif

--- a/engines/default/cdclogfile.h
+++ b/engines/default/cdclogfile.h
@@ -1,0 +1,22 @@
+#ifndef CDCLOGFILE_H
+#define CDCLOGFILE_H
+
+/* external cdc file function */
+bool next_cdclog_path(char *path, char *next_path);
+bool cdclog_file_deletable(void);
+void cdclog_file_delete(const char *path);
+
+void cdclog_file_write(char *log_ptr, uint32_t log_size, bool dual_write);
+void cdclog_file_complete_dual_write(void);
+bool cdclog_file_dual_write_finished(void);
+int cdclog_file_sync(void);
+
+int cdclog_file_open(char *path);
+void cdclog_file_close(void);
+void cdclog_file_init(struct default_engine* engine);
+void cdclog_file_final(void);
+size_t cdclog_file_getsize(void);
+
+void cdclog_get_fsync_lsn(LogSN *lsn);
+
+#endif

--- a/engines/default/chkpt_snapshot.c
+++ b/engines/default/chkpt_snapshot.c
@@ -19,11 +19,14 @@
 #include <stdlib.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <dirent.h>
 #include <assert.h>
 
 #include "default_engine.h"
 #ifdef ENABLE_PERSISTENCE
 #include "cmdlogmgr.h"
+#include "produce.h"
+#include "cdclogfile.h"
 
 #define SNAPSHOT_BUFFER_SIZE (10 * 1024 * 1024)
 #define SCAN_ITEM_ARRAY_SIZE 16
@@ -456,18 +459,114 @@ static ENGINE_ERROR_CODE do_snapshot_direct(snapshot_st *ss,
     return ret;
 }
 
+static int do_chkpt_create_files(snapshot_st *ss, char *dir_path, int64_t newtime)
+{
+    int fd;
+    char snapshot_path[MAX_FILEPATH_LENGTH];
+    if (snprintf(snapshot_path, MAX_FILEPATH_LENGTH, "%s/snapshot_%"PRId64, dir_path, newtime) >= MAX_FILEPATH_LENGTH) {
+        logger->log(EXTENSION_LOG_WARNING, NULL,
+                    "Failed to create snapshot file path. dir=%s\n", dir_path);
+        return -1;
+    }
+
+    fd = open(snapshot_path, O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP);
+    if (fd < 0) {
+        logger->log(EXTENSION_LOG_WARNING, NULL,
+                    "Failed to create snapshot file. path: %s, error: %s\n",
+                    snapshot_path, strerror(errno));
+        return -1;
+    }
+    close(fd);
+    sprintf(ss->file.path, "%s", snapshot_path);
+
+    return 0;
+}
+
+static int cdclogfilter(const struct dirent *ent)
+{
+    return (strncmp(ent->d_name, ".", 1) != 0 && strncmp(ent->d_name, "..", 2) != 0);
+}
+
+static int do_chkpt_clear_files(char *dir_path, int64_t newtime)
+{
+    char time[15];
+    int ret = 0;
+    snprintf(time, 15, "%"PRId64, newtime);
+
+    struct dirent **entry_list;
+    int entry_cnt = scandir(dir_path, &entry_list, cdclogfilter, alphasort);
+    if (entry_cnt < 0) {
+        logger->log(EXTENSION_LOG_WARNING, NULL,
+                    "Failed to scan cdclog directory. path: %s, error: %s\n",
+                    dir_path, strerror(errno));
+        return -1;
+    }
+
+    struct dirent *ent;
+    int idx = 0;
+    while (idx < entry_cnt) {
+        ent = entry_list[idx];
+
+        if (strstr(ent->d_name, time) == NULL) {
+            char path[MAX_FILEPATH_LENGTH];
+            if (snprintf(path, MAX_FILEPATH_LENGTH, "%s/%s", dir_path, ent->d_name) <= MAX_FILEPATH_LENGTH)
+                unlink(path);
+        }
+        idx++;
+    }
+
+    for (int i = 0; i < entry_cnt; i++) {
+        free(entry_list[i]);
+    }
+    free(entry_list);
+
+    return ret;
+}
+
 static void *do_snapshot_thread_main(void *arg)
 {
     snapshot_st *ss = (snapshot_st *)arg;
     assert(ss->running == true);
 
+    int64_t newtime = getnowdatetime_int();
+    char dir_path[MAX_FILEPATH_LENGTH];
+    if (snprintf(dir_path, MAX_FILEPATH_LENGTH, "%s", ss->file.path) >= MAX_FILEPATH_LENGTH) {
+        logger->log(EXTENSION_LOG_WARNING, NULL,
+                    "Failed to create snapshot dir path. path=%s\n", ss->file.path);
+        return NULL;
+    }
+
+    if (do_chkpt_create_files(ss, dir_path, newtime) < 0) {
+        logger->log(EXTENSION_LOG_INFO, NULL,
+                    "Failed to create snapshot file.");
+        return NULL;
+    }
+
+    char cdclog_path[MAX_FILEPATH_LENGTH];
+    if (snprintf(cdclog_path, MAX_FILEPATH_LENGTH,
+                 "%s/cdclog_%"PRId64"_%06d", dir_path, newtime, 1) >= MAX_FILEPATH_LENGTH) {
+        logger->log(EXTENSION_LOG_WARNING, NULL,
+                    "Failed to create cdc log path. dir=%s\n", dir_path);
+        return NULL;
+    }
+
+    if (cdclog_file_open(cdclog_path) < 0) {
+        logger->log(EXTENSION_LOG_WARNING, NULL,
+                    "Failed to open cdc log path. dir=%s\n", dir_path);
+        return NULL;
+    }
+
     if (do_snapshot_action(ss) == true) {
         logger->log(EXTENSION_LOG_INFO, NULL,
                     "The snapshot thread has done the snapshot action.\n");
+        set_snapshot_path(ss->file.path);
+        set_cmdlog_path(cdclog_path);
     } else {
         logger->log(EXTENSION_LOG_INFO, NULL,
                     "The snapshot thread has failed to do snapshot action.\n");
     }
+
+    do_chkpt_clear_files(dir_path, newtime);
 
     pthread_mutex_lock(&ss->lock);
     ss->running = false;
@@ -653,6 +752,15 @@ ENGINE_ERROR_CODE chkpt_snapshot_direct(enum chkpt_snapshot_mode mode,
         *filesize = snapshot_anch.file.size;
     }
     pthread_mutex_unlock(&snapshot_anch.lock);
+    return ret;
+}
+
+ENGINE_ERROR_CODE chkpt_snapshot_init_for_cdc()
+{
+    ENGINE_ERROR_CODE ret = ENGINE_SUCCESS;
+    /* mkdir "default_dirpath" */
+    ret = chkpt_snapshot_start(CHKPT_SNAPSHOT_MODE_CHKPT, NULL, -1,
+                               "/home/intern/minuk/cdc-test" /* default_dirpath */, NULL);
     return ret;
 }
 

--- a/engines/default/chkpt_snapshot.h
+++ b/engines/default/chkpt_snapshot.h
@@ -35,6 +35,7 @@ ENGINE_ERROR_CODE chkpt_snapshot_direct(enum chkpt_snapshot_mode mode,
                                         const char *prefix, const int nprefix,
                                         const char *filepath, size_t *filesize);
 
+ENGINE_ERROR_CODE chkpt_snapshot_init_for_cdc(void);
 ENGINE_ERROR_CODE chkpt_snapshot_start(enum chkpt_snapshot_mode mode,
                                        const char *prefix, const int nprefix,
                                        const char *filepath,

--- a/engines/default/cmdlogbuf.c
+++ b/engines/default/cmdlogbuf.c
@@ -27,6 +27,7 @@
 #ifdef ENABLE_PERSISTENCE
 #include "cmdlogbuf.h"
 #include "cmdlogfile.h"
+#include "cdclogfile.h"
 
 /* FIXME: config log buffer size */
 #define CMDLOG_BUFFER_SIZE (100 * 1024 * 1024) /* 100 MB */
@@ -147,7 +148,8 @@ static uint32_t do_log_buff_flush(bool flush_all)
 
     if (dual_write_complete_flag) {
         cmdlog_file_complete_dual_write();
-        assert(dual_write_size == cmdlog_file_getsize());
+        cdclog_file_complete_dual_write();
+        //assert(dual_write_size == cmdlog_file_getsize());
 
         pthread_mutex_lock(&log_buff_gl.flush_lsn_lock);
         log_buff_gl.nxt_flush_lsn.filenum += 1;
@@ -156,7 +158,10 @@ static uint32_t do_log_buff_flush(bool flush_all)
     }
 
     if (nflush > 0) {
+        // Persistence
         cmdlog_file_write(&logbuff->data[logbuff->head], nflush, dual_write_flag);
+        // CDC
+        cdclog_file_write(&logbuff->data[logbuff->head], nflush, dual_write_flag);
 
         /* update nxt_flush_lsn */
         pthread_mutex_lock(&log_buff_gl.flush_lsn_lock);
@@ -244,6 +249,10 @@ static LogSN do_log_buff_write(LogRec *logrec, bool dual_write)
         /* check remain length */
         spare_length = CMDLOG_FLUSH_AUTO_SIZE - logbuff->fque[logbuff->fend].nflush;
         if (spare_length >= total_length) spare_length = total_length;
+        else {
+            /* Prevent record splitting */
+            if ((++logbuff->fend) == logbuff->fqsz) logbuff->fend = 0;
+        }
 
         logbuff->fque[logbuff->fend].nflush += spare_length;
         logbuff->fque[logbuff->fend].dual_write = dual_write;

--- a/engines/default/cmdlogfile.c
+++ b/engines/default/cmdlogfile.c
@@ -27,6 +27,7 @@
 #ifdef ENABLE_PERSISTENCE
 #include "cmdlogfile.h"
 #include "cmdlogbuf.h"
+#include "disk.h"
 
 #define ENABLE_DEBUG 0
 
@@ -54,89 +55,6 @@ struct log_file_global {
 static struct engine_config *config = NULL;
 static EXTENSION_LOGGER_DESCRIPTOR *logger = NULL;
 static struct log_file_global log_file_gl;
-
-/*
- * Static Functions for DIsk IO
- * FIXME: These can be moved to a separate disk.c file later.
- */
-/***************/
-
-static int disk_open(const char *fname, int flags, int mode)
-{
-    int fd;
-    while (1) {
-        if ((fd = open(fname, flags, mode)) == -1) {
-            if (errno == EINTR) continue;
-        }
-        break;
-    }
-    return fd;
-}
-
-static off_t disk_lseek(int fd, off_t offset, int whence)
-{
-    off_t ret = lseek(fd, offset, whence);
-    return ret;
-}
-
-static ssize_t disk_read(int fd, void *buf, size_t count)
-{
-    char   *bfptr = (char*)buf;
-    ssize_t nleft = count;
-    ssize_t nread;
-
-    while (nleft > 0) {
-        nread = read(fd, bfptr, nleft);
-        if (nread == 0) break;
-        if (nread <  0) {
-            if (errno == EINTR) continue;
-            return nread;
-        }
-        nleft -= nread;
-        bfptr += nread;
-    }
-    return (count - nleft);
-}
-
-static ssize_t disk_write(int fd, void *buf, size_t count)
-{
-    char   *bfptr = (char*)buf;
-    ssize_t nleft = count;
-    ssize_t nwrite;
-
-    while (nleft > 0) {
-        nwrite = write(fd, bfptr, nleft);
-        if (nwrite == 0) break;
-        if (nwrite <  0) {
-            if (errno == EINTR) continue;
-            return nwrite;
-        }
-        nleft -= nwrite;
-        bfptr += nwrite;
-    }
-    return (count - nleft);
-}
-
-static int disk_fsync(int fd)
-{
-    if (fsync(fd) != 0) {
-        return -1;
-    }
-    return 0;
-}
-
-static int disk_close(int fd)
-{
-    while (1) {
-        if (close(fd) != 0) {
-            if (errno == EINTR) continue;
-            return -1;
-        }
-        break;
-    }
-    return 0;
-}
-/***************/
 
 void cmdlog_file_write(char *log_ptr, uint32_t log_size, bool dual_write)
 {

--- a/engines/default/cmdlogmgr.c
+++ b/engines/default/cmdlogmgr.c
@@ -28,6 +28,8 @@
 #include "cmdlogmgr.h"
 #include "cmdlogbuf.h"
 #include "cmdlogfile.h"
+#include "cdclogfile.h"
+#include "produce.h"
 
 static struct assoc_scan *chkpt_scanp=NULL; // checkpoint scan pointer
 
@@ -472,6 +474,16 @@ ENGINE_ERROR_CODE cmdlog_mgr_init(struct default_engine* engine_ptr)
     if (ret != ENGINE_SUCCESS) {
         return ret;
     }
+    (void)cdclog_file_init(engine);
+    ret = ms_prod_init(engine);
+    if (ret != ENGINE_SUCCESS) {
+        return ret;
+    }
+    ret = chkpt_snapshot_init_for_cdc();
+    if (ret != ENGINE_SUCCESS) {
+        return ret;
+    }
+
     /* set enable change log */
     (void)item_clog_set_enable(true);
 
@@ -487,6 +499,10 @@ ENGINE_ERROR_CODE cmdlog_mgr_init(struct default_engine* engine_ptr)
     if (ret != ENGINE_SUCCESS) {
         return ret;
     }
+    ret = producer_thread_start();
+    if (ret != ENGINE_SUCCESS) {
+        return ret;
+    }
 
     logmgr_gl.initialized = true;
     logger->log(EXTENSION_LOG_INFO, NULL, "COMMAND LOG MANAGER module initialized.\n");
@@ -498,13 +514,16 @@ void cmdlog_mgr_final(void)
     chkpt_thread_stop();
     cmdlog_buf_flush_thread_stop();
     do_cmdlog_gcommit_thread_stop();
+    producer_thread_stop();
 
     /* CONSIDER: do last checkpoint before shutdown engine. */
     chkpt_snapshot_final();
     chkpt_final();
     cmdlog_buf_final();
     cmdlog_file_final();
+    cdclog_file_final();
     cmdlog_waiter_final();
+    producer_final();
 
     if (logmgr_gl.initialized == true) {
         logmgr_gl.initialized = false;

--- a/engines/default/disk.c
+++ b/engines/default/disk.c
@@ -1,0 +1,83 @@
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#include "disk.h"
+
+int disk_open(const char *fname, int flags, int mode)
+{
+    int fd;
+    while (1) {
+        if ((fd = open(fname, flags, mode)) == -1) {
+            if (errno == EINTR) continue;
+        }
+        break;
+    }
+    return fd;
+}
+
+off_t disk_lseek(int fd, off_t offset, int whence)
+{
+    off_t ret = lseek(fd, offset, whence);
+    return ret;
+}
+
+ssize_t disk_read(int fd, void *buf, size_t count)
+{
+    char   *bfptr = (char*)buf;
+    ssize_t nleft = count;
+    ssize_t nread;
+
+    while (nleft > 0) {
+        nread = read(fd, bfptr, nleft);
+        if (nread == 0) break;
+        if (nread <  0) {
+            if (errno == EINTR) continue;
+            return nread;
+        }
+        nleft -= nread;
+        bfptr += nread;
+    }
+    return (count - nleft);
+}
+
+ssize_t disk_write(int fd, void *buf, size_t count)
+{
+    char   *bfptr = (char*)buf;
+    ssize_t nleft = count;
+    ssize_t nwrite;
+
+    while (nleft > 0) {
+        nwrite = write(fd, bfptr, nleft);
+        if (nwrite == 0) break;
+        if (nwrite <  0) {
+            if (errno == EINTR) continue;
+            return nwrite;
+        }
+        nleft -= nwrite;
+        bfptr += nwrite;
+    }
+    return (count - nleft);
+}
+
+int disk_fsync(int fd)
+{
+    if (fsync(fd) != 0) {
+        return -1;
+    }
+    return 0;
+}
+
+int disk_close(int fd)
+{
+    while (1) {
+        if (close(fd) != 0) {
+            if (errno == EINTR) continue;
+            return -1;
+        }
+        break;
+    }
+    return 0;
+}

--- a/engines/default/disk.h
+++ b/engines/default/disk.h
@@ -1,0 +1,11 @@
+#ifndef DISK_H
+#define DISK_H
+
+int disk_open(const char *fname, int flags, int mode);
+off_t disk_lseek(int fd, off_t offset, int whence);
+ssize_t disk_read(int fd, void *buf, size_t count);
+ssize_t disk_write(int fd, void *buf, size_t count);
+int disk_fsync(int fd);
+int disk_close(int fd);
+
+#endif

--- a/engines/default/items.c
+++ b/engines/default/items.c
@@ -1549,6 +1549,9 @@ static enum dump_mode do_item_dump_mode_check(const char *modestr)
     if (memcmp(modestr, "key", 3) == 0) {
         mode = DUMP_MODE_KEY;
     }
+    else if (memcmp(modestr, "snapshot", 8) == 0) {
+        mode = DUMP_MODE_SNAPSHOT;
+    }
     return mode;
 }
 
@@ -1591,8 +1594,17 @@ ENGINE_ERROR_CODE item_dump_start(struct default_engine *engine,
 
 #ifdef ENABLE_PERSISTENCE
         if (mode == DUMP_MODE_SNAPSHOT) {
+            struct stat st;
+            stat(filepath, &st);
+            if (!S_ISDIR(st.st_mode)) {
+                logger->log(EXTENSION_LOG_INFO, NULL,
+                        "Chkpt path is not a directory. path=%s err=%s\n",
+                        filepath, strerror(errno));
+                ret = ENGINE_FAILED; break;
+            }
             dumper->running = true;
-            ret = chkpt_snapshot_start(CHKPT_SNAPSHOT_MODE_DATA, prefix, nprefix,
+
+            ret = chkpt_snapshot_start(CHKPT_SNAPSHOT_MODE_CHKPT, prefix, nprefix,
                                        filepath, item_dumper_done);
             if (ret != ENGINE_SUCCESS) {
                 dumper->running = false;

--- a/engines/default/produce.c
+++ b/engines/default/produce.c
@@ -1,0 +1,434 @@
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#include "rdkafka.h"
+
+#include "default_engine.h"
+
+#ifdef ENABLE_PERSISTENCE
+#include "checkpoint.h"
+#include "cmdlogfile.h"
+#include "cmdlogbuf.h"
+#include "cmdlogrec.h"
+#include "cdclogfile.h"
+#include "produce.h"
+
+#define PRODUCE_CMDLOG 0
+#define PRODUCE_SNAPSHOT 1
+
+typedef struct _kafka_st {
+    rd_kafka_t *rk;
+    char *topic;
+    char *brokers;
+} kafka_st;
+
+typedef struct _ms_producer {
+    pthread_mutex_t lock;
+    pthread_cond_t cond;
+    void *config;
+    bool sleep;
+    int mode;
+    int snapshot_req;
+    char snapshot_path[MAX_FILEPATH_LENGTH]; /* snapshot file path */
+    char cmdlog_path[MAX_FILEPATH_LENGTH];   /* cmdlog file path */
+    char *data_path;
+    char *logs_path;
+    volatile uint8_t running;
+    volatile bool reqstop;
+    volatile bool initialized;
+} ms_producer;
+
+/* global data */
+static EXTENSION_LOGGER_DESCRIPTOR* logger = NULL;
+static kafka_st kafka_anch;
+static ms_producer producer;
+
+// callback이 필요한지 검토
+// static void
+// dr_msg_cb(rd_kafka_t *rk, const rd_kafka_message_t *rkmessage, void *opaque) {
+
+// }
+
+static int producer_init(void)
+{
+    kafka_st *ks = &kafka_anch;
+    rd_kafka_t *rk;
+    rd_kafka_conf_t *conf;
+    char errstr[512];
+
+    conf = rd_kafka_conf_new();
+    if (rd_kafka_conf_set(conf, "bootstrap.servers", ks->brokers, errstr,
+                            sizeof(errstr)) != RD_KAFKA_CONF_OK) {
+        logger->log(EXTENSION_LOG_WARNING, NULL,
+                    "%s\n", errstr);
+        return -1;
+    }
+
+    // callback이 필요한지 검토 후 활성화
+    //rd_kafka_conf_set_dr_msg_cb(conf, dr_msg_cb);
+
+    rk = rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr, sizeof(errstr));
+    if (!rk) {
+        logger->log(EXTENSION_LOG_WARNING, NULL,
+                    "Failed to create new producer: %s\n", errstr);
+        return -1;
+    }
+    ks->rk = rk;
+    return 1;
+}
+
+static int do_produce(char *buf, size_t size)
+{
+    kafka_st *ks = &kafka_anch;
+    while(1) {
+        rd_kafka_resp_err_t err;
+        err = rd_kafka_producev(
+                    ks->rk,
+                    RD_KAFKA_V_TOPIC(ks->topic),
+                    RD_KAFKA_V_MSGFLAGS(RD_KAFKA_MSG_F_COPY),
+                    RD_KAFKA_V_VALUE(buf, size),
+                    RD_KAFKA_V_OPAQUE(NULL),
+                    RD_KAFKA_V_END);
+
+        if (err == RD_KAFKA_RESP_ERR_NO_ERROR) {
+            rd_kafka_poll(ks->rk, 0);
+            return 1;
+        }
+
+        if (err == RD_KAFKA_RESP_ERR__QUEUE_FULL) {
+            rd_kafka_poll(ks->rk, 10);
+            continue;
+        }
+
+        return -1;
+    }
+}
+
+static void producer_destory(void)
+{
+    kafka_st *ks = &kafka_anch;
+
+    if (ks->rk == NULL) {
+        return;
+    }
+
+    rd_kafka_poll(ks->rk, 0);
+
+    /* 최대 10초 동안 남은 메세지 전송 대기 */
+    rd_kafka_flush(ks->rk, 10*1000);
+
+    /* flush 후에도 남아있다면 미전달 */
+    int outq = rd_kafka_outq_len(ks->rk);
+    if (outq > 0) {
+        logger->log(EXTENSION_LOG_INFO, NULL,
+                    "%d message(s) were not delivered\n", outq);
+    }
+
+    rd_kafka_destroy(ks->rk);
+    ks->rk = NULL;
+}
+
+static int produce_cmdlog(ms_producer *p, int *cmdlog_offset)
+{
+    int fd;
+    pthread_mutex_lock(&p->lock);
+    if ((fd=open(p->cmdlog_path, O_RDONLY)) < 0) {
+        logger->log(EXTENSION_LOG_WARNING, NULL,
+                    "Failed to open cmdlog file. path=%s err=%s\n",
+                    p->cmdlog_path, strerror(errno));
+        return -1;
+    }
+    pthread_mutex_unlock(&p->lock);
+
+    struct stat sb;
+    fstat(fd, &sb);
+    size_t file_size, seek_offset;
+    file_size = sb.st_size;
+    seek_offset = lseek(fd, *cmdlog_offset, SEEK_SET);
+
+    char buf[MAX_LOG_RECORD_SIZE];
+    ssize_t nread;
+    LogRec *logrec = (LogRec*)buf;
+    LogHdr *loghdr = &logrec->header;
+
+    while (1) {
+        if (p->snapshot_req) {
+            close(fd);
+            return 1;
+        }
+
+        if (seek_offset >= file_size) {
+            close(fd);
+            if (cdclog_file_deletable()) {
+                char path[MAX_FILEPATH_LENGTH];
+                next_cdclog_path(p->cmdlog_path, path);
+                fd = open(path, O_RDONLY);
+                if (fd < 0) {
+                    logger->log(EXTENSION_LOG_WARNING, NULL,
+                                "Failed to open cmdlog file. path=%s err=%s\n",
+                                path, strerror(errno));
+                    *cmdlog_offset = seek_offset;
+                    return -1;
+                }
+                cdclog_file_delete(p->cmdlog_path);
+                snprintf(p->cmdlog_path, MAX_FILEPATH_LENGTH, "%s", path);
+
+                fstat(fd, &sb);
+                file_size = sb.st_size;
+                seek_offset = 0;
+                continue;
+            }
+            break;
+        }
+
+        nread = read(fd, loghdr, sizeof(LogHdr));
+        if (nread != sizeof(LogHdr)) {
+            logger->log(EXTENSION_LOG_WARNING, NULL,
+                        "[PRODUCE] failed : read header data "
+                        "nread(%zd) != header_length(%ld).\n", nread, sizeof(LogHdr));
+            break;
+        }
+
+        size_t log_size = sizeof(LogHdr)+loghdr->body_length;
+        if (loghdr->body_length > 0) {
+            logrec->body = buf+sizeof(LogHdr);
+            nread = read(fd, logrec->body, loghdr->body_length);
+            if (nread != loghdr->body_length) {
+                logger->log(EXTENSION_LOG_WARNING, NULL,
+                        "[PRODUCE] failed : read body data "
+                        "nread(%zd) != body_length(%d).\n", nread, loghdr->body_length);
+                break;
+            }
+        }
+
+        if (do_produce(buf, log_size) < 0) {
+            break;
+        }
+        seek_offset += log_size;
+    }
+
+    *cmdlog_offset = seek_offset;
+    return 1;
+}
+
+static int produce_snapshot(ms_producer *p)
+{
+    int fd;
+    pthread_mutex_lock(&p->lock);
+    if ((fd=open(p->snapshot_path, O_RDONLY)) < 0) {
+        logger->log(EXTENSION_LOG_WARNING, NULL,
+                    "Failed to open snapshot file. path=%s err=%s\n",
+                    p->snapshot_path, strerror(errno));
+        return -1;
+    }
+    pthread_mutex_unlock(&p->lock);
+
+    struct stat sb;
+    fstat(fd, &sb);
+    size_t file_size, seek_offset;
+    file_size = sb.st_size;
+    seek_offset = 0;
+
+    char buf[MAX_LOG_RECORD_SIZE];
+    ssize_t nread;
+    LogRec *logrec = (LogRec*)buf;
+    LogHdr *loghdr = &logrec->header;
+
+    while (seek_offset < file_size) {
+        nread = read(fd, loghdr, sizeof(LogHdr));
+        if (nread != sizeof(LogHdr)) {
+            logger->log(EXTENSION_LOG_WARNING, NULL,
+                        "[PRODUCE] failed : read header data "
+                        "nread(%zd) != header_length(%ld).\n", nread, sizeof(LogHdr));
+            break;
+        }
+
+        size_t log_size = sizeof(LogHdr)+loghdr->body_length;
+        if (loghdr->body_length > 0) {
+            logrec->body = buf+sizeof(LogHdr);
+            nread = read(fd, logrec->body, loghdr->body_length);
+            if (nread != loghdr->body_length) {
+                logger->log(EXTENSION_LOG_WARNING, NULL,
+                        "[PRODUCE] failed : read body data "
+                        "nread(%zd) != body_length(%d).\n", nread, loghdr->body_length);
+                break;
+            }
+        }
+
+        if (do_produce(buf, log_size) < 0) {
+            break;
+        }
+        seek_offset += log_size;
+    }
+    p->mode = PRODUCE_CMDLOG;
+    return 1;
+}
+
+static int do_producer_thread_sleep(ms_producer *p, int sleep_sec)
+{
+    struct timeval tv;
+    struct timespec to;
+
+    gettimeofday(&tv, NULL);
+    to.tv_sec = tv.tv_sec + sleep_sec;
+    to.tv_nsec = tv.tv_usec * 1000;
+
+    pthread_mutex_lock(&p->lock);
+    p->sleep = true;
+    pthread_cond_timedwait(&p->cond, &p->lock, &to);
+    p->sleep = false;
+    pthread_mutex_unlock(&p->lock);
+
+    return sleep_sec;
+}
+
+static void do_producer_thread_wakeup(ms_producer *p)
+{
+    pthread_mutex_lock(&p->lock);
+    if (p->sleep) {
+        pthread_cond_signal(&p->cond);
+    }
+    pthread_mutex_unlock(&p->lock);
+}
+
+void set_cmdlog_path(const char *path)
+{
+    pthread_mutex_lock(&producer.lock);
+    snprintf(producer.cmdlog_path, MAX_FILEPATH_LENGTH,
+            "%s", path);
+    pthread_mutex_unlock(&producer.lock);
+}
+
+void set_snapshot_path(const char *path)
+{
+    pthread_mutex_lock(&producer.lock);
+    snprintf(producer.snapshot_path, MAX_FILEPATH_LENGTH,
+            "%s", path);
+    pthread_mutex_unlock(&producer.lock);
+}
+
+static void* producer_thread_main(void* arg)
+{
+    producer_init();
+
+    ms_producer *p = (ms_producer *)arg;
+    int cmdlog_offset = 0;
+
+    p->running = RUNNING_STARTED;
+    while(1) {
+        do_producer_thread_sleep(p, 1);
+
+        if (p->reqstop) {
+            logger->log(EXTENSION_LOG_INFO, NULL, "Producer thread recognized stop request.\n");
+            break;
+        }
+
+        pthread_mutex_lock(&p->lock);
+        if (p->snapshot_path[0] == '\0' || p->cmdlog_path[0] == '\0') {
+            continue;
+        }
+        pthread_mutex_unlock(&p->lock);
+
+        if (p->mode == PRODUCE_SNAPSHOT) {
+            produce_snapshot(p);
+            cmdlog_offset = 0;
+        }
+        else if (p->mode == PRODUCE_CMDLOG) {
+            produce_cmdlog(p, &cmdlog_offset);
+        }
+    }
+    p->running = RUNNING_STOPPED;
+    producer_destory();
+    return NULL;
+}
+
+ENGINE_ERROR_CODE kafka_st_init(char *topic, char *broker)
+{
+    kafka_anch.topic = topic;
+    kafka_anch.brokers = broker;
+    return ENGINE_SUCCESS;
+}
+
+ENGINE_ERROR_CODE ms_prod_init(struct default_engine* engine)
+{
+    logger = engine->server.log->get_logger();
+
+    kafka_st_init("test-topic", "localhost");
+    pthread_mutex_init(&producer.lock, NULL);
+    pthread_cond_init(&producer.cond, NULL);
+    producer.config = (void*)&engine->config;
+    producer.sleep = false;
+    producer.mode = PRODUCE_SNAPSHOT;
+    producer.snapshot_req = 0;
+    producer.snapshot_path[0] = '\0';
+    producer.cmdlog_path[0] = '\0';
+    producer.data_path = engine->config.data_path;
+    producer.logs_path = engine->config.logs_path;
+    producer.running = RUNNING_UNSTARTED;
+    producer.reqstop = false;
+    producer.initialized = true;
+    logger->log(EXTENSION_LOG_INFO, NULL, "PRODUCER module initialized");
+    return ENGINE_SUCCESS;
+}
+
+ENGINE_ERROR_CODE producer_thread_start(void)
+{
+    pthread_t tid;
+    if (producer.running == RUNNING_STARTED) {
+        logger->log(EXTENSION_LOG_INFO, NULL,
+                    "Producer_thread already started.\n");
+        return ENGINE_FAILED;
+    }
+
+    producer.running = RUNNING_UNSTARTED;
+    /* create producer thread */
+    if (pthread_create(&tid, NULL, producer_thread_main, &producer) != 0) {
+        logger->log(EXTENSION_LOG_WARNING, NULL,
+            "Failed to create producer thread. error=%s\n", strerror(errno));
+        return ENGINE_FAILED;
+    }
+
+    /* wait unitl producer thread starts */
+    while (producer.running == RUNNING_UNSTARTED) {
+        usleep(5000);
+    }
+    logger->log(EXTENSION_LOG_INFO, NULL, "Producer thread started.\n");
+    return ENGINE_SUCCESS;
+}
+
+void producer_thread_stop(void)
+{
+    if (producer.running == RUNNING_UNSTARTED) {
+        return;
+    }
+    while (producer.running == RUNNING_STARTED) {
+        producer.reqstop = true;
+        do_producer_thread_wakeup(&producer);
+        usleep(5000);
+    }
+    logger->log(EXTENSION_LOG_INFO, NULL, "Producer thread stopped.\n");
+}
+
+void producer_final(void)
+{
+    if (producer.initialized == false) {
+        return;
+    }
+    pthread_mutex_destroy(&producer.lock);
+    pthread_cond_destroy(&producer.cond);
+    producer.initialized = false;
+    logger->log(EXTENSION_LOG_INFO, NULL, "PRODUCER module destroyed.\n");
+}
+#endif

--- a/engines/default/produce.h
+++ b/engines/default/produce.h
@@ -1,0 +1,19 @@
+#ifndef PRODUCE_H
+#define PRODUCE_H
+
+/* kafka init */
+ENGINE_ERROR_CODE kafka_st_init(char *topic, char *broker);
+
+/* ------ produce function prototype ------*/
+ENGINE_ERROR_CODE ms_prod_init(struct default_engine* engine);
+ENGINE_ERROR_CODE producer_thread_start(void);
+void producer_thread_stop(void);
+void producer_final(void);
+
+/* util function */
+void set_cmdlog_path(const char *path);
+void set_snapshot_path(const char *path);
+void do_snapshot_to_cmdlog(void);
+void do_cmdlog_to_snapshot(void);
+
+#endif

--- a/memcached.c
+++ b/memcached.c
@@ -10008,7 +10008,7 @@ static void process_dump_command(conn *c, token_t *tokens, const size_t ntokens)
 
     /* dump ascii command
      * dump start <mode> [<prefix>] <filepath>\r\n
-     *   <mode> : key
+     *   <mode> : key, snapshot
      * dump stop\r\n
      */
     if (memcmp(subcommand, "start", 5) == 0) {
@@ -10017,7 +10017,8 @@ static void process_dump_command(conn *c, token_t *tokens, const size_t ntokens)
         modestr = tokens[2].value;
         if (ntokens == 5) {
             filepath = tokens[3].value;
-        } else {
+        }
+        else if (memcmp(modestr, "key", 3) == 0) {
             prefix = tokens[3].value;
             nprefix = tokens[3].length;
             if (nprefix > PREFIX_MAX_LENGTH) {
@@ -10030,6 +10031,10 @@ static void process_dump_command(conn *c, token_t *tokens, const size_t ntokens)
                 nprefix = 0;
             }
             filepath = tokens[4].value;
+        } else {
+            print_invalid_command(c, tokens, ntokens);
+            out_string(c, "ERROR unknown command");
+            return;
         }
     }
     else if (memcmp(subcommand, "stop", 4) == 0) {


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/821

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 기존의 구현
  - 하나의 snapshot, cmdlog 파일을 유지하는 것을 기본으로 동작합니다.
    - `snapshot_<time>` `cmdlog_<time>` 형식을 사용합니다.
  -  log_FILE 구조체의 fd, next_fd, prev_fd를 통해 체크포인트 수행 시 cmdlog 파일을 관리합니다.
    - fd에는 현재 cmdlog 파일의 fd를 기록하며 새롭게 생성된 cmdlog 파일은 next_fd에 기록합니다.
    - 스냅샷이 완료된 item에 대한 변경 로그는 fd, next_fd 모두 기록하며 완료되지 않은 item에 대한 변경 로그는 fd에만 기록합니다.
    - 스냅샷이 완료되면 prev_fd를 fd로 변경하고 fd를 next_fd로 변경합니다.
      - sync 모드의 경우 `cmdlog_file_sync()`에서 prev_fd에 대한 fsync() 후 close()를 합니다.
      - async 모드의 경우 `cmdlog_file_complete_dual_write()` 후 바로 prev_fd를 close()합니다.
   - 파일의 정리는 `chkpt_thread_main`에서 주기적으로 실행합니다.
 
- 변경한 구현
  - 로그 파일의 크기에 따라서 자동으로 체크포인트가 수행되는 `chkpt_thread_main()`의 동작을 비활성화 시켰습니다.
  - `dump start snapshot`을 통해 실행되는 체크포인트는 `do_snapshot_thread_main()`으로 수행하도록 로직을 변경했습니다.
  
  - 하나의 snapshot, 최대 크기를 제한한 로그 파일을 큐 형태로 연결하여 관리합니다.
    - `snapshot_<time>`, `snapshot_<time>_<number>` 형식을 사용합니다.
      - `<number>`는 `<time>`에 해당하는 snapshot 이후로 생성된 몇번 째 로그 파일인지를 나타냅니다.
   
   - 로그 파일을 전역으로 관리하는 `log_file_global`구조체와 구조체의 필드인 `logFILE` 구조체를 변형했습니다.
     - prev_fd, fd, next_fd의 관리 방식은 기존의 구현과 동일합니다.
       - fd는 현재 로그를 기록 중인 파일이고 next_fd는 스냅샷이 수행되는 동안 기록되는 로그 파일입니다. 
     - 스냅샷 파일이 생성된 경우 fd, next_fd를 교체하는 방식으로 동작합니다.
     - fidx_bgn, fidx_end를 통해 `<number>`의 시작과 끝을 관리합니다.
       - Producer에서 전부 전송한 파일의 삭제 여부를 판단하는데 사용할 예정입니다.

  - 체크포인팅 이후 기존 로그 파일을 생성하는 로직을 변경했습니다. 
  - Producer 쓰레드를 구현했습니다.
    - snapshot, cmdlog 파일을 읽고 레코드를 kafka로 produce합니다.
    - cmdlog_<time>_<fidx_bgn>부터 전부 produce했다면 해당 파일을 삭제합니다.
    - fidx_bgn과 fidx_end를 비교하여 같다면 아직 로그가 기록 중인 파일이기에 삭제하지 않습니다.
  - Cosumer 프로세스를 구현했습니다.
    -  `gcc consumer.c util.c -I./include -o consumer -lrdkafka -lmemcached`를 통해서 컴파일 가능합니다.
    - 현재는 key-value, list 컬렉션에 대한 레코드를 소비할 수 있습니다.
