### PR TITLE
INTERNAL: Fix misleading status comment in btree_elem_item

### DIFF
--- a/engines/default/item_base.h
+++ b/engines/default/item_base.h
@@ -199,7 +199,7 @@ typedef struct _map_elem_item {
 typedef struct _btree_elem_item_fixed {
     uint16_t refcount;
     uint8_t  slabs_clsid;        /* which slab class we're in */
-    uint8_t  status;             /* 3(used), 2(insert mark), 1(delete_mark), or 0(free) */
+    uint8_t  status;             /* element lifecycle state: used(in-tree), unlinked(removed but referenced), or free */
     uint8_t  nbkey;              /* length of bkey */
     uint8_t  neflag;             /* length of element flag */
     uint16_t nbytes;             /**< The total size of the data (in bytes) */
@@ -208,7 +208,7 @@ typedef struct _btree_elem_item_fixed {
 typedef struct _btree_elem_item {
     uint16_t refcount;
     uint8_t  slabs_clsid;        /* which slab class we're in */
-    uint8_t  status;             /* 3(used), 2(insert mark), 1(delete_mark), or 0(free) */
+    uint8_t  status;             /* element lifecycle state: used(in-tree), unlinked(removed but referenced), or free */
     uint8_t  nbkey;              /* length of bkey */
     uint8_t  neflag;             /* length of element flag */
     uint16_t nbytes;             /**< The total size of the data (in bytes) */


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/840

### ⌨️ What I did

- `btree_elem_item` 구조체의 `status` 필드 주석이 실제 lifecycle 상태값과 맞지 않아 오해를 유발할 수 있었습니다. `item_base.h`의 주석을 실제 사용 방식(used/unlinked/free lifecycle)에 맞게 수정했습니다.
