### PR TITLE
INTERNAL: Refactor map/set traverse functions into explicit get/delete roles

### DIFF
--- a/engines/default/coll_map.c
+++ b/engines/default/coll_map.c
@@ -520,19 +520,17 @@ static bool do_map_elem_delete_by_field(map_meta_info *info, map_hash_node *node
     return ret;
 }
 
-static int do_map_elem_traverse_dfs_bycnt(map_meta_info *info, map_hash_node *node,
-                                          const uint32_t count, const bool delete,
-                                          map_elem_item **elem_array, enum elem_delete_cause cause)
+static int do_map_elem_get_all(map_meta_info *info, map_hash_node *node,
+                               const bool delete, map_elem_item **elem_array)
 {
+    assert(elem_array != NULL);
     int hidx;
     int fcnt = 0; /* found count */
 
     for (hidx = 0; hidx < MAP_HASHTAB_SIZE; hidx++) {
         if (node->hcnt[hidx] == -1) {
             map_hash_node *child_node = (map_hash_node *)node->htab[hidx];
-            int rcnt = (count > 0 ? (count - fcnt) : 0);
-            int ecnt = do_map_elem_traverse_dfs_bycnt(info, child_node, rcnt, delete,
-                                                      (elem_array==NULL ? NULL : &elem_array[fcnt]), cause);
+            int ecnt = do_map_elem_get_all(info, child_node, delete, &elem_array[fcnt]);
             fcnt += ecnt;
             if (delete) {
                 if (child_node->tot_elem_cnt < (MAP_MAX_HASHCHAIN_SIZE/2)) {
@@ -543,14 +541,40 @@ static int do_map_elem_traverse_dfs_bycnt(map_meta_info *info, map_hash_node *no
         } else if (node->hcnt[hidx] > 0) {
             map_elem_item *elem = node->htab[hidx];
             while (elem != NULL) {
-                if (elem_array) {
-                    elem->refcount++;
-                    elem_array[fcnt] = elem;
-                }
+                elem->refcount++;
+                elem_array[fcnt] = elem;
                 fcnt++;
-                if (delete) do_map_elem_unlink(info, node, hidx, NULL, elem, cause);
-                if (count > 0 && fcnt >= count) break;
+                if (delete) do_map_elem_unlink(info, node, hidx, NULL, elem, ELEM_DELETE_NORMAL);
                 elem = (delete ? node->htab[hidx] : elem->next);
+            }
+        }
+    }
+    return fcnt;
+}
+
+static int do_map_elem_delete_by_count(map_meta_info *info, map_hash_node *node,
+                                       const uint32_t count, enum elem_delete_cause cause)
+{
+    int hidx;
+    int fcnt = 0;
+
+    for (hidx = 0; hidx < MAP_HASHTAB_SIZE; hidx++) {
+        if (node->hcnt[hidx] == -1) {
+            map_hash_node *child_node = (map_hash_node *)node->htab[hidx];
+            int rcnt = (count > 0 ? (count - fcnt) : 0);
+            int ecnt = do_map_elem_delete_by_count(info, child_node, rcnt, cause);
+            fcnt += ecnt;
+            if (child_node->tot_elem_cnt < (MAP_MAX_HASHCHAIN_SIZE/2)) {
+                do_map_node_unlink(info, node, hidx);
+            }
+            node->tot_elem_cnt -= ecnt;
+        } else if (node->hcnt[hidx] > 0) {
+            map_elem_item *elem = node->htab[hidx];
+            while (elem != NULL) {
+                fcnt++;
+                do_map_elem_unlink(info, node, hidx, NULL, elem, cause);
+                if (count > 0 && fcnt >= count) break;
+                elem = node->htab[hidx];
             }
         }
         if (count > 0 && fcnt >= count) break;
@@ -567,7 +591,7 @@ static uint32_t do_map_elem_delete(map_meta_info *info, const int numfields,
     if (info->root != NULL) {
         CLOG_ELEM_DELETE_BEGIN((coll_meta_info*)info, numfields, cause);
         if (numfields == 0) {
-            delcnt = do_map_elem_traverse_dfs_bycnt(info, info->root, 0, true, NULL, cause);
+            delcnt = do_map_elem_delete_by_count(info, info->root, 0, cause);
         } else {
             for (int ii = 0; ii < numfields; ii++) {
                 int hval = genhash_string_hash(flist[ii].value, flist[ii].length);
@@ -674,8 +698,7 @@ static uint32_t do_map_elem_get(map_meta_info *info,
         CLOG_ELEM_DELETE_BEGIN((coll_meta_info*)info, numfields, cause);
     }
     if (numfields == 0) {
-        fcnt = do_map_elem_traverse_dfs_bycnt(info, info->root, 0, delete,
-                                              elem_array, cause);
+        fcnt = do_map_elem_get_all(info, info->root, delete, elem_array);
     } else {
         for (int ii = 0; ii < numfields; ii++) {
             int hval = genhash_string_hash(flist[ii].value, flist[ii].length);
@@ -946,7 +969,7 @@ uint32_t map_elem_delete_with_count(map_meta_info *info, const uint32_t count)
 
     // cache_lock is held by caller.
     if (info->root != NULL) {
-        fcnt = do_map_elem_traverse_dfs_bycnt(info, info->root, count, true, NULL, ELEM_DELETE_COLL);
+        fcnt = do_map_elem_delete_by_count(info, info->root, count, ELEM_DELETE_COLL);
         if (info->root->tot_elem_cnt == 0) {
             do_map_node_unlink(info, NULL, 0);
         }
@@ -954,74 +977,11 @@ uint32_t map_elem_delete_with_count(map_meta_info *info, const uint32_t count)
     return fcnt;
 }
 
-/* See do_map_elem_traverse_dfs and do_map_elem_link. do_map_elem_traverse_dfs
- * can visit all elements, but only supports get and delete operations.
- * Do something similar and visit all elements.
- */
 void map_elem_get_all(map_meta_info *info, elems_result_t *eresult)
 {
     assert(eresult->elem_arrsz >= info->ccnt && eresult->elem_count == 0);
-    map_hash_node *node;
-    map_elem_item *elem;
-    int cur_depth, i;
-    bool push;
-
-    /* Temporay stack we use to do dfs. Static is ugly but is okay...
-     * This function runs with the cache lock acquired.
-     */
-    static int stack_max = 0;
-    static struct _map_hash_posi {
-        map_hash_node *node;
-        int idx;
-    } *stack = NULL;
-
-    node = info->root;
-    cur_depth = 0;
-    push = true;
-    while (node != NULL) {
-        if (push) {
-            push = false;
-            if (stack_max <= cur_depth) {
-                struct _map_hash_posi *tmp;
-                stack_max += 16;
-                tmp = realloc(stack, sizeof(*stack) * stack_max);
-                assert(tmp != NULL);
-                stack = tmp;
-            }
-            stack[cur_depth].node = node;
-            stack[cur_depth].idx = 0;
-        }
-
-        /* Scan the current node */
-        for (i = stack[cur_depth].idx; i < MAP_HASHTAB_SIZE; i++) {
-            if (node->hcnt[i] >= 0) {
-                /* Hash chain.  Insert all elements on the chain into the
-                 * to-be-copied list.
-                 */
-                for (elem = node->htab[i]; elem != NULL; elem = elem->next) {
-                    elem->refcount++;
-                    eresult->elem_array[eresult->elem_count++] = elem;
-                }
-            }
-            else if (node->htab[i] != NULL) {
-                /* Another hash node.  Go down */
-                stack[cur_depth].idx = i+1;
-                push = true;
-                node = node->htab[i];
-                cur_depth++;
-                break;
-            }
-        }
-
-        /* Scannned everything in this node.  Go up. */
-        if (i >= MAP_HASHTAB_SIZE) {
-            cur_depth--;
-            if (cur_depth < 0)
-                node = NULL; /* done */
-            else
-                node = stack[cur_depth].node;
-        }
-    }
+    eresult->elem_count = do_map_elem_get_all(info, info->root, false,
+                                              (map_elem_item **)eresult->elem_array);
     assert(eresult->elem_count == info->ccnt);
 }
 

--- a/engines/default/coll_map.c
+++ b/engines/default/coll_map.c
@@ -446,16 +446,17 @@ static void do_map_elem_unlink(map_meta_info *info,
     }
 }
 
-static bool do_map_elem_traverse_dfs_byfield(map_meta_info *info, map_hash_node *node, const int hval,
-                                             const field_t *field, const bool delete,
-                                             map_elem_item **elem_array)
+static bool do_map_elem_get_by_field(map_meta_info *info, map_hash_node *node, const int hval,
+                                     const field_t *field, const bool delete,
+                                     map_elem_item **elem_array)
 {
+    assert(elem_array != NULL);
     bool ret;
     int hidx = MAP_GET_HASHIDX(hval, node->hdepth);
 
     if (node->hcnt[hidx] == -1) {
         map_hash_node *child_node = node->htab[hidx];
-        ret = do_map_elem_traverse_dfs_byfield(info, child_node, hval, field, delete, elem_array);
+        ret = do_map_elem_get_by_field(info, child_node, hval, field, delete, elem_array);
         if (ret && delete) {
             if (child_node->tot_elem_cnt < (MAP_MAX_HASHCHAIN_SIZE/2)) {
                 do_map_node_unlink(info, node, hidx);
@@ -469,14 +470,45 @@ static bool do_map_elem_traverse_dfs_byfield(map_meta_info *info, map_hash_node 
             map_elem_item *elem = node->htab[hidx];
             while (elem != NULL) {
                 if (map_hash_eq(hval, field->value, field->length, elem->hval, elem->data, elem->nfield)) {
-                    if (elem_array) {
-                        elem->refcount++;
-                        elem_array[0] = elem;
-                    }
-
+                    elem->refcount++;
+                    elem_array[0] = elem;
                     if (delete) {
                         do_map_elem_unlink(info, node, hidx, prev, elem, ELEM_DELETE_NORMAL);
                     }
+                    ret = true;
+                    break;
+                }
+                prev = elem;
+                elem = elem->next;
+            }
+        }
+    }
+    return ret;
+}
+
+static bool do_map_elem_delete_by_field(map_meta_info *info, map_hash_node *node, const int hval,
+                                        const field_t *field)
+{
+    bool ret;
+    int hidx = MAP_GET_HASHIDX(hval, node->hdepth);
+
+    if (node->hcnt[hidx] == -1) {
+        map_hash_node *child_node = node->htab[hidx];
+        ret = do_map_elem_delete_by_field(info, child_node, hval, field);
+        if (ret) {
+            if (child_node->tot_elem_cnt < (MAP_MAX_HASHCHAIN_SIZE/2)) {
+                do_map_node_unlink(info, node, hidx);
+            }
+            node->tot_elem_cnt -= 1;
+        }
+    } else {
+        ret = false;
+        if (node->hcnt[hidx] > 0) {
+            map_elem_item *prev = NULL;
+            map_elem_item *elem = node->htab[hidx];
+            while (elem != NULL) {
+                if (map_hash_eq(hval, field->value, field->length, elem->hval, elem->data, elem->nfield)) {
+                    do_map_elem_unlink(info, node, hidx, prev, elem, ELEM_DELETE_NORMAL);
                     ret = true;
                     break;
                 }
@@ -539,7 +571,7 @@ static uint32_t do_map_elem_delete(map_meta_info *info, const int numfields,
         } else {
             for (int ii = 0; ii < numfields; ii++) {
                 int hval = genhash_string_hash(flist[ii].value, flist[ii].length);
-                if (do_map_elem_traverse_dfs_byfield(info, info->root, hval, &flist[ii], true, NULL)) {
+                if (do_map_elem_delete_by_field(info, info->root, hval, &flist[ii])) {
                     delcnt++;
                 }
             }
@@ -647,8 +679,8 @@ static uint32_t do_map_elem_get(map_meta_info *info,
     } else {
         for (int ii = 0; ii < numfields; ii++) {
             int hval = genhash_string_hash(flist[ii].value, flist[ii].length);
-            if (do_map_elem_traverse_dfs_byfield(info, info->root, hval, &flist[ii],
-                                                 delete, &elem_array[fcnt])) {
+            if (do_map_elem_get_by_field(info, info->root, hval, &flist[ii],
+                                         delete, &elem_array[fcnt])) {
                 fcnt++;
             }
         }

--- a/engines/default/coll_set.c
+++ b/engines/default/coll_set.c
@@ -614,10 +614,11 @@ static set_elem_item *do_set_elem_at_offset(set_meta_info *info, set_hash_node *
     return NULL;
 }
 
-static uint32_t do_set_elem_traverse_rand(set_meta_info *info,
-                                          const uint32_t count, const bool delete,
-                                          set_elem_item **elem_array)
+static uint32_t do_set_elem_get_rand(set_meta_info *info,
+                                     const uint32_t count, const bool delete,
+                                     set_elem_item **elem_array)
 {
+    assert(elem_array != NULL);
     uint32_t fcnt = 0;
 
     if (delete) { /* Deleting partial elements */
@@ -671,7 +672,7 @@ static uint32_t do_set_elem_get(set_meta_info *info,
     if (count >= info->ccnt || count == 0) { /* Return all */
         fcnt = do_set_elem_get_all(info, info->root, delete, elem_array);
     } else { /* Return some */
-        fcnt = do_set_elem_traverse_rand(info, count, delete, elem_array);
+        fcnt = do_set_elem_get_rand(info, count, delete, elem_array);
     }
     if (delete && info->root->tot_elem_cnt == 0) {
         do_set_node_unlink(info, NULL, 0);

--- a/engines/default/coll_set.c
+++ b/engines/default/coll_set.c
@@ -481,19 +481,17 @@ static ENGINE_ERROR_CODE do_set_elem_delete(set_meta_info *info,
     return ret;
 }
 
-static int do_set_elem_traverse_dfs(set_meta_info *info, set_hash_node *node,
-                                    const uint32_t count, const bool delete,
-                                    set_elem_item **elem_array, enum elem_delete_cause cause)
+static int do_set_elem_get_all(set_meta_info *info, set_hash_node *node,
+                               const bool delete, set_elem_item **elem_array)
 {
+    assert(elem_array != NULL);
     int hidx;
     int fcnt = 0; /* found count */
 
     for (hidx = 0; hidx < SET_HASHTAB_SIZE; hidx++) {
         if (node->hcnt[hidx] == -1) {
             set_hash_node *child_node = (set_hash_node *)node->htab[hidx];
-            int rcnt = (count > 0 ? (count - fcnt) : 0);
-            int ecnt = do_set_elem_traverse_dfs(info, child_node, rcnt, delete,
-                                                (elem_array==NULL ? NULL : &elem_array[fcnt]), cause);
+            int ecnt = do_set_elem_get_all(info, child_node, delete, &elem_array[fcnt]);
             fcnt += ecnt;
             if (delete) {
                 if (child_node->tot_elem_cnt < (SET_MAX_HASHCHAIN_SIZE/2)) {
@@ -504,14 +502,40 @@ static int do_set_elem_traverse_dfs(set_meta_info *info, set_hash_node *node,
         } else if (node->hcnt[hidx] > 0) {
             set_elem_item *elem = node->htab[hidx];
             while (elem != NULL) {
-                if (elem_array) {
-                    elem->refcount++;
-                    elem_array[fcnt] = elem;
-                }
+                elem->refcount++;
+                elem_array[fcnt] = elem;
                 fcnt++;
-                if (delete) do_set_elem_unlink(info, node, hidx, NULL, elem, cause);
-                if (count > 0 && fcnt >= count) break;
+                if (delete) do_set_elem_unlink(info, node, hidx, NULL, elem, ELEM_DELETE_NORMAL);
                 elem = (delete ? node->htab[hidx] : elem->next);
+            }
+        }
+    }
+    return fcnt;
+}
+
+static int do_set_elem_delete_by_count(set_meta_info *info, set_hash_node *node,
+                                       const uint32_t count, enum elem_delete_cause cause)
+{
+    int hidx;
+    int fcnt = 0;
+
+    for (hidx = 0; hidx < SET_HASHTAB_SIZE; hidx++) {
+        if (node->hcnt[hidx] == -1) {
+            set_hash_node *child_node = (set_hash_node *)node->htab[hidx];
+            int rcnt = (count > 0 ? (count - fcnt) : 0);
+            int ecnt = do_set_elem_delete_by_count(info, child_node, rcnt, cause);
+            fcnt += ecnt;
+            if (child_node->tot_elem_cnt < (SET_MAX_HASHCHAIN_SIZE/2)) {
+                do_set_node_unlink(info, node, hidx);
+            }
+            node->tot_elem_cnt -= ecnt;
+        } else if (node->hcnt[hidx] > 0) {
+            set_elem_item *elem = node->htab[hidx];
+            while (elem != NULL) {
+                fcnt++;
+                do_set_elem_unlink(info, node, hidx, NULL, elem, cause);
+                if (count > 0 && fcnt >= count) break;
+                elem = node->htab[hidx];
             }
         }
         if (count > 0 && fcnt >= count) break;
@@ -645,7 +669,7 @@ static uint32_t do_set_elem_get(set_meta_info *info,
         CLOG_ELEM_DELETE_BEGIN((coll_meta_info*)info, count, cause);
     }
     if (count >= info->ccnt || count == 0) { /* Return all */
-        fcnt = do_set_elem_traverse_dfs(info, info->root, count, delete, elem_array, cause);
+        fcnt = do_set_elem_get_all(info, info->root, delete, elem_array);
     } else { /* Return some */
         fcnt = do_set_elem_traverse_rand(info, count, delete, elem_array);
     }
@@ -926,7 +950,7 @@ uint32_t set_elem_delete_with_count(set_meta_info *info, const uint32_t count)
 
     // cache_lock is held by caller
     if (info->root != NULL) {
-        fcnt = do_set_elem_traverse_dfs(info, info->root, count, true, NULL, ELEM_DELETE_COLL);
+        fcnt = do_set_elem_delete_by_count(info, info->root, count, ELEM_DELETE_COLL);
         if (info->root->tot_elem_cnt == 0) {
             do_set_node_unlink(info, NULL, 0);
         }
@@ -934,74 +958,11 @@ uint32_t set_elem_delete_with_count(set_meta_info *info, const uint32_t count)
     return fcnt;
 }
 
-/* See do_set_elem_traverse_dfs and do_set_elem_link. do_set_elem_traverse_dfs
- * can visit all elements, but only supports get and delete operations.
- * Do something similar and visit all elements.
- */
 void set_elem_get_all(set_meta_info *info, elems_result_t *eresult)
 {
     assert(eresult->elem_arrsz >= info->ccnt && eresult->elem_count == 0);
-    set_hash_node *node;
-    set_elem_item *elem;
-    int cur_depth, i;
-    bool push;
-
-    /* Temporay stack we use to do dfs. Static is ugly but is okay...
-     * This function runs with the cache lock acquired.
-     */
-    static int stack_max = 0;
-    static struct _set_hash_posi {
-        set_hash_node *node;
-        int idx;
-    } *stack = NULL;
-
-    node = info->root;
-    cur_depth = 0;
-    push = true;
-    while (node != NULL) {
-        if (push) {
-            push = false;
-            if (stack_max <= cur_depth) {
-                struct _set_hash_posi *tmp;
-                stack_max += 16;
-                tmp = realloc(stack, sizeof(*stack) * stack_max);
-                assert(tmp != NULL);
-                stack = tmp;
-            }
-            stack[cur_depth].node = node;
-            stack[cur_depth].idx = 0;
-        }
-
-        /* Scan the current node */
-        for (i = stack[cur_depth].idx; i < SET_HASHTAB_SIZE; i++) {
-            if (node->hcnt[i] >= 0) {
-                /* Hash chain.  Insert all elements on the chain into the
-                 * to-be-copied list.
-                 */
-                for (elem = node->htab[i]; elem != NULL; elem = elem->next) {
-                    elem->refcount++;
-                    eresult->elem_array[eresult->elem_count++] = elem;
-                }
-            }
-            else if (node->htab[i] != NULL) {
-                /* Another hash node. Go down */
-                stack[cur_depth].idx = i+1;
-                push = true;
-                node = node->htab[i];
-                cur_depth++;
-                break;
-            }
-        }
-
-        /* Scannned everything in this node. Go up. */
-        if (i >= SET_HASHTAB_SIZE) {
-            cur_depth--;
-            if (cur_depth < 0)
-                node = NULL; /* done */
-            else
-                node = stack[cur_depth].node;
-        }
-    }
+    eresult->elem_count = do_set_elem_get_all(info, info->root, false,
+                                              (set_elem_item**)(eresult->elem_array));
     assert(eresult->elem_count == info->ccnt);
 }
 

--- a/engines/default/coll_set.c
+++ b/engines/default/coll_set.c
@@ -427,7 +427,7 @@ static set_elem_item *do_set_elem_find(set_meta_info *info, const char *val, con
     return elem;
 }
 
-static ENGINE_ERROR_CODE do_set_elem_traverse_delete(set_meta_info *info, set_hash_node *node,
+static ENGINE_ERROR_CODE do_set_elem_delete_by_value(set_meta_info *info, set_hash_node *node,
                                                      const int hval, const char *val, const int vlen)
 {
     ENGINE_ERROR_CODE ret;
@@ -436,7 +436,7 @@ static ENGINE_ERROR_CODE do_set_elem_traverse_delete(set_meta_info *info, set_ha
 
     if (node->hcnt[hidx] == -1) {
         set_hash_node *child_node = node->htab[hidx];
-        ret = do_set_elem_traverse_delete(info, child_node, hval, val, vlen);
+        ret = do_set_elem_delete_by_value(info, child_node, hval, val, vlen);
         if (ret == ENGINE_SUCCESS) {
             if (child_node->tot_elem_cnt < (SET_MAX_HASHCHAIN_SIZE/2)) {
                 do_set_node_unlink(info, node, hidx);
@@ -469,7 +469,7 @@ static ENGINE_ERROR_CODE do_set_elem_delete(set_meta_info *info,
     ENGINE_ERROR_CODE ret;
     if (info->root != NULL) {
         int hval = genhash_string_hash(val, vlen);
-        ret = do_set_elem_traverse_delete(info, info->root, hval, val, vlen);
+        ret = do_set_elem_delete_by_value(info, info->root, hval, val, vlen);
         if (ret == ENGINE_SUCCESS) {
             if (info->root->tot_elem_cnt == 0) {
                 do_set_node_unlink(info, NULL, 0);


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/844#issuecomment-4278095307

### ⌨️ What I did

기존 traverse 함수들이 `bool delete`, `elem_array` NULL 여부 등을 한꺼번에 받아 조건문으로 분기 처리하고 있어 가독성이 좋지 않았습니다.

`elem_array`에 담아 반환하는 함수는 `get_**`으로, 삭제만 담당하는 함수는 `delete_**`로 분리했습니다.
`get_**` 함수에는 `assert(elem_array != NULL)`을 추가했습니다.

**map**
- `do_map_elem_traverse_dfs_bycnt` → `do_map_elem_get_all` / `do_map_elem_delete_by_count`로 분리
- `do_map_elem_traverse_dfs_byfield` → `do_map_elem_get_by_field` / `do_map_elem_delete_by_field`로 분리
- `map_elem_get_all`: 기존 stack 기반 DFS 구현을 `do_map_elem_get_all` 호출로 교체

**set**
- `do_set_elem_traverse_dfs` → `do_set_elem_get_all` / `do_set_elem_delete_by_count`로 분리
- `do_set_elem_traverse_rand` → `do_set_elem_get_rand`로 rename
- `do_set_elem_traverse_delete` → `do_set_elem_delete_by_value`로 rename
- `set_elem_get_all`: 기존 stack 기반 DFS 구현을 `do_set_elem_get_all` 호출로 교체
