### PR TITLE
INTERNAL: Replace elem status flag with linked count

### DIFF
--- a/engines/default/coll_btree.c
+++ b/engines/default/coll_btree.c
@@ -284,7 +284,7 @@ static btree_elem_item *do_btree_elem_alloc(const uint32_t nbkey, const uint32_t
         assert(elem->slabs_clsid > 0);
 
         elem->refcount    = 0;
-        elem->status      = ELEM_STATUS_UNLINKED; /* unlinked state */
+        elem->linked      = 0;
         elem->nbkey       = (uint8_t)nbkey;
         elem->neflag      = (uint8_t)neflag;
         elem->nbytes      = (uint16_t)nbytes;
@@ -305,7 +305,7 @@ static void do_btree_elem_release(btree_elem_item *elem)
     if (elem->refcount != 0) {
         elem->refcount--;
     }
-    if (elem->refcount == 0 && elem->status == ELEM_STATUS_UNLINKED) {
+    if (elem->refcount == 0 && elem->linked == 0) {
         do_btree_elem_free(elem);
     }
 }
@@ -1659,9 +1659,9 @@ static void do_btree_elem_unlink(btree_meta_info *info, btree_elem_posi *path,
 
     CLOG_BTREE_ELEM_DELETE(info, elem, cause);
 
-    if (elem->refcount > 0) {
-        elem->status = ELEM_STATUS_UNLINKED;
-    } else  {
+    elem->linked--;
+    assert(elem->linked == 0);
+    if (elem->refcount == 0) {
         do_btree_elem_free(elem);
     }
 
@@ -1695,13 +1695,13 @@ static void do_btree_elem_replace(btree_meta_info *info,
 
     CLOG_BTREE_ELEM_INSERT(info, old_elem, new_elem);
 
-    if (old_elem->refcount > 0) {
-        old_elem->status = ELEM_STATUS_UNLINKED;
-    } else  {
+    old_elem->linked--;
+    assert(old_elem->linked == 0);
+    if (old_elem->refcount == 0) {
         do_btree_elem_free(old_elem);
     }
 
-    new_elem->status = ELEM_STATUS_LINKED;
+    new_elem->linked++;
     posi->node->item[posi->indx] = new_elem;
 
     if (new_stotal != old_stotal) { /* apply memory space */
@@ -1841,9 +1841,9 @@ static int do_btree_elem_delete_fast(btree_meta_info *info,
         if (node->ndepth == 0) { /* leaf node */
             for (i = 0; i < node->used_count; i++) {
                 elem = (btree_elem_item *)node->item[i];
-                if (elem->refcount > 0) {
-                    elem->status = ELEM_STATUS_UNLINKED;
-                } else {
+                elem->linked--;
+                assert(elem->linked == 0);
+                if (elem->refcount == 0) {
                     do_btree_elem_free(elem);
                 }
             }
@@ -1935,9 +1935,9 @@ static uint32_t do_btree_elem_delete(btree_meta_info *info,
                     tot_space += slabs_space_size(do_btree_elem_ntotal(elem));
 
                     CLOG_BTREE_ELEM_DELETE(info, elem, cause);
-                    if (elem->refcount > 0) {
-                        elem->status = ELEM_STATUS_UNLINKED;
-                    } else {
+                    elem->linked--;
+                    assert(elem->linked == 0);
+                    if (elem->refcount == 0) {
                         do_btree_elem_free(elem);
                     }
                     c_posi.node->item[c_posi.indx] = NULL;
@@ -2234,7 +2234,7 @@ static ENGINE_ERROR_CODE do_btree_elem_link(btree_meta_info *info, btree_elem_it
         CLOG_BTREE_ELEM_INSERT(info, NULL, elem);
 
         /* insert the element into the leaf page */
-        elem->status = ELEM_STATUS_LINKED;
+        elem->linked++;
         if (path[0].indx < path[0].node->used_count) {
             for (int i = (path[0].node->used_count-1); i >= path[0].indx; i--) {
                 path[0].node->item[i+1] = path[0].node->item[i];
@@ -2384,7 +2384,8 @@ static uint32_t do_btree_elem_get(btree_meta_info *info,
                     elem_array[tot_found+cur_found] = elem;
                     if (delete) {
                         tot_space += slabs_space_size(do_btree_elem_ntotal(elem));
-                        elem->status = ELEM_STATUS_UNLINKED;
+                        elem->linked--;
+                        assert(elem->linked == 0);
                         c_posi.node->item[c_posi.indx] = NULL;
                         CLOG_BTREE_ELEM_DELETE(info, elem, ELEM_DELETE_NORMAL);
                     }
@@ -3681,7 +3682,7 @@ btree_elem_item *btree_elem_alloc(const uint32_t nbkey, const uint32_t neflag, c
 void btree_elem_free(btree_elem_item *elem)
 {
     LOCK_CACHE();
-    assert(elem->status == ELEM_STATUS_UNLINKED);
+    assert(elem->linked == 0);
     do_btree_elem_free(elem);
     UNLOCK_CACHE();
 }

--- a/engines/default/coll_list.c
+++ b/engines/default/coll_list.c
@@ -132,7 +132,7 @@ static list_elem_item *do_list_elem_alloc(const uint32_t nbytes, const void *coo
 
         elem->refcount    = 0;
         elem->nbytes      = (uint16_t)nbytes;
-        elem->status = ELEM_STATUS_UNLINKED; /* unlinked state */
+        elem->linked      = 0;
     }
     return elem;
 }
@@ -150,7 +150,7 @@ static void do_list_elem_release(list_elem_item *elem)
     if (elem->refcount != 0) {
         elem->refcount--;
     }
-    if (elem->refcount == 0 && elem->status == ELEM_STATUS_UNLINKED) {
+    if (elem->refcount == 0 && elem->linked == 0) {
         do_list_elem_free(elem);
     }
 }
@@ -198,7 +198,7 @@ static ENGINE_ERROR_CODE do_list_elem_link(list_meta_info *info, const int index
     else              prev->next = elem;
     if (next == NULL) info->tail = elem;
     else              next->prev = elem;
-    elem->status = ELEM_STATUS_LINKED;
+    elem->linked++;
     info->ccnt++;
 
     if (1) { /* apply memory space */
@@ -215,7 +215,7 @@ static void do_list_elem_unlink(list_meta_info *info, list_elem_item *elem,
     else                    elem->prev->next = elem->next;
     if (elem->next == NULL) info->tail = elem->prev;
     else                    elem->next->prev = elem->prev;
-    elem->status = ELEM_STATUS_UNLINKED;
+    elem->linked--;
     info->ccnt--;
 
     if (info->stotal > 0) { /* apply memory space */
@@ -223,6 +223,7 @@ static void do_list_elem_unlink(list_meta_info *info, list_elem_item *elem,
         do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_LIST, stotal);
     }
 
+    assert(elem->linked == 0);
     if (elem->refcount == 0) {
         do_list_elem_free(elem);
     }
@@ -388,7 +389,7 @@ list_elem_item *list_elem_alloc(const uint32_t nbytes, const void *cookie)
 void list_elem_free(list_elem_item *elem)
 {
     LOCK_CACHE();
-    assert(elem->status == ELEM_STATUS_UNLINKED);
+    assert(elem->linked == 0);
     do_list_elem_free(elem);
     UNLOCK_CACHE();
 }

--- a/engines/default/coll_map.c
+++ b/engines/default/coll_map.c
@@ -176,7 +176,7 @@ static map_elem_item *do_map_elem_alloc(const int nfield,
         elem->refcount    = 0;
         elem->nfield      = (uint8_t)nfield;
         elem->nbytes      = (uint16_t)nbytes;
-        elem->status = ELEM_STATUS_UNLINKED; /* unlinked state */
+        elem->linked      = 0;
     }
     return elem;
 }
@@ -194,7 +194,7 @@ static void do_map_elem_release(map_elem_item *elem)
     if (elem->refcount != 0) {
         elem->refcount--;
     }
-    if (elem->refcount == 0 && elem->status == ELEM_STATUS_UNLINKED) {
+    if (elem->refcount == 0 && elem->linked == 0) {
         do_map_elem_free(elem);
     }
 }
@@ -302,9 +302,10 @@ static void do_map_elem_replace(map_meta_info *info,
     } else {
         pinfo->node->htab[pinfo->hidx] = new_elem;
     }
-    new_elem->status = ELEM_STATUS_LINKED;
+    new_elem->linked++;
 
-    old_elem->status = ELEM_STATUS_UNLINKED;
+    old_elem->linked--;
+    assert(old_elem->linked == 0);
     if (old_elem->refcount == 0) {
         do_map_elem_free(old_elem);
     }
@@ -403,7 +404,7 @@ static ENGINE_ERROR_CODE do_map_elem_link(map_meta_info *info, map_elem_item *el
     node->htab[hidx] = elem;
     node->hcnt[hidx] += 1;
     node->tot_elem_cnt += 1;
-    elem->status = ELEM_STATUS_LINKED;
+    elem->linked++;
 
     map_hash_node *par_node = info->root;
     while (par_node != node) {
@@ -429,7 +430,7 @@ static void do_map_elem_unlink(map_meta_info *info,
 {
     if (prev != NULL) prev->next = elem->next;
     else              node->htab[hidx] = elem->next;
-    elem->status = ELEM_STATUS_UNLINKED;
+    elem->linked--;
     node->hcnt[hidx] -= 1;
     node->tot_elem_cnt -= 1;
     info->ccnt--;
@@ -441,6 +442,7 @@ static void do_map_elem_unlink(map_meta_info *info,
         do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_MAP, stotal);
     }
 
+    assert(elem->linked == 0);
     if (elem->refcount == 0) {
         do_map_elem_free(elem);
     }
@@ -789,7 +791,7 @@ map_elem_item *map_elem_alloc(const int nfield, const uint32_t nbytes, const voi
 void map_elem_free(map_elem_item *elem)
 {
     LOCK_CACHE();
-    assert(elem->status == ELEM_STATUS_UNLINKED);
+    assert(elem->linked == 0);
     do_map_elem_free(elem);
     UNLOCK_CACHE();
 }

--- a/engines/default/coll_set.c
+++ b/engines/default/coll_set.c
@@ -214,7 +214,7 @@ static set_elem_item *do_set_elem_alloc(const uint32_t nbytes, const void *cooki
 
         elem->refcount    = 0;
         elem->nbytes      = (uint16_t)nbytes;
-        elem->status = ELEM_STATUS_UNLINKED; /* unlinked state */
+        elem->linked      = 0;
     }
     return elem;
 }
@@ -232,7 +232,7 @@ static void do_set_elem_release(set_elem_item *elem)
     if (elem->refcount != 0) {
         elem->refcount--;
     }
-    if (elem->refcount == 0 && elem->status == ELEM_STATUS_UNLINKED) {
+    if (elem->refcount == 0 && elem->linked == 0) {
         do_set_elem_free(elem);
     }
 }
@@ -359,7 +359,7 @@ static ENGINE_ERROR_CODE do_set_elem_link(set_meta_info *info, set_elem_item *el
     node->htab[hidx] = elem;
     node->hcnt[hidx] += 1;
     node->tot_elem_cnt += 1;
-    elem->status = ELEM_STATUS_LINKED;
+    elem->linked++;
 
     set_hash_node *par_node = info->root;
     while (par_node != node) {
@@ -385,7 +385,7 @@ static void do_set_elem_unlink(set_meta_info *info,
 {
     if (prev != NULL) prev->next = elem->next;
     else              node->htab[hidx] = elem->next;
-    elem->status = ELEM_STATUS_UNLINKED;
+    elem->linked--;
     node->hcnt[hidx] -= 1;
     node->tot_elem_cnt -= 1;
     info->ccnt--;
@@ -397,6 +397,7 @@ static void do_set_elem_unlink(set_meta_info *info,
         do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_SET, stotal);
     }
 
+    assert(elem->linked == 0);
     if (elem->refcount == 0) {
         do_set_elem_free(elem);
     }
@@ -770,7 +771,7 @@ set_elem_item *set_elem_alloc(const uint32_t nbytes, const void *cookie)
 void set_elem_free(set_elem_item *elem)
 {
     LOCK_CACHE();
-    assert(elem->status == ELEM_STATUS_UNLINKED);
+    assert(elem->linked == 0);
     do_set_elem_free(elem);
     UNLOCK_CACHE();
 }

--- a/engines/default/item_base.h
+++ b/engines/default/item_base.h
@@ -141,13 +141,6 @@ enum elem_delete_cause {
 /* collection meta info offset */
 #define META_OFFSET_IN_ITEM(nkey,nbytes) ((((nkey)+(nbytes)-1)/8+1)*8)
 
-/* special address for representing unlinked status */
-#define ADDR_MEANS_UNLINKED  1
-
-/* collection element lifecycle status */
-#define ELEM_STATUS_LINKED   1
-#define ELEM_STATUS_UNLINKED 0
-
 /* hash item strtucture */
 typedef struct _hash_item {
     uint16_t refcount;  /* reference count */
@@ -171,7 +164,7 @@ typedef struct _hash_item {
 typedef struct _list_elem_item {
     uint16_t refcount;
     uint8_t  slabs_clsid;         /* which slab class we're in */
-    uint8_t  status;              /* element lifecycle state: linked(in-list) or unlinked(removed but referenced) */
+    uint8_t  linked;              /* link count */
     uint16_t reserved;            /* reserved space */
     uint16_t nbytes;              /* the size of the value */
     struct _list_elem_item *next; /* next chain in double linked list */
@@ -183,7 +176,7 @@ typedef struct _list_elem_item {
 typedef struct _set_elem_item {
     uint16_t refcount;
     uint8_t  slabs_clsid;         /* which slab class we're in */
-    uint8_t  status;              /* element lifecycle state: linked(in-set) or unlinked(removed but referenced) */
+    uint8_t  linked;              /* link count */
     uint16_t reserved;            /* reserved space */
     uint16_t nbytes;              /* the size of the value */
     struct _set_elem_item *next;  /* hash chain next */
@@ -195,7 +188,7 @@ typedef struct _set_elem_item {
 typedef struct _map_elem_item {
     uint16_t refcount;
     uint8_t  slabs_clsid;         /* which slab class we're in */
-    uint8_t  status;              /* element lifecycle state: linked(in-map) or unlinked(removed but referenced) */
+    uint8_t  linked;              /* link count */
     uint8_t  nfield;              /* the size of the field */
     uint8_t  reserved;            /* reserved space */
     uint16_t nbytes;              /* the size of the value */
@@ -208,7 +201,7 @@ typedef struct _map_elem_item {
 typedef struct _btree_elem_item {
     uint16_t refcount;
     uint8_t  slabs_clsid;        /* which slab class we're in */
-    uint8_t  status;             /* element lifecycle state: linked(in-tree) or unlinked(removed but referenced) */
+    uint8_t  linked;             /* link count */
     uint8_t  nbkey;              /* the size of the bkey */
     uint8_t  neflag;             /* the size of the element flag */
     uint16_t nbytes;             /* the size of the value */


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/844#issuecomment-4666821876

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 향후 zset과 같이 elem이 여러 자료구조에 동시에 링크되는 경우를 대비하여 LINKED / UNLINKED로 관리되고 있던 collection elem의 `status`를 link count를 관리하는 `linked`로 변경하였습니다.
- `ELEM_STATUS_LINKED`, `ELEM_STATUS_UNLINKED`, `ADDR_MEANS_UNLINKED` 매크로를 제거하였습니다. 
- linked == 0 && refcount == 0 조건으로 free를 통일하였습니다.