### PR TITLE
INTERNAL: Refactor map/set node link/unlink to split/merge pattern

### DIFF
--- a/engines/default/coll_map.c
+++ b/engines/default/coll_map.c
@@ -199,33 +199,64 @@ static void do_map_elem_release(map_elem_item *elem)
     }
 }
 
-static void do_map_node_link(map_meta_info *info,
-                             map_hash_node *par_node, const int par_hidx,
-                             map_hash_node *node)
+/* Split par_node's chain at par_hidx into a new child node:
+ * allocate child, transfer existing chain into it, and link it as a child. */
+static bool do_map_node_split(map_meta_info *info,
+                              map_hash_node *par_node, const int par_hidx,
+                              const void *cookie)
 {
-    if (par_node == NULL) {
-        info->root = node;
-    } else {
-        map_elem_item *elem;
-        while (par_node->htab[par_hidx] != NULL) {
-            elem = par_node->htab[par_hidx];
-            par_node->htab[par_hidx] = elem->next;
+    map_hash_node *n_node = do_map_node_alloc(par_node->hdepth + 1, cookie);
+    if (n_node == NULL)
+        return false;
 
-            int hidx = MAP_GET_HASHIDX(elem->hval, node->hdepth);
-            elem->next = node->htab[hidx];
-            node->htab[hidx] = elem;
-            node->hcnt[hidx] += 1;
-            node->tot_elem_cnt += 1;
-        }
-        assert(node->tot_elem_cnt == par_node->hcnt[par_hidx]);
-        par_node->htab[par_hidx] = node;
-        par_node->hcnt[par_hidx] = -1; /* child hash node */
+    map_elem_item *elem;
+    while (par_node->htab[par_hidx] != NULL) {
+        /* pop from par_node's chain */
+        elem = (map_elem_item *)par_node->htab[par_hidx];
+        par_node->htab[par_hidx] = elem->next;
+
+        /* re-compute hidx at child depth */
+        int hidx = MAP_GET_HASHIDX(elem->hval, n_node->hdepth);
+
+        /* insert into child node's slot */
+        elem->next = n_node->htab[hidx];
+        n_node->htab[hidx] = elem;
+        n_node->hcnt[hidx] += 1;
+        n_node->tot_elem_cnt += 1;
     }
+    assert(n_node->tot_elem_cnt == par_node->hcnt[par_hidx]);
+
+    /* replace the chain slot with the child node */
+    par_node->htab[par_hidx] = n_node;
+    par_node->hcnt[par_hidx] = -1;
 
     if (1) { /* apply memory space */
         size_t stotal = slabs_space_size(sizeof(map_hash_node));
         do_coll_space_incr((coll_meta_info *)info, ITEM_TYPE_MAP, stotal);
     }
+    return true;
+}
+
+/* Split the par_node's chain at hidx into a new child node if it is full,
+ * updating *node_pptr and *hidx_ptr to point to the insertion slot in the child. */
+static bool do_map_node_try_split(map_meta_info *info,
+                                  map_hash_node **node_pptr, int *hidx_ptr,
+                                  const int hval, const void *cookie)
+{
+    map_hash_node *par_node = *node_pptr;
+    int hidx = *hidx_ptr;
+    /* chain not full: no split needed */
+    if (par_node->hcnt[hidx] < MAP_MAX_HASHCHAIN_SIZE)
+        return true;
+
+    /* split: allocate child, transfer chain, and link as child of par_node */
+    if (!do_map_node_split(info, par_node, hidx, cookie))
+        return false;
+
+    /* update *node_pptr and *hidx_ptr so caller inserts into the child node */
+    *node_pptr = (map_hash_node *)par_node->htab[hidx];
+    *hidx_ptr = MAP_GET_HASHIDX(hval, (*node_pptr)->hdepth);
+    return true;
 }
 
 static void do_map_node_unlink(map_meta_info *info,
@@ -385,33 +416,27 @@ static ENGINE_ERROR_CODE do_map_elem_link(map_meta_info *info, map_elem_item *el
         return ENGINE_EOVERFLOW;
     }
 
-    if (node->hcnt[hidx] >= MAP_MAX_HASHCHAIN_SIZE) {
-        map_hash_node *n_node = do_map_node_alloc(node->hdepth+1, cookie);
-        if (n_node == NULL) {
-            res = ENGINE_ENOMEM;
-            return res;
-        }
-        do_map_node_link(info, node, hidx, n_node);
-
-        node = n_node;
-        hidx = MAP_GET_HASHIDX(elem->hval, node->hdepth);
-    }
+    /* split the hash chain into a new child node if it is full */
+    if (!do_map_node_try_split(info, &node, &hidx, elem->hval, cookie))
+        return ENGINE_ENOMEM;
 
     CLOG_MAP_ELEM_INSERT(info, NULL, elem);
 
+    /* prepend elem to the hash chain */
     elem->next = node->htab[hidx];
     node->htab[hidx] = elem;
     node->hcnt[hidx] += 1;
-    node->tot_elem_cnt += 1;
     elem->status = ELEM_STATUS_LINKED;
 
-    map_hash_node *par_node = info->root;
-    while (par_node != node) {
-        par_node->tot_elem_cnt += 1;
-        hidx = MAP_GET_HASHIDX(elem->hval, par_node->hdepth);
-        assert(par_node->hcnt[hidx] == -1);
-        par_node = par_node->htab[hidx];
+    /* increment tot_elem_cnt on every node from root down to node */
+    map_hash_node *cur = info->root;
+    while (cur != node) {
+        cur->tot_elem_cnt += 1;
+        int cidx = MAP_GET_HASHIDX(elem->hval, cur->hdepth);
+        assert(cur->hcnt[cidx] == -1);
+        cur = (map_hash_node *)cur->htab[cidx];
     }
+    cur->tot_elem_cnt += 1;
     info->ccnt++;
 
     if (1) { /* apply memory space */
@@ -688,7 +713,11 @@ static ENGINE_ERROR_CODE do_map_elem_insert(hash_item *it, map_elem_item *elem,
         if (r_node == NULL) {
             return ENGINE_ENOMEM;
         }
-        do_map_node_link(info, NULL, 0, r_node);
+        info->root = r_node;
+        if (1) { /* apply memory space */
+            size_t stotal = slabs_space_size(sizeof(map_hash_node));
+            do_coll_space_incr((coll_meta_info *)info, ITEM_TYPE_MAP, stotal);
+        }
         new_root_flag = true;
     }
 

--- a/engines/default/coll_map.c
+++ b/engines/default/coll_map.c
@@ -259,8 +259,11 @@ static bool do_map_node_try_split(map_meta_info *info,
     return true;
 }
 
-static void do_map_node_unlink(map_meta_info *info,
-                               map_hash_node *par_node, const int par_hidx)
+
+/* Merge node back into par_node at par_hidx:
+ * transfer node's hash chain back into par_node's slot and free node. */
+static void do_map_node_merge(map_meta_info *info,
+                              map_hash_node *par_node, const int par_hidx)
 {
     map_hash_node *node;
 
@@ -268,36 +271,38 @@ static void do_map_node_unlink(map_meta_info *info,
         node = info->root;
         info->root = NULL;
         assert(node->tot_elem_cnt == 0);
-    } else {
-        assert(par_node->hcnt[par_hidx] == -1); /* child hash node */
-        map_elem_item *head = NULL;
-        map_elem_item *elem;
-        int hidx, fcnt = 0;
-
-        node = (map_hash_node *)par_node->htab[par_hidx];
-        assert(node->tot_elem_cnt < (MAP_MAX_HASHCHAIN_SIZE/2));
-
-        for (hidx = 0; hidx < MAP_HASHTAB_SIZE; hidx++) {
-            assert(node->hcnt[hidx] >= 0);
-            if (node->hcnt[hidx] > 0) {
-                fcnt += node->hcnt[hidx];
-                while (node->htab[hidx] != NULL) {
-                    elem = node->htab[hidx];
-                    node->htab[hidx] = elem->next;
-                    node->hcnt[hidx] -= 1;
-
-                    elem->next = head;
-                    head = elem;
-                }
-                assert(node->hcnt[hidx] == 0);
-            }
+        if (info->stotal > 0) { /* apply memory space */
+            size_t stotal = slabs_space_size(sizeof(map_hash_node));
+            do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_MAP, stotal);
         }
-        assert(fcnt == node->tot_elem_cnt);
-        node->tot_elem_cnt = 0;
-
-        par_node->htab[par_hidx] = head;
-        par_node->hcnt[par_hidx] = fcnt;
+        do_map_node_free(node);
+        return;
     }
+    assert(par_node->hcnt[par_hidx] == -1);
+    node = (map_hash_node *)par_node->htab[par_hidx];
+
+    map_elem_item *head = NULL;
+    map_elem_item *elem;
+    int fcnt = 0;
+    for (int hidx = 0; hidx < MAP_HASHTAB_SIZE; hidx++) {
+        assert(node->hcnt[hidx] >= 0);
+        if (node->hcnt[hidx] == 0) continue;
+
+        fcnt += node->hcnt[hidx];
+        while (node->htab[hidx] != NULL) {
+            elem = (map_elem_item *)node->htab[hidx];
+            node->htab[hidx] = elem->next;
+            node->hcnt[hidx] -= 1;
+            elem->next = head;
+            head = elem;
+        }
+        assert(node->hcnt[hidx] == 0);
+    }
+    assert(fcnt == node->tot_elem_cnt);
+    node->tot_elem_cnt = 0;
+
+    par_node->htab[par_hidx] = head;
+    par_node->hcnt[par_hidx] = fcnt;
 
     if (info->stotal > 0) { /* apply memory space */
         size_t stotal = slabs_space_size(sizeof(map_hash_node));
@@ -306,6 +311,19 @@ static void do_map_node_unlink(map_meta_info *info,
 
     /* free the node */
     do_map_node_free(node);
+}
+
+/* Merge child back into par_node if child is empty or too sparse (< MAX/2). */
+static void do_map_node_try_merge(map_meta_info *info,
+                                  map_hash_node *par_node, const int par_hidx,
+                                  map_hash_node *child)
+{
+    if (info->root == NULL) return;
+    if (child->tot_elem_cnt == 0 ||
+        (par_node != NULL &&
+         child->tot_elem_cnt < (MAP_MAX_HASHCHAIN_SIZE/2))) {
+        do_map_node_merge(info, par_node, par_hidx);
+    }
 }
 
 static void do_map_elem_replace(map_meta_info *info,
@@ -454,9 +472,18 @@ static void do_map_elem_unlink(map_meta_info *info,
 {
     if (prev != NULL) prev->next = elem->next;
     else              node->htab[hidx] = elem->next;
-    elem->status = ELEM_STATUS_UNLINKED;
     node->hcnt[hidx] -= 1;
-    node->tot_elem_cnt -= 1;
+    elem->status = ELEM_STATUS_UNLINKED;
+
+    /* decrement tot_elem_cnt on every node from root down to node */
+    map_hash_node *cur = info->root;
+    while (cur != node) {
+        cur->tot_elem_cnt -= 1;
+        int cidx = MAP_GET_HASHIDX(elem->hval, cur->hdepth);
+        assert(cur->hcnt[cidx] == -1);
+        cur = (map_hash_node *)cur->htab[cidx];
+    }
+    cur->tot_elem_cnt -= 1;
     info->ccnt--;
 
     CLOG_MAP_ELEM_DELETE(info, elem, cause);
@@ -482,10 +509,7 @@ static bool do_map_elem_traverse_dfs_byfield(map_meta_info *info, map_hash_node 
         map_hash_node *child_node = node->htab[hidx];
         ret = do_map_elem_traverse_dfs_byfield(info, child_node, hval, field, delete, elem_array);
         if (ret && delete) {
-            if (child_node->tot_elem_cnt < (MAP_MAX_HASHCHAIN_SIZE/2)) {
-                do_map_node_unlink(info, node, hidx);
-            }
-            node->tot_elem_cnt -= 1;
+            do_map_node_try_merge(info, node, hidx, child_node);
         }
     } else {
         ret = false;
@@ -528,10 +552,7 @@ static int do_map_elem_traverse_dfs_bycnt(map_meta_info *info, map_hash_node *no
                                                       (elem_array==NULL ? NULL : &elem_array[fcnt]), cause);
             fcnt += ecnt;
             if (delete) {
-                if (child_node->tot_elem_cnt < (MAP_MAX_HASHCHAIN_SIZE/2)) {
-                    do_map_node_unlink(info, node, hidx);
-                }
-                node->tot_elem_cnt -= ecnt;
+                do_map_node_try_merge(info, node, hidx, child_node);
             }
         } else if (node->hcnt[hidx] > 0) {
             map_elem_item *elem = node->htab[hidx];
@@ -569,9 +590,7 @@ static uint32_t do_map_elem_delete_with_field(map_meta_info *info, const int num
                 }
             }
         }
-        if (info->root->tot_elem_cnt == 0) {
-            do_map_node_unlink(info, NULL, 0);
-        }
+        do_map_node_try_merge(info, NULL, 0, info->root);
         CLOG_ELEM_DELETE_END((coll_meta_info*)info, cause);
     }
     return delcnt;
@@ -660,9 +679,7 @@ static uint32_t do_map_elem_delete(map_meta_info *info, const uint32_t count)
     uint32_t fcnt = 0;
     if (info->root != NULL) {
         fcnt = do_map_elem_traverse_dfs_bycnt(info, info->root, count, true, NULL, ELEM_DELETE_COLL);
-        if (info->root->tot_elem_cnt == 0) {
-            do_map_node_unlink(info, NULL, 0);
-        }
+        do_map_node_try_merge(info, NULL, 0, info->root);
     }
     return fcnt;
 }
@@ -690,10 +707,8 @@ static uint32_t do_map_elem_get(map_meta_info *info,
             }
         }
     }
-    if (delete && info->root->tot_elem_cnt == 0) {
-        do_map_node_unlink(info, NULL, 0);
-    }
     if (delete) {
+        do_map_node_try_merge(info, NULL, 0, info->root);
         CLOG_ELEM_DELETE_END((coll_meta_info*)info, cause);
     }
     return fcnt;
@@ -725,7 +740,13 @@ static ENGINE_ERROR_CODE do_map_elem_insert(hash_item *it, map_elem_item *elem,
     ret = do_map_elem_link(info, elem, replace_if_exist, replaced, cookie);
     if (ret != ENGINE_SUCCESS) {
         if (new_root_flag) {
-            do_map_node_unlink(info, NULL, 0);
+            map_hash_node *node = info->root;
+            info->root = NULL;
+            if (info->stotal > 0) { /* apply memory space */
+                size_t stotal = slabs_space_size(sizeof(map_hash_node));
+                do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_MAP, stotal);
+            }
+            do_map_node_free(node);
         }
         return ret;
     }

--- a/engines/default/coll_set.c
+++ b/engines/default/coll_set.c
@@ -237,33 +237,62 @@ static void do_set_elem_release(set_elem_item *elem)
     }
 }
 
-static void do_set_node_link(set_meta_info *info,
-                             set_hash_node *par_node, const int par_hidx,
-                             set_hash_node *node)
+/* Split par_node's chain at par_hidx into a new child node:
+ * allocate child, transfer existing chain into it, and link it as a child. */
+static bool do_set_node_split(set_meta_info *info,
+                              set_hash_node *par_node, const int par_hidx,
+                              const void *cookie)
 {
-    if (par_node == NULL) {
-        info->root = node;
-    } else {
-        set_elem_item *elem;
-        while (par_node->htab[par_hidx] != NULL) {
-            elem = par_node->htab[par_hidx];
-            par_node->htab[par_hidx] = elem->next;
+    set_hash_node *n_node = do_set_node_alloc(par_node->hdepth + 1, cookie);
+    if (n_node == NULL)
+        return false;
 
-            int hidx = SET_GET_HASHIDX(elem->hval, node->hdepth);
-            elem->next = node->htab[hidx];
-            node->htab[hidx] = elem;
-            node->hcnt[hidx] += 1;
-            node->tot_elem_cnt += 1;
-        }
-        assert(node->tot_elem_cnt == par_node->hcnt[par_hidx]);
-        par_node->htab[par_hidx] = node;
-        par_node->hcnt[par_hidx] = -1; /* child hash node */
+    set_elem_item *elem;
+    while (par_node->htab[par_hidx] != NULL) {
+        /* pop from par_node's chain */
+        elem = (set_elem_item *)par_node->htab[par_hidx];
+        par_node->htab[par_hidx] = elem->next;
+
+        /* re-compute hidx at child depth */
+        int hidx = SET_GET_HASHIDX(elem->hval, n_node->hdepth);
+        
+        /* insert into child node's slot */
+        elem->next = n_node->htab[hidx];
+        n_node->htab[hidx] = elem;
+        n_node->hcnt[hidx] += 1;
+        n_node->tot_elem_cnt += 1;
     }
+    assert(n_node->tot_elem_cnt == par_node->hcnt[par_hidx]);
+
+    /* replace the chain slot with the child node */
+    par_node->htab[par_hidx] = n_node;
+    par_node->hcnt[par_hidx] = -1;
 
     if (1) { /* apply memory space */
         size_t stotal = slabs_space_size(sizeof(set_hash_node));
         do_coll_space_incr((coll_meta_info *)info, ITEM_TYPE_SET, stotal);
     }
+    return true;
+}
+
+/* Split the chain at *hidx_ptr into a child node if full,
+ * updating *node_pptr and *hidx_ptr to the insertion slot. */
+static bool do_set_node_try_split(set_meta_info *info,
+                                  set_hash_node **node_pptr, int *hidx_ptr,
+                                  const int hval, const void *cookie)
+{
+    set_hash_node *par_node = *node_pptr;
+    int hidx = *hidx_ptr;
+    /* chain not full: no split needed */
+    if (par_node->hcnt[hidx] < SET_MAX_HASHCHAIN_SIZE) return true;
+    
+    /* split: allocate child, transfer chain, and link as child of par_node */
+    if (!do_set_node_split(info, par_node, hidx, cookie)) return false;
+    
+    /* update *node_pptr and *hidx_ptr so caller inserts into the child node */
+    *node_pptr = (set_hash_node *)par_node->htab[hidx];
+    *hidx_ptr = SET_GET_HASHIDX(hval, (*node_pptr)->hdepth);
+    return true;
 }
 
 static void do_set_node_unlink(set_meta_info *info,
@@ -344,30 +373,25 @@ static ENGINE_ERROR_CODE do_set_elem_link(set_meta_info *info, set_elem_item *el
         return ENGINE_ELEM_EEXISTS;
     }
 
-    if (node->hcnt[hidx] >= SET_MAX_HASHCHAIN_SIZE) {
-        set_hash_node *n_node = do_set_node_alloc(node->hdepth+1, cookie);
-        if (n_node == NULL) {
-            return ENGINE_ENOMEM;
-        }
-        do_set_node_link(info, node, hidx, n_node);
+    /* split the hash chain into a new child node if it is full */
+    if (!do_set_node_try_split(info, &node, &hidx, elem->hval, cookie))
+        return ENGINE_ENOMEM;
 
-        node = n_node;
-        hidx = SET_GET_HASHIDX(elem->hval, node->hdepth);
-    }
-
+    /* prepend elem to the hash chain */
     elem->next = node->htab[hidx];
     node->htab[hidx] = elem;
     node->hcnt[hidx] += 1;
-    node->tot_elem_cnt += 1;
     elem->status = ELEM_STATUS_LINKED;
 
-    set_hash_node *par_node = info->root;
-    while (par_node != node) {
-        par_node->tot_elem_cnt += 1;
-        hidx = SET_GET_HASHIDX(elem->hval, par_node->hdepth);
-        assert(par_node->hcnt[hidx] == -1);
-        par_node = par_node->htab[hidx];
+    /* increment tot_elem_cnt on every node from root down to node */
+    set_hash_node *cur = info->root;
+    while (cur != node) {
+        cur->tot_elem_cnt += 1;
+        int cidx = SET_GET_HASHIDX(elem->hval, cur->hdepth);
+        assert(cur->hcnt[cidx] == -1);
+        cur = (set_hash_node *)cur->htab[cidx];
     }
+    cur->tot_elem_cnt += 1;
     info->ccnt++;
 
     if (1) { /* apply memory space */
@@ -698,7 +722,11 @@ static ENGINE_ERROR_CODE do_set_elem_insert(hash_item *it, set_elem_item *elem,
         if (r_node == NULL) {
             return ENGINE_ENOMEM;
         }
-        do_set_node_link(info, NULL, 0, r_node);
+        info->root = r_node;
+        if (1) { /* apply memory space */
+            size_t stotal = slabs_space_size(sizeof(set_hash_node));
+            do_coll_space_incr((coll_meta_info *)info, ITEM_TYPE_SET, stotal);
+        }
         new_root_flag = true;
     }
 

--- a/engines/default/coll_set.c
+++ b/engines/default/coll_set.c
@@ -255,7 +255,7 @@ static bool do_set_node_split(set_meta_info *info,
 
         /* re-compute hidx at child depth */
         int hidx = SET_GET_HASHIDX(elem->hval, n_node->hdepth);
-        
+
         /* insert into child node's slot */
         elem->next = n_node->htab[hidx];
         n_node->htab[hidx] = elem;
@@ -285,18 +285,20 @@ static bool do_set_node_try_split(set_meta_info *info,
     int hidx = *hidx_ptr;
     /* chain not full: no split needed */
     if (par_node->hcnt[hidx] < SET_MAX_HASHCHAIN_SIZE) return true;
-    
+
     /* split: allocate child, transfer chain, and link as child of par_node */
     if (!do_set_node_split(info, par_node, hidx, cookie)) return false;
-    
+
     /* update *node_pptr and *hidx_ptr so caller inserts into the child node */
     *node_pptr = (set_hash_node *)par_node->htab[hidx];
     *hidx_ptr = SET_GET_HASHIDX(hval, (*node_pptr)->hdepth);
     return true;
 }
 
-static void do_set_node_unlink(set_meta_info *info,
-                               set_hash_node *par_node, const int par_hidx)
+/* Merge node back into par_node at par_hidx:
+ * transfer node's hash chain back into par_node's slot and free node. */
+static void do_set_node_merge(set_meta_info *info,
+                              set_hash_node *par_node, const int par_hidx)
 {
     set_hash_node *node;
 
@@ -304,36 +306,38 @@ static void do_set_node_unlink(set_meta_info *info,
         node = info->root;
         info->root = NULL;
         assert(node->tot_elem_cnt == 0);
-    } else {
-        assert(par_node->hcnt[par_hidx] == -1); /* child hash node */
-        set_elem_item *head = NULL;
-        set_elem_item *elem;
-        int hidx, fcnt = 0;
-
-        node = (set_hash_node *)par_node->htab[par_hidx];
-        assert(node->tot_elem_cnt < (SET_MAX_HASHCHAIN_SIZE/2));
-
-        for (hidx = 0; hidx < SET_HASHTAB_SIZE; hidx++) {
-            assert(node->hcnt[hidx] >= 0);
-            if (node->hcnt[hidx] > 0) {
-                fcnt += node->hcnt[hidx];
-                while (node->htab[hidx] != NULL) {
-                    elem = node->htab[hidx];
-                    node->htab[hidx] = elem->next;
-                    node->hcnt[hidx] -= 1;
-
-                    elem->next = head;
-                    head = elem;
-                }
-                assert(node->hcnt[hidx] == 0);
-            }
+        if (info->stotal > 0) { /* apply memory space */
+            size_t stotal = slabs_space_size(sizeof(set_hash_node));
+            do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_SET, stotal);
         }
-        assert(fcnt == node->tot_elem_cnt);
-        node->tot_elem_cnt = 0;
-
-        par_node->htab[par_hidx] = head;
-        par_node->hcnt[par_hidx] = fcnt;
+        do_set_node_free(node);
+        return;
     }
+    assert(par_node->hcnt[par_hidx] == -1);
+    node = (set_hash_node *)par_node->htab[par_hidx];
+
+    set_elem_item *head = NULL;
+    set_elem_item *elem;
+    int fcnt = 0;
+    for (int hidx = 0; hidx < SET_HASHTAB_SIZE; hidx++) {
+        assert(node->hcnt[hidx] >= 0);
+        if (node->hcnt[hidx] == 0) continue;
+
+        fcnt += node->hcnt[hidx];
+        while (node->htab[hidx] != NULL) {
+            elem = (set_elem_item *)node->htab[hidx];
+            node->htab[hidx] = elem->next;
+            node->hcnt[hidx] -= 1;
+            elem->next = head;
+            head = elem;
+        }
+        assert(node->hcnt[hidx] == 0);
+    }
+    assert(fcnt == node->tot_elem_cnt);
+    node->tot_elem_cnt = 0;
+
+    par_node->htab[par_hidx] = head;
+    par_node->hcnt[par_hidx] = fcnt;
 
     if (info->stotal > 0) { /* apply memory space */
         size_t stotal = slabs_space_size(sizeof(set_hash_node));
@@ -342,6 +346,19 @@ static void do_set_node_unlink(set_meta_info *info,
 
     /* free the node */
     do_set_node_free(node);
+}
+
+/* Merge child back into par_node if child is empty or too sparse (< MAX/2). */
+static void do_set_node_try_merge(set_meta_info *info,
+                                  set_hash_node *par_node, const int par_hidx,
+                                  set_hash_node *child)
+{
+    if (info->root == NULL) return;
+    if (child->tot_elem_cnt == 0 ||
+        (par_node != NULL &&
+         child->tot_elem_cnt < (SET_MAX_HASHCHAIN_SIZE/2))) {
+        do_set_node_merge(info, par_node, par_hidx);
+    }
 }
 
 static ENGINE_ERROR_CODE do_set_elem_link(set_meta_info *info, set_elem_item *elem,
@@ -409,9 +426,18 @@ static void do_set_elem_unlink(set_meta_info *info,
 {
     if (prev != NULL) prev->next = elem->next;
     else              node->htab[hidx] = elem->next;
-    elem->status = ELEM_STATUS_UNLINKED;
     node->hcnt[hidx] -= 1;
-    node->tot_elem_cnt -= 1;
+    elem->status = ELEM_STATUS_UNLINKED;
+
+    /* decrement tot_elem_cnt on every node from root down to node */
+    set_hash_node *cur = info->root;
+    while (cur != node) {
+        cur->tot_elem_cnt -= 1;
+        int cidx = SET_GET_HASHIDX(elem->hval, cur->hdepth);
+        assert(cur->hcnt[cidx] == -1);
+        cur = (set_hash_node *)cur->htab[cidx];
+    }
+    cur->tot_elem_cnt -= 1;
     info->ccnt--;
 
     CLOG_SET_ELEM_DELETE(info, elem, cause);
@@ -462,10 +488,7 @@ static ENGINE_ERROR_CODE do_set_elem_traverse_delete(set_meta_info *info, set_ha
         set_hash_node *child_node = node->htab[hidx];
         ret = do_set_elem_traverse_delete(info, child_node, hval, val, vlen);
         if (ret == ENGINE_SUCCESS) {
-            if (child_node->tot_elem_cnt < (SET_MAX_HASHCHAIN_SIZE/2)) {
-                do_set_node_unlink(info, node, hidx);
-            }
-            node->tot_elem_cnt -= 1;
+            do_set_node_try_merge(info, node, hidx, child_node);
         }
     } else {
         ret = ENGINE_ELEM_ENOENT;
@@ -495,9 +518,7 @@ static ENGINE_ERROR_CODE do_set_elem_delete_with_value(set_meta_info *info,
         int hval = genhash_string_hash(val, vlen);
         ret = do_set_elem_traverse_delete(info, info->root, hval, val, vlen);
         if (ret == ENGINE_SUCCESS) {
-            if (info->root->tot_elem_cnt == 0) {
-                do_set_node_unlink(info, NULL, 0);
-            }
+            do_set_node_try_merge(info, NULL, 0, info->root);
         }
     } else {
         ret = ENGINE_ELEM_ENOENT;
@@ -520,10 +541,7 @@ static int do_set_elem_traverse_dfs(set_meta_info *info, set_hash_node *node,
                                                 (elem_array==NULL ? NULL : &elem_array[fcnt]), cause);
             fcnt += ecnt;
             if (delete) {
-                if (child_node->tot_elem_cnt < (SET_MAX_HASHCHAIN_SIZE/2)) {
-                    do_set_node_unlink(info, node, hidx);
-                }
-                node->tot_elem_cnt -= ecnt;
+                do_set_node_try_merge(info, node, hidx, child_node);
             }
         } else if (node->hcnt[hidx] > 0) {
             set_elem_item *elem = node->htab[hidx];
@@ -587,10 +605,7 @@ static set_elem_item *do_set_elem_at_offset(set_meta_info *info, set_hash_node *
             }
             set_elem_item *found = do_set_elem_at_offset(info, child_node, offset, delete);
             if (delete) {
-                if (child_node->tot_elem_cnt < (SET_MAX_HASHCHAIN_SIZE/2)) {
-                    do_set_node_unlink(info, node, hidx);
-                }
-                node->tot_elem_cnt -= 1;
+                do_set_node_try_merge(info, node, hidx, child_node);
             }
             return found;
         } else if (node->hcnt[hidx] > 0) {
@@ -619,9 +634,7 @@ static uint32_t do_set_elem_delete(set_meta_info *info, const uint32_t count)
     uint32_t fcnt = 0;
     if (info->root != NULL) {
         fcnt = do_set_elem_traverse_dfs(info, info->root, count, true, NULL, ELEM_DELETE_COLL);
-        if (info->root->tot_elem_cnt == 0) {
-            do_set_node_unlink(info, NULL, 0);
-        }
+        do_set_node_try_merge(info, NULL, 0, info->root);
     }
     return fcnt;
 }
@@ -685,10 +698,8 @@ static uint32_t do_set_elem_get(set_meta_info *info,
     } else { /* Return some */
         fcnt = do_set_elem_traverse_rand(info, count, delete, elem_array);
     }
-    if (delete && info->root->tot_elem_cnt == 0) {
-        do_set_node_unlink(info, NULL, 0);
-    }
     if (delete) {
+        do_set_node_try_merge(info, NULL, 0, info->root);
         CLOG_ELEM_DELETE_END((coll_meta_info*)info, cause);
     }
     return fcnt;
@@ -734,7 +745,13 @@ static ENGINE_ERROR_CODE do_set_elem_insert(hash_item *it, set_elem_item *elem,
     ret = do_set_elem_link(info, elem, cookie);
     if (ret != ENGINE_SUCCESS) {
         if (new_root_flag) {
-            do_set_node_unlink(info, NULL, 0);
+            set_hash_node *node = info->root;
+            info->root = NULL;
+            if (info->stotal > 0) {
+                size_t stotal = slabs_space_size(sizeof(set_hash_node));
+                do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_SET, stotal);
+            }
+            do_set_node_free(node);
         }
         return ret;
     }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/844#issuecomment-4278095307

### ⌨️ What I did

hash tree 공통 모듈 추출 전, map/set의 node_link/node_unlink를 일관되게 리팩토링했습니다.

- `do_node_link` → `do_node_try_split` + `do_node_split`으로 교체
  - `node_try_split`: chain full 여부 체크 후 split 진행, 삽입 슬롯 갱신
  - `node_split`: 기존 chain을 child node로 이동하는 로직만 담당
- `do_node_unlink` → `do_node_try_merge` + `do_node_merge`로 교체
  - `node_try_merge`: empty 또는 sparse 조건 체크 후 merge 진행
  - `node_merge`: child node의 chain을 par_node로 다시 이동하는 로직만 담당
- `tot_elem_cnt` propagation을 각 traverse 함수에서 `do_elem_unlink` 내부로 이동
  - `elem_link`와 대칭 구조 유지
