### PR TITLE
INTERNAL: Unify elem lifecycle state management with status field

### DIFF
--- a/engines/default/coll_btree.c
+++ b/engines/default/coll_btree.c
@@ -62,11 +62,6 @@ static inline void UNLOCK_CACHE(void)
 #define BKEY_RANGE_TYPE_ASC 2 /* ascending bkey range */
 #define BKEY_RANGE_TYPE_DSC 3 /* descending bkey range */
 
-/* btree item status */
-#define BTREE_ITEM_STATUS_USED   2
-#define BTREE_ITEM_STATUS_UNLINK 1
-#define BTREE_ITEM_STATUS_FREE   0
-
 /* overflow type */
 #define OVFL_TYPE_NONE  0
 #define OVFL_TYPE_COUNT 1
@@ -289,7 +284,7 @@ static btree_elem_item *do_btree_elem_alloc(const uint32_t nbkey, const uint32_t
         assert(elem->slabs_clsid > 0);
 
         elem->refcount    = 0;
-        elem->status      = BTREE_ITEM_STATUS_UNLINK; /* unlinked state */
+        elem->status      = ELEM_STATUS_UNLINKED; /* unlinked state */
         elem->nbkey       = (uint8_t)nbkey;
         elem->neflag      = (uint8_t)neflag;
         elem->nbytes      = (uint16_t)nbytes;
@@ -307,12 +302,10 @@ static void do_btree_elem_free(btree_elem_item *elem)
 
 static void do_btree_elem_release(btree_elem_item *elem)
 {
-    /* assert(elem->status != BTREE_ITEM_STATUS_FREE); */
     if (elem->refcount != 0) {
         elem->refcount--;
     }
-    if (elem->refcount == 0 && elem->status == BTREE_ITEM_STATUS_UNLINK) {
-        elem->status = BTREE_ITEM_STATUS_FREE;
+    if (elem->refcount == 0 && elem->status == ELEM_STATUS_UNLINKED) {
         do_btree_elem_free(elem);
     }
 }
@@ -1667,9 +1660,8 @@ static void do_btree_elem_unlink(btree_meta_info *info, btree_elem_posi *path,
     CLOG_BTREE_ELEM_DELETE(info, elem, cause);
 
     if (elem->refcount > 0) {
-        elem->status = BTREE_ITEM_STATUS_UNLINK;
+        elem->status = ELEM_STATUS_UNLINKED;
     } else  {
-        elem->status = BTREE_ITEM_STATUS_FREE;
         do_btree_elem_free(elem);
     }
 
@@ -1704,13 +1696,12 @@ static void do_btree_elem_replace(btree_meta_info *info,
     CLOG_BTREE_ELEM_INSERT(info, old_elem, new_elem);
 
     if (old_elem->refcount > 0) {
-        old_elem->status = BTREE_ITEM_STATUS_UNLINK;
+        old_elem->status = ELEM_STATUS_UNLINKED;
     } else  {
-        old_elem->status = BTREE_ITEM_STATUS_FREE;
         do_btree_elem_free(old_elem);
     }
 
-    new_elem->status = BTREE_ITEM_STATUS_USED;
+    new_elem->status = ELEM_STATUS_LINKED;
     posi->node->item[posi->indx] = new_elem;
 
     if (new_stotal != old_stotal) { /* apply memory space */
@@ -1851,9 +1842,8 @@ static int do_btree_elem_delete_fast(btree_meta_info *info,
             for (i = 0; i < node->used_count; i++) {
                 elem = (btree_elem_item *)node->item[i];
                 if (elem->refcount > 0) {
-                    elem->status = BTREE_ITEM_STATUS_UNLINK;
+                    elem->status = ELEM_STATUS_UNLINKED;
                 } else {
-                    elem->status = BTREE_ITEM_STATUS_FREE;
                     do_btree_elem_free(elem);
                 }
             }
@@ -1946,9 +1936,8 @@ static uint32_t do_btree_elem_delete(btree_meta_info *info,
 
                     CLOG_BTREE_ELEM_DELETE(info, elem, cause);
                     if (elem->refcount > 0) {
-                        elem->status = BTREE_ITEM_STATUS_UNLINK;
+                        elem->status = ELEM_STATUS_UNLINKED;
                     } else {
-                        elem->status = BTREE_ITEM_STATUS_FREE;
                         do_btree_elem_free(elem);
                     }
                     c_posi.node->item[c_posi.indx] = NULL;
@@ -2245,7 +2234,7 @@ static ENGINE_ERROR_CODE do_btree_elem_link(btree_meta_info *info, btree_elem_it
         CLOG_BTREE_ELEM_INSERT(info, NULL, elem);
 
         /* insert the element into the leaf page */
-        elem->status = BTREE_ITEM_STATUS_USED;
+        elem->status = ELEM_STATUS_LINKED;
         if (path[0].indx < path[0].node->used_count) {
             for (int i = (path[0].node->used_count-1); i >= path[0].indx; i--) {
                 path[0].node->item[i+1] = path[0].node->item[i];
@@ -2395,7 +2384,7 @@ static uint32_t do_btree_elem_get(btree_meta_info *info,
                     elem_array[tot_found+cur_found] = elem;
                     if (delete) {
                         tot_space += slabs_space_size(do_btree_elem_ntotal(elem));
-                        elem->status = BTREE_ITEM_STATUS_UNLINK;
+                        elem->status = ELEM_STATUS_UNLINKED;
                         c_posi.node->item[c_posi.indx] = NULL;
                         CLOG_BTREE_ELEM_DELETE(info, elem, ELEM_DELETE_NORMAL);
                     }
@@ -3692,8 +3681,7 @@ btree_elem_item *btree_elem_alloc(const uint32_t nbkey, const uint32_t neflag, c
 void btree_elem_free(btree_elem_item *elem)
 {
     LOCK_CACHE();
-    assert(elem->status == BTREE_ITEM_STATUS_UNLINK);
-    elem->status = BTREE_ITEM_STATUS_FREE;
+    assert(elem->status == ELEM_STATUS_UNLINKED);
     do_btree_elem_free(elem);
     UNLOCK_CACHE();
 }

--- a/engines/default/coll_list.c
+++ b/engines/default/coll_list.c
@@ -132,7 +132,7 @@ static list_elem_item *do_list_elem_alloc(const uint32_t nbytes, const void *coo
 
         elem->refcount    = 0;
         elem->nbytes      = nbytes;
-        elem->prev = elem->next = (list_elem_item *)ADDR_MEANS_UNLINKED; /* Unliked state */
+        elem->status = ELEM_STATUS_UNLINKED; /* unlinked state */
     }
     return elem;
 }
@@ -150,7 +150,7 @@ static void do_list_elem_release(list_elem_item *elem)
     if (elem->refcount != 0) {
         elem->refcount--;
     }
-    if (elem->refcount == 0 && elem->next == (list_elem_item *)ADDR_MEANS_UNLINKED) {
+    if (elem->refcount == 0 && elem->status == ELEM_STATUS_UNLINKED) {
         do_list_elem_free(elem);
     }
 }
@@ -198,6 +198,7 @@ static ENGINE_ERROR_CODE do_list_elem_link(list_meta_info *info, const int index
     else              prev->next = elem;
     if (next == NULL) info->tail = elem;
     else              next->prev = elem;
+    elem->status = ELEM_STATUS_LINKED;
     info->ccnt++;
 
     if (1) { /* apply memory space */
@@ -210,23 +211,20 @@ static ENGINE_ERROR_CODE do_list_elem_link(list_meta_info *info, const int index
 static void do_list_elem_unlink(list_meta_info *info, list_elem_item *elem,
                                 enum elem_delete_cause cause)
 {
-    /* if (elem->next != (list_elem_item *)ADDR_MEANS_UNLINKED) */
-    {
-        if (elem->prev == NULL) info->head = elem->next;
-        else                    elem->prev->next = elem->next;
-        if (elem->next == NULL) info->tail = elem->prev;
-        else                    elem->next->prev = elem->prev;
-        elem->prev = elem->next = (list_elem_item *)ADDR_MEANS_UNLINKED;
-        info->ccnt--;
+    if (elem->prev == NULL) info->head = elem->next;
+    else                    elem->prev->next = elem->next;
+    if (elem->next == NULL) info->tail = elem->prev;
+    else                    elem->next->prev = elem->prev;
+    elem->status = ELEM_STATUS_UNLINKED;
+    info->ccnt--;
 
-        if (info->stotal > 0) { /* apply memory space */
-            size_t stotal = slabs_space_size(do_list_elem_ntotal(elem));
-            do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_LIST, stotal);
-        }
+    if (info->stotal > 0) { /* apply memory space */
+        size_t stotal = slabs_space_size(do_list_elem_ntotal(elem));
+        do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_LIST, stotal);
+    }
 
-        if (elem->refcount == 0) {
-            do_list_elem_free(elem);
-        }
+    if (elem->refcount == 0) {
+        do_list_elem_free(elem);
     }
 }
 
@@ -390,7 +388,7 @@ list_elem_item *list_elem_alloc(const uint32_t nbytes, const void *cookie)
 void list_elem_free(list_elem_item *elem)
 {
     LOCK_CACHE();
-    assert(elem->next == (list_elem_item *)ADDR_MEANS_UNLINKED);
+    assert(elem->status == ELEM_STATUS_UNLINKED);
     do_list_elem_free(elem);
     UNLOCK_CACHE();
 }

--- a/engines/default/coll_map.c
+++ b/engines/default/coll_map.c
@@ -177,7 +177,7 @@ static map_elem_item *do_map_elem_alloc(const int nfield,
         elem->refcount    = 0;
         elem->nfield      = (uint8_t)nfield;
         elem->nbytes      = (uint16_t)nbytes;
-        elem->next = (map_elem_item *)ADDR_MEANS_UNLINKED; /* Unliked state */
+        elem->status = ELEM_STATUS_UNLINKED; /* unlinked state */
     }
     return elem;
 }
@@ -195,7 +195,7 @@ static void do_map_elem_release(map_elem_item *elem)
     if (elem->refcount != 0) {
         elem->refcount--;
     }
-    if (elem->refcount == 0 && elem->next == (map_elem_item *)ADDR_MEANS_UNLINKED) {
+    if (elem->refcount == 0 && elem->status == ELEM_STATUS_UNLINKED) {
         do_map_elem_free(elem);
     }
 }
@@ -313,8 +313,9 @@ static void do_map_elem_replace(map_meta_info *info,
     } else {
         pinfo->node->htab[pinfo->hidx] = new_elem;
     }
+    new_elem->status = ELEM_STATUS_LINKED;
 
-    old_elem->next = (map_elem_item *)ADDR_MEANS_UNLINKED;
+    old_elem->status = ELEM_STATUS_UNLINKED;
     if (old_elem->refcount == 0) {
         do_map_elem_free(old_elem);
     }
@@ -413,6 +414,7 @@ static ENGINE_ERROR_CODE do_map_elem_link(map_meta_info *info, map_elem_item *el
     node->htab[hidx] = elem;
     node->hcnt[hidx] += 1;
     node->cur_elem_cnt += 1;
+    elem->status = ELEM_STATUS_LINKED;
 
     info->ccnt++;
 
@@ -431,7 +433,7 @@ static void do_map_elem_unlink(map_meta_info *info,
 {
     if (prev != NULL) prev->next = elem->next;
     else              node->htab[hidx] = elem->next;
-    elem->next = (map_elem_item *)ADDR_MEANS_UNLINKED;
+    elem->status = ELEM_STATUS_UNLINKED;
     node->hcnt[hidx] -= 1;
     node->cur_elem_cnt -= 1;
     info->ccnt--;
@@ -748,7 +750,7 @@ map_elem_item *map_elem_alloc(const int nfield, const uint32_t nbytes, const voi
 void map_elem_free(map_elem_item *elem)
 {
     LOCK_CACHE();
-    assert(elem->next == (map_elem_item *)ADDR_MEANS_UNLINKED);
+    assert(elem->status == ELEM_STATUS_UNLINKED);
     do_map_elem_free(elem);
     UNLOCK_CACHE();
 }

--- a/engines/default/coll_set.c
+++ b/engines/default/coll_set.c
@@ -223,7 +223,7 @@ static set_elem_item *do_set_elem_alloc(const uint32_t nbytes, const void *cooki
 
         elem->refcount    = 0;
         elem->nbytes      = nbytes;
-        elem->next = (set_elem_item *)ADDR_MEANS_UNLINKED; /* Unliked state */
+        elem->status = ELEM_STATUS_UNLINKED; /* unlinked state */
     }
     return elem;
 }
@@ -241,7 +241,7 @@ static void do_set_elem_release(set_elem_item *elem)
     if (elem->refcount != 0) {
         elem->refcount--;
     }
-    if (elem->refcount == 0 && elem->next == (set_elem_item *)ADDR_MEANS_UNLINKED) {
+    if (elem->refcount == 0 && elem->status == ELEM_STATUS_UNLINKED) {
         do_set_elem_free(elem);
     }
 }
@@ -367,6 +367,7 @@ static ENGINE_ERROR_CODE do_set_elem_link(set_meta_info *info, set_elem_item *el
     node->htab[hidx] = elem;
     node->hcnt[hidx] += 1;
     node->tot_elem_cnt += 1;
+    elem->status = ELEM_STATUS_LINKED;
 
     set_hash_node *par_node = info->root;
     while (par_node != node) {
@@ -392,7 +393,7 @@ static void do_set_elem_unlink(set_meta_info *info,
 {
     if (prev != NULL) prev->next = elem->next;
     else              node->htab[hidx] = elem->next;
-    elem->next = (set_elem_item *)ADDR_MEANS_UNLINKED;
+    elem->status = ELEM_STATUS_UNLINKED;
     node->hcnt[hidx] -= 1;
     node->tot_elem_cnt -= 1;
     info->ccnt--;
@@ -772,7 +773,7 @@ set_elem_item *set_elem_alloc(const uint32_t nbytes, const void *cookie)
 void set_elem_free(set_elem_item *elem)
 {
     LOCK_CACHE();
-    assert(elem->next == (set_elem_item *)ADDR_MEANS_UNLINKED);
+    assert(elem->status == ELEM_STATUS_UNLINKED);
     do_set_elem_free(elem);
     UNLOCK_CACHE();
 }

--- a/engines/default/item_base.h
+++ b/engines/default/item_base.h
@@ -144,6 +144,10 @@ enum elem_delete_cause {
 /* special address for representing unlinked status */
 #define ADDR_MEANS_UNLINKED  1
 
+/* collection element lifecycle status */
+#define ELEM_STATUS_LINKED   1
+#define ELEM_STATUS_UNLINKED 0
+
 /* hash item strtucture */
 typedef struct _hash_item {
     uint16_t refcount;  /* reference count */
@@ -167,7 +171,7 @@ typedef struct _hash_item {
 typedef struct _list_elem_item {
     uint16_t refcount;
     uint8_t  slabs_clsid;         /* which slab class we're in */
-    uint32_t dummy;
+    uint8_t  status;              /* element lifecycle state: linked(in-list) or unlinked(removed but referenced) */
     struct _list_elem_item *next; /* next chain in double linked list */
     struct _list_elem_item *prev; /* prev chain in double linked list */
     uint32_t nbytes;              /**< The total size of the data (in bytes) */
@@ -178,6 +182,7 @@ typedef struct _list_elem_item {
 typedef struct _set_elem_item {
     uint16_t refcount;
     uint8_t  slabs_clsid;         /* which slab class we're in */
+    uint8_t  status;              /* element lifecycle state: linked(in-set) or unlinked(removed but referenced) */
     uint32_t hval;                /* hash value */
     struct _set_elem_item *next;  /* hash chain next */
     uint32_t nbytes;              /**< The total size of the data (in bytes) */
@@ -188,6 +193,7 @@ typedef struct _set_elem_item {
 typedef struct _map_elem_item {
     uint16_t refcount;
     uint8_t  slabs_clsid;         /* which slab class we're in */
+    uint8_t  status;              /* element lifecycle state: linked(in-map) or unlinked(removed but referenced) */
     uint32_t hval;                /* hash value */
     struct _map_elem_item *next;  /* hash chain next */
     uint8_t nfield;               /**< The total size of the field (in bytes) */
@@ -199,7 +205,7 @@ typedef struct _map_elem_item {
 typedef struct _btree_elem_item {
     uint16_t refcount;
     uint8_t  slabs_clsid;        /* which slab class we're in */
-    uint8_t  status;             /* element lifecycle state: used(in-tree), unlinked(removed but referenced), or free */
+    uint8_t  status;             /* element lifecycle state: linked(in-tree) or unlinked(removed but referenced) */
     uint8_t  nbkey;              /* length of bkey */
     uint8_t  neflag;             /* length of element flag */
     uint16_t nbytes;             /**< The total size of the data (in bytes) */


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/840

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- list/set/map elem 구조체에 `status` 필드를 추가하고, `next` 포인터에 `ADDR_MEANS_UNLINKED = 1`을 저장하여 unlink 상태를 나타내던 센티넬 포인터 패턴을 제거했습니다.
- btree에서만 사용하던 `BTREE_ITEM_STATUS_USED/UNLINK/FREE` define을 `ELEM_STATUS_USED/UNLINK/FREE`로 이름을 바꿔 `item_base.h`로 이동하여 4개의 컬렉션이 동일하게 사용하도록 했습니다.
- `list_elem_item`의 경우 기존에 패딩용 `dummy` 필드가 명시적으로 정의되어 있었습니다. 때문에 새로 `status` 필드를 추가하는 것이 아닌, `dummy` 필드를 `status`로 교체하여 구조체 크기 변화 없이 필드를 추가했습니다.
- btree의 기존 `BTREE_ITEM_STATUS_*` 사용 코드는 공용 `ELEM_STATUS_*`를 사용하도록 교체했으며, 동작 변화는 없습니다.