### PR TITLE
INTERNAL: Use C99 flexible array members and remove btree_elem_item_fixed

### DIFF
--- a/engines/default/cmdlogmgr.c
+++ b/engines/default/cmdlogmgr.c
@@ -62,7 +62,7 @@ typedef struct _group_commit {
 
 typedef struct _waiter_chunk {
     struct _waiter_chunk *next;
-    log_waiter_t          waiters[1];
+    log_waiter_t          waiters[];
 } log_waiter_chunk;
 
 typedef struct _waiter_info {

--- a/engines/default/cmdlogrec.h
+++ b/engines/default/cmdlogrec.h
@@ -137,7 +137,7 @@ typedef struct _IT_link_data {
         uint64_t cas;
         struct lrec_coll_meta meta;
     } ptr;
-    char data[1];
+    char data[];
 } ITLinkData;
 
 typedef struct _IT_link_log {
@@ -150,7 +150,7 @@ typedef struct _IT_link_log {
 /* Item Unlink Log Record */
 typedef struct _IT_unlink_data {
     uint16_t keylen;         /* key length */
-    char     data[1];
+    char     data[];
 } ITUnlinkData;
 
 typedef struct _IT_unlink_log {
@@ -162,7 +162,7 @@ typedef struct _IT_unlink_log {
 /* Item Flush Log Record */
 typedef struct _IT_flush_data {
     uint8_t nprefix;        /* prefix length */
-    char    data[1];
+    char    data[];
 } ITFlushData;
 
 typedef struct _IT_flush_log {
@@ -181,7 +181,7 @@ typedef struct _IT_setattr_data {
     uint8_t  maxbkrlen;      /* maxbkeyrange length */
     uint8_t  reserved_8[1];
     int32_t  mcnt;           /* maximum element count */
-    char     data[1];
+    char     data[];
 } ITSetAttrData;
 
 typedef struct _IT_setattr_log {
@@ -196,7 +196,7 @@ typedef struct _snapshot_elem_data {
     uint32_t nbytes;
     uint8_t  nekey;          /* nbkey(btree), nfield(map) */
     uint8_t  neflag;         /* neflag(btree) */
-    char     data[1];
+    char     data[];
 } SnapshotElemData;
 
 typedef struct _snapshot_elem_log {
@@ -223,7 +223,7 @@ typedef struct _List_elem_insert_data {
     uint32_t vallen;  /* value length */
     uint32_t totcnt;  /* total element count */
     int32_t  eindex;  /* element index */
-    char     data[1];
+    char     data[];
 } ListElemInsData;
 
 typedef struct _List_elem_insert_log {
@@ -242,7 +242,7 @@ typedef struct _List_elem_delete_data {
     uint32_t totcnt;  /* total element count */
     int32_t  eindex;  /* element index */
     uint32_t delcnt;  /* delete count */
-    char     data[1];
+    char     data[];
 } ListElemDelData;
 
 typedef struct _List_elem_delete_log {
@@ -257,7 +257,7 @@ typedef struct _Map_elem_insert_data {
     uint8_t  create;  /* create flag */
     uint8_t  fldlen;  /* field length */
     uint32_t vallen;  /* value length */
-    char     data[1];
+    char     data[];
 } MapElemInsData;
 
 typedef struct _Map_elem_insert_log {
@@ -273,7 +273,7 @@ typedef struct _Map_elem_delete_data {
     uint16_t keylen;  /* key length */
     uint8_t  drop;    /* drop if empty */
     uint8_t  fldlen;  /* field length */
-    char     data[1];
+    char     data[];
 } MapElemDelData;
 
 typedef struct _Map_elem_delete_log {
@@ -289,7 +289,7 @@ typedef struct _Set_elem_insert_data {
     uint8_t  create;  /* create flag */
     uint8_t  reserved_8[1];
     uint32_t vallen;  /* value length */
-    char     data[1];
+    char     data[];
 } SetElemInsData;
 
 typedef struct _Set_elem_insert_log {
@@ -306,7 +306,7 @@ typedef struct _Set_elem_delete_data {
     uint8_t  drop;    /* drop if empty */
     uint8_t  reserved_8[1];
     uint32_t vallen;  /* value length */
-    char     data[1];
+    char     data[];
 } SetElemDelData;
 
 typedef struct _Set_elem_delete_log {
@@ -324,7 +324,7 @@ typedef struct _Btree_elem_insert_data {
     uint8_t  neflag;  /* eflag length */
     uint8_t  reserved_8[3];
     uint32_t vallen;  /* value length */
-    char     data[1];
+    char     data[];
 } BtreeElemInsData;
 
 typedef struct _Btree_elem_insert_log {
@@ -340,7 +340,7 @@ typedef struct _Btree_elem_delete_data {
     uint16_t keylen;  /* key length */
     uint8_t  drop;    /* drop if empty */
     uint8_t  nbkey;   /* bkey length */
-    char     data[1];
+    char     data[];
 } BtreeElemDelData;
 
 typedef struct _Btree_elem_delete_log {
@@ -365,7 +365,7 @@ typedef struct _Btree_elem_delete_logical_data {
     uint8_t  compop;     /* compare operation */
     uint32_t offset;     /* element offset */
     uint32_t reqcount;   /* request count */
-    char     data[1];
+    char     data[];
 } BtreeElemDelLgcData;
 
 typedef struct _Btree_elem_delete_logical_log {

--- a/engines/default/coll_btree.c
+++ b/engines/default/coll_btree.c
@@ -179,7 +179,7 @@ static void _setif_forced_btree_overflow_action(btree_meta_info *info,
 
 static inline uint32_t do_btree_elem_ntotal(btree_elem_item *elem)
 {
-    return sizeof(btree_elem_item_fixed) + BTREE_REAL_NBKEY(elem->nbkey)
+    return sizeof(btree_elem_item) + BTREE_REAL_NBKEY(elem->nbkey)
            + elem->neflag + elem->nbytes;
 }
 
@@ -281,7 +281,7 @@ static void do_btree_node_free(btree_indx_node *node)
 static btree_elem_item *do_btree_elem_alloc(const uint32_t nbkey, const uint32_t neflag,
                                             const uint32_t nbytes, const void *cookie)
 {
-    size_t ntotal = sizeof(btree_elem_item_fixed) + BTREE_REAL_NBKEY(nbkey) + neflag + nbytes;
+    size_t ntotal = sizeof(btree_elem_item) + BTREE_REAL_NBKEY(nbkey) + neflag + nbytes;
 
     btree_elem_item *elem = do_item_mem_alloc(ntotal, LRU_CLSID_FOR_SMALL, cookie);
     if (elem != NULL) {

--- a/engines/default/item_base.h
+++ b/engines/default/item_base.h
@@ -171,7 +171,7 @@ typedef struct _list_elem_item {
     struct _list_elem_item *next; /* next chain in double linked list */
     struct _list_elem_item *prev; /* prev chain in double linked list */
     uint32_t nbytes;              /**< The total size of the data (in bytes) */
-    char     value[1];            /**< the data itself */
+    char     value[];             /**< the data itself */
 } list_elem_item;
 
 /* set element */
@@ -181,7 +181,7 @@ typedef struct _set_elem_item {
     uint32_t hval;                /* hash value */
     struct _set_elem_item *next;  /* hash chain next */
     uint32_t nbytes;              /**< The total size of the data (in bytes) */
-    char     value[1];            /**< the data itself */
+    char     value[];             /**< the data itself */
 } set_elem_item;
 
 /* map element */
@@ -192,19 +192,10 @@ typedef struct _map_elem_item {
     struct _map_elem_item *next;  /* hash chain next */
     uint8_t nfield;               /**< The total size of the field (in bytes) */
     uint16_t nbytes;              /**< The total size of the data (in bytes) */
-    unsigned char data[1];        /* data: <field, value> */
+    unsigned char data[];         /* data: <field, value> */
 } map_elem_item;
 
 /* btree element */
-typedef struct _btree_elem_item_fixed {
-    uint16_t refcount;
-    uint8_t  slabs_clsid;        /* which slab class we're in */
-    uint8_t  status;             /* element lifecycle state: used(in-tree), unlinked(removed but referenced), or free */
-    uint8_t  nbkey;              /* length of bkey */
-    uint8_t  neflag;             /* length of element flag */
-    uint16_t nbytes;             /**< The total size of the data (in bytes) */
-} btree_elem_item_fixed;
-
 typedef struct _btree_elem_item {
     uint16_t refcount;
     uint8_t  slabs_clsid;        /* which slab class we're in */
@@ -212,7 +203,7 @@ typedef struct _btree_elem_item {
     uint8_t  nbkey;              /* length of bkey */
     uint8_t  neflag;             /* length of element flag */
     uint16_t nbytes;             /**< The total size of the data (in bytes) */
-    unsigned char data[1];       /* data: <bkey, [eflag,] value> */
+    unsigned char data[];        /* data: <bkey, [eflag,] value> */
 } btree_elem_item;
 
 /* list meta info */


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/840

### ⌨️ What I did
- 컬렉션 elem 구조체(`list_elem_item`, `set_elem_item`, `map_elem_item`, `btree_elem_item`),
커맨드 로그 레코드 구조체(`cmdlogrec.h`), 로그 waiter 구조체(`cmdlogmgr.c`)에서
C89의 struct hack(`arr[1]`)을
C99 flexible array member(`arr[]`)로 변경하였습니다.

- 이를 통해 불필요해진 `btree_elem_item_fixed` 타입을 제거하고,
ntotal 계산에서 `sizeof(btree_elem_item)`을 직접 사용하도록 수정하였습니다.