### PR TITLE
INTERNAL: Unify elem_item struct layout across collection types

### DIFF
--- a/engines/default/coll_list.c
+++ b/engines/default/coll_list.c
@@ -131,7 +131,7 @@ static list_elem_item *do_list_elem_alloc(const uint32_t nbytes, const void *coo
         assert(elem->slabs_clsid > 0);
 
         elem->refcount    = 0;
-        elem->nbytes      = nbytes;
+        elem->nbytes      = (uint16_t)nbytes;
         elem->status = ELEM_STATUS_UNLINKED; /* unlinked state */
     }
     return elem;

--- a/engines/default/coll_set.c
+++ b/engines/default/coll_set.c
@@ -222,7 +222,7 @@ static set_elem_item *do_set_elem_alloc(const uint32_t nbytes, const void *cooki
         assert(elem->slabs_clsid > 0);
 
         elem->refcount    = 0;
-        elem->nbytes      = nbytes;
+        elem->nbytes      = (uint16_t)nbytes;
         elem->status = ELEM_STATUS_UNLINKED; /* unlinked state */
     }
     return elem;

--- a/engines/default/item_base.h
+++ b/engines/default/item_base.h
@@ -172,9 +172,10 @@ typedef struct _list_elem_item {
     uint16_t refcount;
     uint8_t  slabs_clsid;         /* which slab class we're in */
     uint8_t  status;              /* element lifecycle state: linked(in-list) or unlinked(removed but referenced) */
+    uint16_t reserved;            /* reserved space */
+    uint16_t nbytes;              /**< The total size of the data (in bytes) */
     struct _list_elem_item *next; /* next chain in double linked list */
     struct _list_elem_item *prev; /* prev chain in double linked list */
-    uint32_t nbytes;              /**< The total size of the data (in bytes) */
     char     value[];             /**< the data itself */
 } list_elem_item;
 
@@ -183,9 +184,10 @@ typedef struct _set_elem_item {
     uint16_t refcount;
     uint8_t  slabs_clsid;         /* which slab class we're in */
     uint8_t  status;              /* element lifecycle state: linked(in-set) or unlinked(removed but referenced) */
-    uint32_t hval;                /* hash value */
+    uint16_t reserved;            /* reserved space */
+    uint16_t nbytes;              /**< The total size of the data (in bytes) */
     struct _set_elem_item *next;  /* hash chain next */
-    uint32_t nbytes;              /**< The total size of the data (in bytes) */
+    uint32_t hval;                /* hash value */
     char     value[];             /**< the data itself */
 } set_elem_item;
 
@@ -194,10 +196,11 @@ typedef struct _map_elem_item {
     uint16_t refcount;
     uint8_t  slabs_clsid;         /* which slab class we're in */
     uint8_t  status;              /* element lifecycle state: linked(in-map) or unlinked(removed but referenced) */
-    uint32_t hval;                /* hash value */
-    struct _map_elem_item *next;  /* hash chain next */
-    uint8_t nfield;               /**< The total size of the field (in bytes) */
+    uint8_t  nfield;              /**< The total size of the field (in bytes) */
+    uint8_t  reserved;            /* reserved space */
     uint16_t nbytes;              /**< The total size of the data (in bytes) */
+    struct _map_elem_item *next;  /* hash chain next */
+    uint32_t hval;                /* hash value */
     unsigned char data[];         /* data: <field, value> */
 } map_elem_item;
 
@@ -301,14 +304,14 @@ typedef struct _btree_indx_node {
 } btree_indx_node;
 
 typedef struct _btree_meta_info {
-    int32_t  mcnt;      /* maximum count */
-    int32_t  ccnt;      /* current count */
-    uint8_t  ovflact;   /* overflow action */
-    uint8_t  mflags;    /* sticky, readable, trimmed flags */
-    uint16_t itdist;    /* distance from hash item (unit: sizeof(size_t)) */
-    uint32_t stotal;    /* total space */
-    uint8_t  bktype;    /* bkey type : BKEY_TYPE_UINT64 or BKEY_TYPE_BINARY */
-    uint8_t  dummy[7];  /* reserved space */
+    int32_t  mcnt;         /* maximum count */
+    int32_t  ccnt;         /* current count */
+    uint8_t  ovflact;      /* overflow action */
+    uint8_t  mflags;       /* sticky, readable, trimmed flags */
+    uint16_t itdist;       /* distance from hash item (unit: sizeof(size_t)) */
+    uint32_t stotal;       /* total space */
+    uint8_t  bktype;       /* bkey type : BKEY_TYPE_UINT64 or BKEY_TYPE_BINARY */
+    uint8_t  reserved[7];  /* reserved space */
     bkey_t   maxbkeyrange;
     btree_indx_node *root;
 } btree_meta_info;


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/844#issuecomment-4278095307

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- hash tree 공통 모듈 추출 전 collection elem_item 레이아웃 통일을 먼저 진행하였습니다.
- btree, map에서 `uint16_t`로 사용하던 `nbytes`를 list, set에도 동일하게 적용하여 모든 elem_item의 `nbytes` 타입을 `uint16_t`로 통일하였습니다.
- 암묵적 패딩 자리를 `reserved` 필드로 명시적으로 표현하였습니다.
- elem_item의 필드 순서를 공통 필드(refcount, slabs_clsid, status) → 길이 필드(nbytes, nfield 등) → 포인터/해시 필드(next, hval) 순서로 통일하였습니다.
- 작업 중 `char value[]`와 `unsigned char data[]` 선언 방식의 차이를 확인하였습니다.
  - list, set은 값 자체를 저장하는 용도로 대소 비교가 필요 없어 `char value[]`로 선언하였으며,
  - map, btree는 내부에서 field/bkey 비교가 필요하기 때문에 sign extension을 피하기 위해 `unsigned char data[]`로 선언하고 변수명도 `data`로 구분하고 있었습니다.  
  - 이후 구현하는 element들도 경우에 맞게 선언하면 될 것 같습니다.