### PR TITLE
INTERNAL: Separate hash tree operations from collection state updates in map/set

### DIFF
--- a/engines/default/coll_map.c
+++ b/engines/default/coll_map.c
@@ -291,24 +291,17 @@ static void do_map_elem_replace(map_meta_info *info,
         old_elem = (map_elem_item *)pinfo->node->htab[pinfo->hidx];
     }
 
-    old_stotal = slabs_space_size(do_map_elem_ntotal(old_elem));
-    new_stotal = slabs_space_size(do_map_elem_ntotal(new_elem));
-
-    CLOG_MAP_ELEM_INSERT(info, old_elem, new_elem);
-
     new_elem->next = old_elem->next;
     if (prev != NULL) {
         prev->next = new_elem;
     } else {
         pinfo->node->htab[pinfo->hidx] = new_elem;
     }
-    new_elem->status = ELEM_STATUS_LINKED;
 
-    old_elem->status = ELEM_STATUS_UNLINKED;
-    if (old_elem->refcount == 0) {
-        do_map_elem_free(old_elem);
-    }
+    CLOG_MAP_ELEM_INSERT(info, old_elem, new_elem);
 
+    old_stotal = slabs_space_size(do_map_elem_ntotal(old_elem));
+    new_stotal = slabs_space_size(do_map_elem_ntotal(new_elem));
     if (new_stotal != old_stotal) {
         assert(info->stotal > 0);
         if (new_stotal > old_stotal) {
@@ -316,6 +309,12 @@ static void do_map_elem_replace(map_meta_info *info,
         } else {
             do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_MAP, (old_stotal-new_stotal));
         }
+    }
+
+    new_elem->status = ELEM_STATUS_LINKED;
+    old_elem->status = ELEM_STATUS_UNLINKED;
+    if (old_elem->refcount == 0) {
+        do_map_elem_free(old_elem);
     }
 }
 
@@ -397,13 +396,10 @@ static ENGINE_ERROR_CODE do_map_elem_link(map_meta_info *info, map_elem_item *el
         hidx = MAP_GET_HASHIDX(elem->hval, node->hdepth);
     }
 
-    CLOG_MAP_ELEM_INSERT(info, NULL, elem);
-
     elem->next = node->htab[hidx];
     node->htab[hidx] = elem;
     node->hcnt[hidx] += 1;
     node->tot_elem_cnt += 1;
-    elem->status = ELEM_STATUS_LINKED;
 
     map_hash_node *par_node = info->root;
     while (par_node != node) {
@@ -412,12 +408,14 @@ static ENGINE_ERROR_CODE do_map_elem_link(map_meta_info *info, map_elem_item *el
         assert(par_node->hcnt[hidx] == -1);
         par_node = par_node->htab[hidx];
     }
-    info->ccnt++;
 
+    CLOG_MAP_ELEM_INSERT(info, NULL, elem);
+    info->ccnt++;
     if (1) { /* apply memory space */
         size_t stotal = slabs_space_size(do_map_elem_ntotal(elem));
         do_coll_space_incr((coll_meta_info *)info, ITEM_TYPE_MAP, stotal);
     }
+    elem->status = ELEM_STATUS_LINKED;
 
     return res;
 }
@@ -429,18 +427,16 @@ static void do_map_elem_unlink(map_meta_info *info,
 {
     if (prev != NULL) prev->next = elem->next;
     else              node->htab[hidx] = elem->next;
-    elem->status = ELEM_STATUS_UNLINKED;
     node->hcnt[hidx] -= 1;
     node->tot_elem_cnt -= 1;
-    info->ccnt--;
 
     CLOG_MAP_ELEM_DELETE(info, elem, cause);
-
+    info->ccnt--;
     if (info->stotal > 0) { /* apply memory space */
         size_t stotal = slabs_space_size(do_map_elem_ntotal(elem));
         do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_MAP, stotal);
     }
-
+    elem->status = ELEM_STATUS_UNLINKED;
     if (elem->refcount == 0) {
         do_map_elem_free(elem);
     }

--- a/engines/default/coll_map.c
+++ b/engines/default/coll_map.c
@@ -318,9 +318,9 @@ static void do_map_elem_replace(map_meta_info *info,
     }
 }
 
