### PR TITLE
INTERNAL: Unify tot_elem_cnt and delete cause handling between map and set

### DIFF
--- a/engines/default/coll_map.c
+++ b/engines/default/coll_map.c
@@ -537,10 +537,10 @@ static int do_map_elem_traverse_dfs_bycnt(map_meta_info *info, map_hash_node *no
 }
 
 static uint32_t do_map_elem_delete_with_field(map_meta_info *info, const int numfields,
-                                              const field_t *flist, enum elem_delete_cause cause)
+                                              const field_t *flist)
 {
-    assert(cause == ELEM_DELETE_NORMAL);
     uint32_t delcnt = 0;
+    enum elem_delete_cause cause = ELEM_DELETE_NORMAL;
 
     if (info->root != NULL) {
         CLOG_ELEM_DELETE_BEGIN((coll_meta_info*)info, numfields, cause);
@@ -640,13 +640,11 @@ static ENGINE_ERROR_CODE do_map_elem_update(map_meta_info *info,
     return ENGINE_SUCCESS;
 }
 
-static uint32_t do_map_elem_delete(map_meta_info *info, const uint32_t count,
-                                   enum elem_delete_cause cause)
+static uint32_t do_map_elem_delete(map_meta_info *info, const uint32_t count)
 {
-    assert(cause == ELEM_DELETE_COLL);
     uint32_t fcnt = 0;
     if (info->root != NULL) {
-        fcnt = do_map_elem_traverse_dfs_bycnt(info, info->root, count, true, NULL, cause);
+        fcnt = do_map_elem_traverse_dfs_bycnt(info, info->root, count, true, NULL, ELEM_DELETE_COLL);
         if (info->root->tot_elem_cnt == 0) {
             do_map_node_unlink(info, NULL, 0);
         }
@@ -660,13 +658,14 @@ static uint32_t do_map_elem_get(map_meta_info *info,
 {
     assert(info->root);
     uint32_t fcnt = 0;
+    enum elem_delete_cause cause = ELEM_DELETE_NORMAL;
 
     if (delete) {
-        CLOG_ELEM_DELETE_BEGIN((coll_meta_info*)info, numfields, ELEM_DELETE_NORMAL);
+        CLOG_ELEM_DELETE_BEGIN((coll_meta_info*)info, numfields, cause);
     }
     if (numfields == 0) {
         fcnt = do_map_elem_traverse_dfs_bycnt(info, info->root, 0, delete,
-                                              elem_array, ELEM_DELETE_NORMAL);
+                                              elem_array, cause);
     } else {
         for (int ii = 0; ii < numfields; ii++) {
             int hval = genhash_string_hash(flist[ii].value, flist[ii].length);
@@ -680,7 +679,7 @@ static uint32_t do_map_elem_get(map_meta_info *info,
         do_map_node_unlink(info, NULL, 0);
     }
     if (delete) {
-        CLOG_ELEM_DELETE_END((coll_meta_info*)info, ELEM_DELETE_NORMAL);
+        CLOG_ELEM_DELETE_END((coll_meta_info*)info, cause);
     }
     return fcnt;
 }
@@ -854,7 +853,7 @@ ENGINE_ERROR_CODE map_elem_delete(const char *key, const uint32_t nkey,
     ret = do_map_item_find(key, nkey, DONT_UPDATE, &it);
     if (ret == ENGINE_SUCCESS) { /* it != NULL */
         map_meta_info *info = (map_meta_info *)item_get_meta(it);
-        *del_count = do_map_elem_delete_with_field(info, numfields, flist, ELEM_DELETE_NORMAL);
+        *del_count = do_map_elem_delete_with_field(info, numfields, flist);
         if (*del_count > 0) {
             if (info->ccnt == 0 && drop_if_empty) {
                 assert(info->root == NULL);
@@ -933,7 +932,7 @@ ENGINE_ERROR_CODE map_elem_get(const char *key, const uint32_t nkey,
 
 uint32_t map_elem_delete_with_count(map_meta_info *info, const uint32_t count)
 {
-    return do_map_elem_delete(info, count, ELEM_DELETE_COLL);
+    return do_map_elem_delete(info, count);
 }
 
 /* See do_map_elem_traverse_dfs and do_map_elem_link. do_map_elem_traverse_dfs
@@ -1186,7 +1185,7 @@ ENGINE_ERROR_CODE map_apply_elem_delete(void *engine, hash_item *it,
             ret = ENGINE_ELEM_ENOENT; break;
         }
 
-        ndeleted = do_map_elem_delete_with_field(info, 1, &flist, ELEM_DELETE_NORMAL);
+        ndeleted = do_map_elem_delete_with_field(info, 1, &flist);
         if (ndeleted == 0) {
             logger->log(EXTENSION_LOG_INFO, NULL, "map_apply_elem_delete failed."
                         " no element deleted. key=%.*s nkey=%u field=%.*s nfield=%u\n",

--- a/engines/default/coll_map.c
+++ b/engines/default/coll_map.c
@@ -76,6 +76,15 @@ static inline uint32_t do_map_elem_ntotal(map_elem_item *elem)
     return sizeof(map_elem_item) + elem->nfield + elem->nbytes;
 }
 
+static inline bool is_leaf_node(map_hash_node *node)
+{
+    for (int hidx = 0; hidx < MAP_HASHTAB_SIZE; hidx++) {
+        if (node->hcnt[hidx] == -1)
+            return false;
+    }
+    return true;
+}
+
 static ENGINE_ERROR_CODE do_map_item_find(const void *key, const uint32_t nkey,
                                           bool do_update, hash_item **item)
 {
@@ -151,8 +160,7 @@ static map_hash_node *do_map_node_alloc(uint8_t hash_depth, const void *cookie)
 
         node->refcount    = 0;
         node->hdepth      = hash_depth;
-        node->cur_hash_cnt = 0;
-        node->cur_elem_cnt = 0;
+        node->tot_elem_cnt = 0;
         memset(node->hcnt, 0, MAP_HASHTAB_SIZE*sizeof(uint16_t));
         memset(node->htab, 0, MAP_HASHTAB_SIZE*sizeof(void*));
     }
@@ -208,9 +216,6 @@ static void do_map_node_link(map_meta_info *info,
         info->root = node;
     } else {
         map_elem_item *elem;
-        int num_elems = par_node->hcnt[par_hidx];
-        int num_found =0;
-
         while (par_node->htab[par_hidx] != NULL) {
             elem = par_node->htab[par_hidx];
             par_node->htab[par_hidx] = elem->next;
@@ -219,15 +224,11 @@ static void do_map_node_link(map_meta_info *info,
             elem->next = node->htab[hidx];
             node->htab[hidx] = elem;
             node->hcnt[hidx] += 1;
-            num_found ++;
+            node->tot_elem_cnt += 1;
         }
-        assert(num_found  == num_elems);
-        node->cur_elem_cnt = num_found ;
-
+        assert(node->tot_elem_cnt == par_node->hcnt[par_hidx]);
         par_node->htab[par_hidx] = node;
         par_node->hcnt[par_hidx] = -1; /* child hash node */
-        par_node->cur_elem_cnt -= num_found ;
-        par_node->cur_hash_cnt += 1;
     }
 
     if (1) { /* apply memory space */
@@ -244,8 +245,7 @@ static void do_map_node_unlink(map_meta_info *info,
     if (par_node == NULL) {
         node = info->root;
         info->root = NULL;
-        assert(node->cur_hash_cnt == 0);
-        assert(node->cur_elem_cnt == 0);
+        assert(node->tot_elem_cnt == 0);
     } else {
         assert(par_node->hcnt[par_hidx] == -1); /* child hash node */
         map_elem_item *head = NULL;
@@ -253,7 +253,6 @@ static void do_map_node_unlink(map_meta_info *info,
         int hidx, fcnt = 0;
 
         node = (map_hash_node *)par_node->htab[par_hidx];
-        assert(node->cur_hash_cnt == 0);
 
         for (hidx = 0; hidx < MAP_HASHTAB_SIZE; hidx++) {
             assert(node->hcnt[hidx] >= 0);
@@ -270,13 +269,11 @@ static void do_map_node_unlink(map_meta_info *info,
                 assert(node->hcnt[hidx] == 0);
             }
         }
-        assert(fcnt == node->cur_elem_cnt);
-        node->cur_elem_cnt = 0;
+        assert(fcnt == node->tot_elem_cnt);
+        node->tot_elem_cnt = 0;
 
         par_node->htab[par_hidx] = head;
         par_node->hcnt[par_hidx] = fcnt;
-        par_node->cur_elem_cnt += fcnt;
-        par_node->cur_hash_cnt -= 1;
     }
 
     if (info->stotal > 0) { /* apply memory space */
@@ -413,9 +410,16 @@ static ENGINE_ERROR_CODE do_map_elem_link(map_meta_info *info, map_elem_item *el
     elem->next = node->htab[hidx];
     node->htab[hidx] = elem;
     node->hcnt[hidx] += 1;
-    node->cur_elem_cnt += 1;
+    node->tot_elem_cnt += 1;
     elem->status = ELEM_STATUS_LINKED;
 
+    map_hash_node *par_node = info->root;
+    while (par_node != node) {
+        par_node->tot_elem_cnt += 1;
+        hidx = MAP_GET_HASHIDX(elem->hval, par_node->hdepth);
+        assert(par_node->hcnt[hidx] == -1);
+        par_node = par_node->htab[hidx];
+    }
     info->ccnt++;
 
     if (1) { /* apply memory space */
@@ -435,7 +439,7 @@ static void do_map_elem_unlink(map_meta_info *info,
     else              node->htab[hidx] = elem->next;
     elem->status = ELEM_STATUS_UNLINKED;
     node->hcnt[hidx] -= 1;
-    node->cur_elem_cnt -= 1;
+    node->tot_elem_cnt -= 1;
     info->ccnt--;
 
     CLOG_MAP_ELEM_DELETE(info, elem, cause);
@@ -461,10 +465,11 @@ static bool do_map_elem_traverse_dfs_byfield(map_meta_info *info, map_hash_node 
         map_hash_node *child_node = node->htab[hidx];
         ret = do_map_elem_traverse_dfs_byfield(info, child_node, hval, field, delete, elem_array);
         if (ret && delete) {
-            if (child_node->cur_hash_cnt == 0 &&
-                child_node->cur_elem_cnt < (MAP_MAX_HASHCHAIN_SIZE/2)) {
+            if (child_node->tot_elem_cnt < (MAP_MAX_HASHCHAIN_SIZE/2)
+                && is_leaf_node(child_node)) {
                 do_map_node_unlink(info, node, hidx);
             }
+            node->tot_elem_cnt -= 1;
         }
     } else {
         ret = false;
@@ -503,13 +508,15 @@ static int do_map_elem_traverse_dfs_bycnt(map_meta_info *info, map_hash_node *no
         if (node->hcnt[hidx] == -1) {
             map_hash_node *child_node = (map_hash_node *)node->htab[hidx];
             int rcnt = (count > 0 ? (count - fcnt) : 0);
-            fcnt += do_map_elem_traverse_dfs_bycnt(info, child_node, rcnt, delete,
-                                                  (elem_array==NULL ? NULL : &elem_array[fcnt]), cause);
+            int ecnt = do_map_elem_traverse_dfs_bycnt(info, child_node, rcnt, delete,
+                                                      (elem_array==NULL ? NULL : &elem_array[fcnt]), cause);
+            fcnt += ecnt;
             if (delete) {
-                if (child_node->cur_hash_cnt == 0 &&
-                    child_node->cur_elem_cnt < (MAP_MAX_HASHCHAIN_SIZE/2)) {
+                if (child_node->tot_elem_cnt < (MAP_MAX_HASHCHAIN_SIZE/2)
+                    && is_leaf_node(child_node)) {
                     do_map_node_unlink(info, node, hidx);
                 }
+                node->tot_elem_cnt -= ecnt;
             }
         } else if (node->hcnt[hidx] > 0) {
             map_elem_item *elem = node->htab[hidx];
@@ -547,7 +554,7 @@ static uint32_t do_map_elem_delete_with_field(map_meta_info *info, const int num
                 }
             }
         }
-        if (info->root->cur_hash_cnt == 0 && info->root->cur_elem_cnt == 0) {
+        if (info->root->tot_elem_cnt == 0) {
             do_map_node_unlink(info, NULL, 0);
         }
         CLOG_ELEM_DELETE_END((coll_meta_info*)info, cause);
@@ -640,7 +647,7 @@ static uint32_t do_map_elem_delete(map_meta_info *info, const uint32_t count,
     uint32_t fcnt = 0;
     if (info->root != NULL) {
         fcnt = do_map_elem_traverse_dfs_bycnt(info, info->root, count, true, NULL, cause);
-        if (info->root->cur_hash_cnt == 0 && info->root->cur_elem_cnt == 0) {
+        if (info->root->tot_elem_cnt == 0) {
             do_map_node_unlink(info, NULL, 0);
         }
     }
@@ -669,7 +676,7 @@ static uint32_t do_map_elem_get(map_meta_info *info,
             }
         }
     }
-    if (delete && info->root->cur_hash_cnt == 0 && info->root->cur_elem_cnt == 0) {
+    if (delete && info->root->tot_elem_cnt == 0) {
         do_map_node_unlink(info, NULL, 0);
     }
     if (delete) {

--- a/engines/default/coll_map.c
+++ b/engines/default/coll_map.c
@@ -76,15 +76,6 @@ static inline uint32_t do_map_elem_ntotal(map_elem_item *elem)
     return sizeof(map_elem_item) + elem->nfield + elem->nbytes;
 }
 
-static inline bool is_leaf_node(map_hash_node *node)
-{
-    for (int hidx = 0; hidx < MAP_HASHTAB_SIZE; hidx++) {
-        if (node->hcnt[hidx] == -1)
-            return false;
-    }
-    return true;
-}
-
 static ENGINE_ERROR_CODE do_map_item_find(const void *key, const uint32_t nkey,
                                           bool do_update, hash_item **item)
 {
@@ -253,6 +244,7 @@ static void do_map_node_unlink(map_meta_info *info,
         int hidx, fcnt = 0;
 
         node = (map_hash_node *)par_node->htab[par_hidx];
+        assert(node->tot_elem_cnt < (MAP_MAX_HASHCHAIN_SIZE/2));
 
         for (hidx = 0; hidx < MAP_HASHTAB_SIZE; hidx++) {
             assert(node->hcnt[hidx] >= 0);
@@ -465,8 +457,7 @@ static bool do_map_elem_traverse_dfs_byfield(map_meta_info *info, map_hash_node 
         map_hash_node *child_node = node->htab[hidx];
         ret = do_map_elem_traverse_dfs_byfield(info, child_node, hval, field, delete, elem_array);
         if (ret && delete) {
-            if (child_node->tot_elem_cnt < (MAP_MAX_HASHCHAIN_SIZE/2)
-                && is_leaf_node(child_node)) {
+            if (child_node->tot_elem_cnt < (MAP_MAX_HASHCHAIN_SIZE/2)) {
                 do_map_node_unlink(info, node, hidx);
             }
             node->tot_elem_cnt -= 1;
@@ -512,8 +503,7 @@ static int do_map_elem_traverse_dfs_bycnt(map_meta_info *info, map_hash_node *no
                                                       (elem_array==NULL ? NULL : &elem_array[fcnt]), cause);
             fcnt += ecnt;
             if (delete) {
-                if (child_node->tot_elem_cnt < (MAP_MAX_HASHCHAIN_SIZE/2)
-                    && is_leaf_node(child_node)) {
+                if (child_node->tot_elem_cnt < (MAP_MAX_HASHCHAIN_SIZE/2)) {
                     do_map_node_unlink(info, node, hidx);
                 }
                 node->tot_elem_cnt -= ecnt;

--- a/engines/default/coll_set.c
+++ b/engines/default/coll_set.c
@@ -494,7 +494,7 @@ static ENGINE_ERROR_CODE do_set_elem_delete_with_value(set_meta_info *info,
 
 static int do_set_elem_traverse_dfs(set_meta_info *info, set_hash_node *node,
                                     const uint32_t count, const bool delete,
-                                    set_elem_item **elem_array)
+                                    set_elem_item **elem_array, enum elem_delete_cause cause)
 {
     int hidx;
     int fcnt = 0; /* found count */
@@ -504,7 +504,7 @@ static int do_set_elem_traverse_dfs(set_meta_info *info, set_hash_node *node,
             set_hash_node *child_node = (set_hash_node *)node->htab[hidx];
             int rcnt = (count > 0 ? (count - fcnt) : 0);
             int ecnt = do_set_elem_traverse_dfs(info, child_node, rcnt, delete,
-                                                (elem_array==NULL ? NULL : &elem_array[fcnt]));
+                                                (elem_array==NULL ? NULL : &elem_array[fcnt]), cause);
             fcnt += ecnt;
             if (delete) {
                 if (child_node->tot_elem_cnt < (SET_MAX_HASHCHAIN_SIZE/2)
@@ -521,9 +521,7 @@ static int do_set_elem_traverse_dfs(set_meta_info *info, set_hash_node *node,
                     elem_array[fcnt] = elem;
                 }
                 fcnt++;
-                if (delete) do_set_elem_unlink(info, node, hidx, NULL, elem,
-                                               (elem_array==NULL ? ELEM_DELETE_COLL
-                                                                 : ELEM_DELETE_NORMAL));
+                if (delete) do_set_elem_unlink(info, node, hidx, NULL, elem, cause);
                 if (count > 0 && fcnt >= count) break;
                 elem = (delete ? node->htab[hidx] : elem->next);
             }
@@ -611,7 +609,7 @@ static uint32_t do_set_elem_delete(set_meta_info *info, const uint32_t count,
     assert(cause == ELEM_DELETE_COLL);
     uint32_t fcnt = 0;
     if (info->root != NULL) {
-        fcnt = do_set_elem_traverse_dfs(info, info->root, count, true, NULL);
+        fcnt = do_set_elem_traverse_dfs(info, info->root, count, true, NULL, cause);
         if (info->root->tot_elem_cnt == 0) {
             do_set_node_unlink(info, NULL, 0);
         }
@@ -673,7 +671,7 @@ static uint32_t do_set_elem_get(set_meta_info *info,
         CLOG_ELEM_DELETE_BEGIN((coll_meta_info*)info, count, ELEM_DELETE_NORMAL);
     }
     if (count >= info->ccnt || count == 0) { /* Return all */
-        fcnt = do_set_elem_traverse_dfs(info, info->root, count, delete, elem_array);
+        fcnt = do_set_elem_traverse_dfs(info, info->root, count, delete, elem_array, ELEM_DELETE_NORMAL);
     } else { /* Return some */
         fcnt = do_set_elem_traverse_rand(info, count, delete, elem_array);
     }

--- a/engines/default/coll_set.c
+++ b/engines/default/coll_set.c
@@ -473,10 +473,8 @@ static ENGINE_ERROR_CODE do_set_elem_traverse_delete(set_meta_info *info, set_ha
 }
 
 static ENGINE_ERROR_CODE do_set_elem_delete_with_value(set_meta_info *info,
-                                                       const char *val, const int vlen,
-                                                       enum elem_delete_cause cause)
+                                                       const char *val, const int vlen)
 {
-    assert(cause == ELEM_DELETE_NORMAL);
     ENGINE_ERROR_CODE ret;
     if (info->root != NULL) {
         int hval = genhash_string_hash(val, vlen);
@@ -603,13 +601,11 @@ static set_elem_item *do_set_elem_at_offset(set_meta_info *info, set_hash_node *
     return NULL;
 }
 
-static uint32_t do_set_elem_delete(set_meta_info *info, const uint32_t count,
-                                   enum elem_delete_cause cause)
+static uint32_t do_set_elem_delete(set_meta_info *info, const uint32_t count)
 {
-    assert(cause == ELEM_DELETE_COLL);
     uint32_t fcnt = 0;
     if (info->root != NULL) {
-        fcnt = do_set_elem_traverse_dfs(info, info->root, count, true, NULL, cause);
+        fcnt = do_set_elem_traverse_dfs(info, info->root, count, true, NULL, ELEM_DELETE_COLL);
         if (info->root->tot_elem_cnt == 0) {
             do_set_node_unlink(info, NULL, 0);
         }
@@ -666,12 +662,13 @@ static uint32_t do_set_elem_get(set_meta_info *info,
 {
     assert(info->root);
     uint32_t fcnt;
+    enum elem_delete_cause cause = ELEM_DELETE_NORMAL;
 
     if (delete) {
-        CLOG_ELEM_DELETE_BEGIN((coll_meta_info*)info, count, ELEM_DELETE_NORMAL);
+        CLOG_ELEM_DELETE_BEGIN((coll_meta_info*)info, count, cause);
     }
     if (count >= info->ccnt || count == 0) { /* Return all */
-        fcnt = do_set_elem_traverse_dfs(info, info->root, count, delete, elem_array, ELEM_DELETE_NORMAL);
+        fcnt = do_set_elem_traverse_dfs(info, info->root, count, delete, elem_array, cause);
     } else { /* Return some */
         fcnt = do_set_elem_traverse_rand(info, count, delete, elem_array);
     }
@@ -679,7 +676,7 @@ static uint32_t do_set_elem_get(set_meta_info *info,
         do_set_node_unlink(info, NULL, 0);
     }
     if (delete) {
-        CLOG_ELEM_DELETE_END((coll_meta_info*)info, ELEM_DELETE_NORMAL);
+        CLOG_ELEM_DELETE_END((coll_meta_info*)info, cause);
     }
     return fcnt;
 }
@@ -845,7 +842,7 @@ ENGINE_ERROR_CODE set_elem_delete(const char *key, const uint32_t nkey,
     ret = do_set_item_find(key, nkey, DONT_UPDATE, &it);
     if (ret == ENGINE_SUCCESS) { /* it != NULL */
         set_meta_info *info = (set_meta_info *)item_get_meta(it);
-        ret = do_set_elem_delete_with_value(info, value, nbytes, ELEM_DELETE_NORMAL);
+        ret = do_set_elem_delete_with_value(info, value, nbytes);
         if (ret == ENGINE_SUCCESS) {
             if (info->ccnt == 0 && drop_if_empty) {
                 do_item_unlink(it, ITEM_UNLINK_NORMAL);
@@ -948,7 +945,7 @@ ENGINE_ERROR_CODE set_elem_get(const char *key, const uint32_t nkey,
 
 uint32_t set_elem_delete_with_count(set_meta_info *info, const uint32_t count)
 {
-    return do_set_elem_delete(info, count, ELEM_DELETE_COLL);
+    return do_set_elem_delete(info, count);
 }
 
 /* See do_set_elem_traverse_dfs and do_set_elem_link. do_set_elem_traverse_dfs
@@ -1187,7 +1184,7 @@ ENGINE_ERROR_CODE set_apply_elem_delete(void *engine, hash_item *it,
         }
 
         info = (set_meta_info *)item_get_meta(it);
-        ret = do_set_elem_delete_with_value(info, value, nbytes, ELEM_DELETE_NORMAL);
+        ret = do_set_elem_delete_with_value(info, value, nbytes);
         if (ret == ENGINE_ELEM_ENOENT) {
             logger->log(EXTENSION_LOG_INFO, NULL, "set_apply_elem_delete failed."
                         " no element deleted. key=%.*s nkey=%u\n",

--- a/engines/default/coll_set.c
+++ b/engines/default/coll_set.c
@@ -116,15 +116,6 @@ static inline uint32_t do_set_elem_ntotal(set_elem_item *elem)
     return sizeof(set_elem_item) + elem->nbytes;
 }
 
-static inline bool is_leaf_node(set_hash_node *node)
-{
-    for (int hidx = 0; hidx < SET_HASHTAB_SIZE; hidx++) {
-        if (node->hcnt[hidx] == -1)
-            return false;
-    }
-    return true;
-}
-
 static ENGINE_ERROR_CODE do_set_item_find(const void *key, const uint32_t nkey,
                                           bool do_update, hash_item **item)
 {
@@ -291,6 +282,7 @@ static void do_set_node_unlink(set_meta_info *info,
         int hidx, fcnt = 0;
 
         node = (set_hash_node *)par_node->htab[par_hidx];
+        assert(node->tot_elem_cnt < (SET_MAX_HASHCHAIN_SIZE/2));
 
         for (hidx = 0; hidx < SET_HASHTAB_SIZE; hidx++) {
             assert(node->hcnt[hidx] >= 0);
@@ -446,8 +438,7 @@ static ENGINE_ERROR_CODE do_set_elem_traverse_delete(set_meta_info *info, set_ha
         set_hash_node *child_node = node->htab[hidx];
         ret = do_set_elem_traverse_delete(info, child_node, hval, val, vlen);
         if (ret == ENGINE_SUCCESS) {
-            if (child_node->tot_elem_cnt < (SET_MAX_HASHCHAIN_SIZE/2)
-                && is_leaf_node(child_node)) {
+            if (child_node->tot_elem_cnt < (SET_MAX_HASHCHAIN_SIZE/2)) {
                 do_set_node_unlink(info, node, hidx);
             }
             node->tot_elem_cnt -= 1;
@@ -505,8 +496,7 @@ static int do_set_elem_traverse_dfs(set_meta_info *info, set_hash_node *node,
                                                 (elem_array==NULL ? NULL : &elem_array[fcnt]), cause);
             fcnt += ecnt;
             if (delete) {
-                if (child_node->tot_elem_cnt < (SET_MAX_HASHCHAIN_SIZE/2)
-                    && is_leaf_node(child_node)) {
+                if (child_node->tot_elem_cnt < (SET_MAX_HASHCHAIN_SIZE/2)) {
                     do_set_node_unlink(info, node, hidx);
                 }
                 node->tot_elem_cnt -= ecnt;
@@ -573,8 +563,7 @@ static set_elem_item *do_set_elem_at_offset(set_meta_info *info, set_hash_node *
             }
             set_elem_item *found = do_set_elem_at_offset(info, child_node, offset, delete);
             if (delete) {
-                if (child_node->tot_elem_cnt < (SET_MAX_HASHCHAIN_SIZE/2)
-                    && is_leaf_node(child_node)) {
+                if (child_node->tot_elem_cnt < (SET_MAX_HASHCHAIN_SIZE/2)) {
                     do_set_node_unlink(info, node, hidx);
                 }
                 node->tot_elem_cnt -= 1;

--- a/engines/default/item_base.h
+++ b/engines/default/item_base.h
@@ -260,8 +260,7 @@ typedef struct _map_hash_node {
     uint16_t refcount;
     uint8_t  slabs_clsid;         /* which slab class we're in */
     uint8_t  hdepth;
-    uint16_t cur_elem_cnt;
-    uint16_t cur_hash_cnt;
+    uint32_t tot_elem_cnt;
     int16_t  hcnt[MAP_HASHTAB_SIZE];
     void    *htab[MAP_HASHTAB_SIZE];
 } map_hash_node;


### PR DESCRIPTION
### 🔗 Related Issue

- https://github.com/jam2in/arcus-works/issues/844#issuecomment-4278095307

### ⌨️ What I did

hash tree 모듈 추출 전 set, map의 elem_cnt 관리 방식을 통일했습니다.

- `map_hash_node`는 기존에 `cur_elem_cnt`와 `cur_hash_cnt`를 별도로 관리했으나, set과 동일하게 `tot_elem_cnt` 하나로 통합했습니다.
- 그에 맞춰 관련된 함수 로직도 변경하였습니다. 
- traverse_dfs 함수에서 삭제 원인을 내부에서 추론하던 방식을 map과 동일하게 caller가 `cause`를 명시적으로 전달하도록 변경했습니다.
- 내부 delete 함수에서 항상 고정값으로 사용되던 `cause` 파라미터를 제거했습니다.
