### PR TITLE
INTERNAL: Clarify elem_item comments in item_base.h

### DIFF
--- a/engines/default/item_base.h
+++ b/engines/default/item_base.h
@@ -160,8 +160,8 @@ typedef struct _hash_item {
     rel_time_t time;    /* least recent access */
     rel_time_t exptime; /* When the item will expire (relative to process startup) */
     uint8_t  iflag;     /* Internal flags: item type and flag */
-    uint16_t nkey;      /* The total length of the key (in bytes) */
-    uint32_t nbytes;    /* The total length of the data (in bytes) */
+    uint16_t nkey;      /* The total length of the key */
+    uint32_t nbytes;    /* The total length of the data */
     /* Following fields are used to trade off memory space for performance */
     uint32_t khash;     /* The hash value of key string */
     void    *pfxptr;    /* pointer to prefix structure */
@@ -173,10 +173,10 @@ typedef struct _list_elem_item {
     uint8_t  slabs_clsid;         /* which slab class we're in */
     uint8_t  status;              /* element lifecycle state: linked(in-list) or unlinked(removed but referenced) */
     uint16_t reserved;            /* reserved space */
-    uint16_t nbytes;              /**< The total size of the data (in bytes) */
+    uint16_t nbytes;              /* the size of the value */
     struct _list_elem_item *next; /* next chain in double linked list */
     struct _list_elem_item *prev; /* prev chain in double linked list */
-    char     value[];             /**< the data itself */
+    char     value[];             /* the data itself */
 } list_elem_item;
 
 /* set element */
@@ -185,10 +185,10 @@ typedef struct _set_elem_item {
     uint8_t  slabs_clsid;         /* which slab class we're in */
     uint8_t  status;              /* element lifecycle state: linked(in-set) or unlinked(removed but referenced) */
     uint16_t reserved;            /* reserved space */
-    uint16_t nbytes;              /**< The total size of the data (in bytes) */
+    uint16_t nbytes;              /* the size of the value */
     struct _set_elem_item *next;  /* hash chain next */
     uint32_t hval;                /* hash value */
-    char     value[];             /**< the data itself */
+    char     value[];             /* the data itself */
 } set_elem_item;
 
 /* map element */
@@ -196,9 +196,9 @@ typedef struct _map_elem_item {
     uint16_t refcount;
     uint8_t  slabs_clsid;         /* which slab class we're in */
     uint8_t  status;              /* element lifecycle state: linked(in-map) or unlinked(removed but referenced) */
-    uint8_t  nfield;              /**< The total size of the field (in bytes) */
+    uint8_t  nfield;              /* the size of the field */
     uint8_t  reserved;            /* reserved space */
-    uint16_t nbytes;              /**< The total size of the data (in bytes) */
+    uint16_t nbytes;              /* the size of the value */
     struct _map_elem_item *next;  /* hash chain next */
     uint32_t hval;                /* hash value */
     unsigned char data[];         /* data: <field, value> */
@@ -209,9 +209,9 @@ typedef struct _btree_elem_item {
     uint16_t refcount;
     uint8_t  slabs_clsid;        /* which slab class we're in */
     uint8_t  status;             /* element lifecycle state: linked(in-tree) or unlinked(removed but referenced) */
-    uint8_t  nbkey;              /* length of bkey */
-    uint8_t  neflag;             /* length of element flag */
-    uint16_t nbytes;             /**< The total size of the data (in bytes) */
+    uint8_t  nbkey;              /* the size of the bkey */
+    uint8_t  neflag;             /* the size of the element flag */
+    uint16_t nbytes;             /* the size of the value */
     unsigned char data[];        /* data: <bkey, [eflag,] value> */
 } btree_elem_item;
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/844#issuecomment-4278095307
### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
`item_base.h`의 `elem_item` 구조체 멤버 주석을 정리:

- `map`, `btree`의 `nbytes` 주석이 "total size of the data"로 되어 있어, `data[]` 전체 크기로 오해할 수 있었습니다.
  - 실제로는 `data[]` 내 value 부분의 크기만을 의미하므로 "size of the value"로 수정했습니다.
  (`map`의 `data[]`는 field+value, `btree`의 `data[]`는 bkey+eflag+value)
- `in data[]`, `(in bytes)` 등 불필요한 중복 표현 제거
- `/**<` Doxygen 스타일 주석을 `/*` 로 통일