-static ENGINE_ERROR_CODE do_map_elem_link(map_meta_info *info, map_elem_item *elem,
-                                          const bool replace_if_exist, bool *replaced,
-                                          const void *cookie)
+static ENGINE_ERROR_CODE do_map_htree_elem_link(map_meta_info *info, map_elem_item *elem,
+                                                const bool replace_if_exist, bool *replaced,
+                                                const void *cookie)
 {
     assert(info->root != NULL);
     map_hash_node *node = info->root;
@@ -409,15 +409,37 @@ static ENGINE_ERROR_CODE do_map_elem_link(map_meta_info *info, map_elem_item *el
         par_node = par_node->htab[hidx];
     }
 
-    CLOG_MAP_ELEM_INSERT(info, NULL, elem);
-    info->ccnt++;
-    if (1) { /* apply memory space */
-        size_t stotal = slabs_space_size(do_map_elem_ntotal(elem));
-        do_coll_space_incr((coll_meta_info *)info, ITEM_TYPE_MAP, stotal);
-    }
-    elem->status = ELEM_STATUS_LINKED;
-
     return res;
+}
+
+static ENGINE_ERROR_CODE do_map_elem_link(map_meta_info *info, map_elem_item *elem,
+                                          const bool replace_if_exist, bool *replaced,
+                                          const void *cookie)
+{
+    ENGINE_ERROR_CODE ret = do_map_htree_elem_link(info, elem, replace_if_exist, replaced, cookie);
+    if (ret != ENGINE_SUCCESS) return ret;
+
+    if (replaced == NULL || !(*replaced)) {
+        CLOG_MAP_ELEM_INSERT(info, NULL, elem);
+        info->ccnt++;
+        if (1) { /* apply memory space */
+            size_t stotal = slabs_space_size(do_map_elem_ntotal(elem));
+            do_coll_space_incr((coll_meta_info *)info, ITEM_TYPE_MAP, stotal);
+        }
+        elem->status = ELEM_STATUS_LINKED;
+    }
+
+    return ENGINE_SUCCESS;
+}
+
+static void do_map_htree_elem_unlink(map_meta_info *info,
+                                     map_hash_node *node, const int hidx,
+                                     map_elem_item *prev, map_elem_item *elem)
+{
+    if (prev != NULL) prev->next = elem->next;
+    else              node->htab[hidx] = elem->next;
+    node->hcnt[hidx] -= 1;
+    node->tot_elem_cnt -= 1;
 }
 
 static void do_map_elem_unlink(map_meta_info *info,
@@ -425,10 +447,7 @@ static void do_map_elem_unlink(map_meta_info *info,
                                map_elem_item *prev, map_elem_item *elem,
                                enum elem_delete_cause cause)
 {
-    if (prev != NULL) prev->next = elem->next;
-    else              node->htab[hidx] = elem->next;
-    node->hcnt[hidx] -= 1;
-    node->tot_elem_cnt -= 1;
+    do_map_htree_elem_unlink(info, node, hidx, prev, elem);
 
     CLOG_MAP_ELEM_DELETE(info, elem, cause);
     info->ccnt--;

--- a/engines/default/coll_set.c
+++ b/engines/default/coll_set.c
@@ -359,7 +359,6 @@ static ENGINE_ERROR_CODE do_set_elem_link(set_meta_info *info, set_elem_item *el
     node->htab[hidx] = elem;
     node->hcnt[hidx] += 1;
     node->tot_elem_cnt += 1;
-    elem->status = ELEM_STATUS_LINKED;
 
     set_hash_node *par_node = info->root;
     while (par_node != node) {
@@ -368,12 +367,14 @@ static ENGINE_ERROR_CODE do_set_elem_link(set_meta_info *info, set_elem_item *el
         assert(par_node->hcnt[hidx] == -1);
         par_node = par_node->htab[hidx];
     }
-    info->ccnt++;
 
+    CLOG_SET_ELEM_INSERT(info, elem);
+    info->ccnt++;
     if (1) { /* apply memory space */
         size_t stotal = slabs_space_size(do_set_elem_ntotal(elem));
         do_coll_space_incr((coll_meta_info *)info, ITEM_TYPE_SET, stotal);
     }
+    elem->status = ELEM_STATUS_LINKED;
 
     return ENGINE_SUCCESS;
 }
@@ -385,18 +386,16 @@ static void do_set_elem_unlink(set_meta_info *info,
 {
     if (prev != NULL) prev->next = elem->next;
     else              node->htab[hidx] = elem->next;
-    elem->status = ELEM_STATUS_UNLINKED;
     node->hcnt[hidx] -= 1;
     node->tot_elem_cnt -= 1;
-    info->ccnt--;
 
     CLOG_SET_ELEM_DELETE(info, elem, cause);
-
+    info->ccnt--;
     if (info->stotal > 0) { /* apply memory space */
         size_t stotal = slabs_space_size(do_set_elem_ntotal(elem));
         do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_SET, stotal);
     }
-
+    elem->status = ELEM_STATUS_UNLINKED;
     if (elem->refcount == 0) {
         do_set_elem_free(elem);
     }
@@ -724,7 +723,6 @@ static ENGINE_ERROR_CODE do_set_elem_insert(hash_item *it, set_elem_item *elem,
         return ret;
     }
 
-    CLOG_SET_ELEM_INSERT(info, elem);
     return ENGINE_SUCCESS;
 }
 

--- a/engines/default/coll_set.c
+++ b/engines/default/coll_set.c
@@ -315,8 +315,8 @@ static void do_set_node_unlink(set_meta_info *info,
     do_set_node_free(node);
 }
 
-static ENGINE_ERROR_CODE do_set_elem_link(set_meta_info *info, set_elem_item *elem,
-                                          const void *cookie)
+static ENGINE_ERROR_CODE do_set_htree_elem_link(set_meta_info *info, set_elem_item *elem,
+                                                const void *cookie)
 {
     assert(info->root != NULL);
     set_hash_node *node = info->root;
@@ -368,6 +368,15 @@ static ENGINE_ERROR_CODE do_set_elem_link(set_meta_info *info, set_elem_item *el
         par_node = par_node->htab[hidx];
     }
 
+    return ENGINE_SUCCESS;
+}
+
+static ENGINE_ERROR_CODE do_set_elem_link(set_meta_info *info, set_elem_item *elem,
+                                          const void *cookie)
+{
+    ENGINE_ERROR_CODE ret = do_set_htree_elem_link(info, elem, cookie);
+    if (ret != ENGINE_SUCCESS) return ret;
+
     CLOG_SET_ELEM_INSERT(info, elem);
     info->ccnt++;
     if (1) { /* apply memory space */
@@ -379,15 +388,22 @@ static ENGINE_ERROR_CODE do_set_elem_link(set_meta_info *info, set_elem_item *el
     return ENGINE_SUCCESS;
 }
 
-static void do_set_elem_unlink(set_meta_info *info,
-                               set_hash_node *node, const int hidx,
-                               set_elem_item *prev, set_elem_item *elem,
-                               enum elem_delete_cause cause)
+static void do_set_htree_elem_unlink(set_meta_info *info,
+                                     set_hash_node *node, const int hidx,
+                                     set_elem_item *prev, set_elem_item *elem)
 {
     if (prev != NULL) prev->next = elem->next;
     else              node->htab[hidx] = elem->next;
     node->hcnt[hidx] -= 1;
     node->tot_elem_cnt -= 1;
+}
+
+static void do_set_elem_unlink(set_meta_info *info,
+                               set_hash_node *node, const int hidx,
+                               set_elem_item *prev, set_elem_item *elem,
+                               enum elem_delete_cause cause)
+{
+    do_set_htree_elem_unlink(info, node, hidx, prev, elem);
 
     CLOG_SET_ELEM_DELETE(info, elem, cause);
     info->ccnt--;


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/844#issuecomment-4278095307

### ⌨️ What I did

- 향후 set, map, zset이 공유하는 `hash_tree` 모듈 추출을 위한 사전 작업을 진행했습니다. zset은 하나의 elem을 btree와 hash tree 두 자료구조에 모두 연결하므로 `CLOG`/`ccnt`/`space accounting`/`elem status` 업데이트는 collection 단에서 한 번만 이뤄져야 합니다.
- map/set의 elem_link, unlink, replace에서 hash tree 구조 조작과 collection 상태 업데이트(CLOG, ccnt, space accounting, elem status)를 분리했습니다.

### 향후 작업
- `do_htree_elem_link`에 있는 `sticky overflow`, `overflow` check를 collection 단의 작업(`do_{map, set}_elem_link` 내부)으로 빼냅니다.
- `htree_elem_link`: 현재 root가 NULL일 시 외부에서 root node를 생성해준 후 htree_elem_link를 하고 있습니다. hash tree 모듈에서는 node 관련 작업을 hash tree 단에서 해주어야 하므로 노드를 새로 생성하는 로직을 내부로 통합합니다.
- `htree_elem_unlink`: unlink 후 node의 elem이 sparse해지면 par_node의 체인으로 흡수하는 로직을 통합합니다.
