### PR TITLE
CLEANUP: Remove cookie parameter from eviction callback and its callers

### DIFF
--- a/engines/default/coll_btree.c
+++ b/engines/default/coll_btree.c
@@ -211,14 +211,14 @@ static int32_t do_btree_real_maxcount(int32_t maxcount)
 }
 
 static hash_item *do_btree_item_alloc(const void *key, const uint32_t nkey,
-                                      item_attr *attrp, const void *cookie)
+                                      item_attr *attrp)
 {
     uint32_t nbytes = 2; /* "\r\n" */
     uint32_t real_nbytes = META_OFFSET_IN_ITEM(nkey,nbytes)
                          + sizeof(btree_meta_info) - nkey;
 
     hash_item *it = do_item_alloc(key, nkey, attrp->flags, attrp->exptime,
-                                  real_nbytes, cookie);
+                                  real_nbytes);
     if (it != NULL) {
         it->iflag |= ITEM_IFLAG_BTREE;
         it->nbytes = nbytes; /* NOT real_nbytes */
@@ -247,11 +247,11 @@ static hash_item *do_btree_item_alloc(const void *key, const uint32_t nkey,
     return it;
 }
 
-static btree_indx_node *do_btree_node_alloc(const uint8_t node_depth, const void *cookie)
+static btree_indx_node *do_btree_node_alloc(const uint8_t node_depth)
 {
     size_t ntotal = (node_depth > 0 ? sizeof(btree_indx_node) : sizeof(btree_leaf_node));
 
-    btree_indx_node *node = do_item_mem_alloc(ntotal, LRU_CLSID_FOR_SMALL, cookie);
+    btree_indx_node *node = do_item_mem_alloc(ntotal, LRU_CLSID_FOR_SMALL);
     if (node != NULL) {
         node->slabs_clsid = slabs_clsid(ntotal);
         assert(node->slabs_clsid > 0);
@@ -274,11 +274,11 @@ static void do_btree_node_free(btree_indx_node *node)
 }
 
 static btree_elem_item *do_btree_elem_alloc(const uint32_t nbkey, const uint32_t neflag,
-                                            const uint32_t nbytes, const void *cookie)
+                                            const uint32_t nbytes)
 {
     size_t ntotal = sizeof(btree_elem_item) + BTREE_REAL_NBKEY(nbkey) + neflag + nbytes;
 
-    btree_elem_item *elem = do_item_mem_alloc(ntotal, LRU_CLSID_FOR_SMALL, cookie);
+    btree_elem_item *elem = do_item_mem_alloc(ntotal, LRU_CLSID_FOR_SMALL);
     if (elem != NULL) {
         elem->slabs_clsid = slabs_clsid(ntotal);
         assert(elem->slabs_clsid > 0);
@@ -1349,8 +1349,7 @@ static void do_btree_node_link(btree_meta_info *info, btree_indx_node *node,
     }
 }
 
-static ENGINE_ERROR_CODE do_btree_node_split(btree_meta_info *info, btree_elem_posi *path,
-                                             const void *cookie)
+static ENGINE_ERROR_CODE do_btree_node_split(btree_meta_info *info, btree_elem_posi *path)
 {
     ENGINE_ERROR_CODE ret = ENGINE_SUCCESS;
     btree_indx_node *s_node;
@@ -1367,14 +1366,14 @@ static ENGINE_ERROR_CODE do_btree_node_split(btree_meta_info *info, btree_elem_p
             break;
         }
 
-        n_node[btree_depth] = do_btree_node_alloc(btree_depth, cookie);
+        n_node[btree_depth] = do_btree_node_alloc(btree_depth);
         if (n_node[btree_depth] == NULL) {
             ret = ENGINE_ENOMEM; break;
         }
         btree_depth += 1;
         assert(btree_depth < BTREE_MAX_DEPTH);
         if (btree_depth > info->root->ndepth) {
-            btree_indx_node *r_node = do_btree_node_alloc(btree_depth, cookie);
+            btree_indx_node *r_node = do_btree_node_alloc(btree_depth);
             if (r_node == NULL) {
                 ret = ENGINE_ENOMEM; break;
             }
@@ -1716,8 +1715,7 @@ static void do_btree_elem_replace(btree_meta_info *info,
 static ENGINE_ERROR_CODE do_btree_elem_update(btree_meta_info *info,
                                               const int bkrtype, const bkey_range *bkrange,
                                               const eflag_update *eupdate,
-                                              const char *value, const uint32_t nbytes,
-                                              const void *cookie)
+                                              const char *value, const uint32_t nbytes)
 {
     btree_elem_posi  posi;
     btree_elem_item *elem;
@@ -1779,7 +1777,7 @@ static ENGINE_ERROR_CODE do_btree_elem_update(btree_meta_info *info,
          }
 #endif
 
-        btree_elem_item *new_elem = do_btree_elem_alloc(elem->nbkey, new_neflag, new_nbytes, cookie);
+        btree_elem_item *new_elem = do_btree_elem_alloc(elem->nbkey, new_neflag, new_nbytes);
         if (new_elem == NULL) {
             return ENGINE_ENOMEM;
         }
@@ -2191,8 +2189,7 @@ static void do_btree_overflow_trim(btree_meta_info *info,
 
 static ENGINE_ERROR_CODE do_btree_elem_link(btree_meta_info *info, btree_elem_item *elem,
                                             const bool replace_if_exist, bool *replaced,
-                                            btree_elem_item **trimmed_elems, uint32_t *trimmed_count,
-                                            const void *cookie)
+                                            btree_elem_item **trimmed_elems, uint32_t *trimmed_count)
 {
     btree_elem_posi path[BTREE_MAX_DEPTH];
     int ovfl_type = OVFL_TYPE_NONE;
@@ -2211,7 +2208,7 @@ static ENGINE_ERROR_CODE do_btree_elem_link(btree_meta_info *info, btree_elem_it
 
         /* If the leaf node is full of elements, split it ahead. */
         if (path[0].node->used_count >= BTREE_ITEM_COUNT) {
-            res = do_btree_node_split(info, path, cookie);
+            res = do_btree_node_split(info, path);
             if (res != ENGINE_SUCCESS) {
                 return res;
             }
@@ -2533,7 +2530,7 @@ static uint32_t do_btree_elem_count(btree_meta_info *info,
 static ENGINE_ERROR_CODE do_btree_elem_insert(hash_item *it, btree_elem_item *elem,
                                               const bool replace_if_exist, bool *replaced,
                                               btree_elem_item **trimmed_elems,
-                                              uint32_t *trimmed_count, const void *cookie)
+                                              uint32_t *trimmed_count)
 {
     btree_meta_info *info = (btree_meta_info *)item_get_meta(it);
     ENGINE_ERROR_CODE ret;
@@ -2553,7 +2550,7 @@ static ENGINE_ERROR_CODE do_btree_elem_insert(hash_item *it, btree_elem_item *el
     /* create the root node if it does not exist */
     bool new_root_flag = false;
     if (info->root == NULL) {
-        btree_indx_node *r_node = do_btree_node_alloc(0, cookie);
+        btree_indx_node *r_node = do_btree_node_alloc(0);
         if (r_node == NULL) {
             return ENGINE_ENOMEM;
         }
@@ -2563,7 +2560,7 @@ static ENGINE_ERROR_CODE do_btree_elem_insert(hash_item *it, btree_elem_item *el
 
     /* insert the element */
     ret = do_btree_elem_link(info, elem, replace_if_exist, replaced,
-                             trimmed_elems, trimmed_count, cookie);
+                             trimmed_elems, trimmed_count);
     if (ret != ENGINE_SUCCESS) {
         if (new_root_flag) {
             do_btree_node_unlink(info, info->root, NULL);
@@ -2579,7 +2576,7 @@ static ENGINE_ERROR_CODE do_btree_elem_arithmetic(btree_meta_info *info,
                                                   const bool increment, const bool create,
                                                   const uint64_t delta, const uint64_t initial,
                                                   const eflag_t *eflagp,
-                                                  uint64_t *result, const void *cookie)
+                                                  uint64_t *result)
 {
     ENGINE_ERROR_CODE ret;
     btree_elem_item *elem;
@@ -2604,7 +2601,7 @@ static ENGINE_ERROR_CODE do_btree_elem_arithmetic(btree_meta_info *info,
 
         elem = do_btree_elem_alloc(bkrange->from_nbkey,
                                    (eflagp == NULL || eflagp->len == EFLAG_NULL ? 0 : eflagp->len),
-                                   nlen, cookie);
+                                   nlen);
         if (elem == NULL) {
             return ENGINE_ENOMEM;
         }
@@ -2618,7 +2615,7 @@ static ENGINE_ERROR_CODE do_btree_elem_arithmetic(btree_meta_info *info,
             memcpy(elem->data + real_nbkey + eflagp->len, nbuf, nlen);
         }
 
-        ret = do_btree_elem_link(info, elem, false, NULL, NULL, NULL, cookie);
+        ret = do_btree_elem_link(info, elem, false, NULL, NULL, NULL);
         if (ret != ENGINE_SUCCESS) {
             assert(ret != ENGINE_ELEM_EEXISTS);
             /* ENGINE_ENOMEM || ENGINE_BKEYOOR || ENGINE_OVERFLOW */
@@ -2653,7 +2650,7 @@ static ENGINE_ERROR_CODE do_btree_elem_arithmetic(btree_meta_info *info,
              * Because, the space difference is negligible.
              */
 #endif
-            btree_elem_item *new_elem = do_btree_elem_alloc(elem->nbkey, elem->neflag, nlen, cookie);
+            btree_elem_item *new_elem = do_btree_elem_alloc(elem->nbkey, elem->neflag, nlen);
             if (new_elem == NULL) {
                 return ENGINE_ENOMEM;
             }
@@ -3655,7 +3652,7 @@ ENGINE_ERROR_CODE btree_struct_create(const char *key, const uint32_t nkey,
         do_item_release(it);
         ret = ENGINE_KEY_EEXISTS;
     } else {
-        it = do_btree_item_alloc(key, nkey, attrp, cookie);
+        it = do_btree_item_alloc(key, nkey, attrp);
         if (it == NULL) {
             ret = ENGINE_ENOMEM;
         } else {
@@ -3669,12 +3666,11 @@ ENGINE_ERROR_CODE btree_struct_create(const char *key, const uint32_t nkey,
     return ret;
 }
 
-btree_elem_item *btree_elem_alloc(const uint32_t nbkey, const uint32_t neflag, const uint32_t nbytes,
-                                  const void *cookie)
+btree_elem_item *btree_elem_alloc(const uint32_t nbkey, const uint32_t neflag, const uint32_t nbytes)
 {
     btree_elem_item *elem;
     LOCK_CACHE();
-    elem = do_btree_elem_alloc(nbkey, neflag, nbytes, cookie);
+    elem = do_btree_elem_alloc(nbkey, neflag, nbytes);
     UNLOCK_CACHE();
     return elem;
 }
@@ -3722,7 +3718,7 @@ ENGINE_ERROR_CODE btree_elem_insert(const char *key, const uint32_t nkey,
     LOCK_CACHE();
     ret = do_btree_item_find(key, nkey, DONT_UPDATE, &it);
     if (ret == ENGINE_KEY_ENOENT && attrp != NULL) {
-        it = do_btree_item_alloc(key, nkey, attrp, cookie);
+        it = do_btree_item_alloc(key, nkey, attrp);
         if (it == NULL) {
             ret = ENGINE_ENOMEM;
         } else {
@@ -3734,7 +3730,7 @@ ENGINE_ERROR_CODE btree_elem_insert(const char *key, const uint32_t nkey,
     }
     if (ret == ENGINE_SUCCESS) {
         ret = do_btree_elem_insert(it, elem, replace_if_exist, replaced,
-                                   trimmed_elems, trimmed_count, cookie);
+                                   trimmed_elems, trimmed_count);
         if (ret != ENGINE_SUCCESS && *created) {
             do_item_unlink(it, ITEM_UNLINK_NORMAL);
         }
@@ -3773,7 +3769,7 @@ ENGINE_ERROR_CODE btree_elem_update(const char *key, const uint32_t nkey, const 
                 (info->bktype == BKEY_TYPE_BINARY && bkrange->from_nbkey == 0)) {
                 ret = ENGINE_EBADBKEY; break;
             }
-            ret = do_btree_elem_update(info, bkrtype, bkrange, eupdate, value, nbytes, cookie);
+            ret = do_btree_elem_update(info, bkrtype, bkrange, eupdate, value, nbytes);
         } while(0);
         do_item_release(it);
     }
@@ -3856,7 +3852,7 @@ ENGINE_ERROR_CODE btree_elem_arithmetic(const char *key, const uint32_t nkey,
             }
             if (info->root == NULL && create == true) {
                 /* create new root node */
-                btree_indx_node *r_node = do_btree_node_alloc(0, cookie);
+                btree_indx_node *r_node = do_btree_node_alloc(0);
                 if (r_node == NULL) {
                     ret = ENGINE_ENOMEM; break;
                 }
@@ -3864,7 +3860,7 @@ ENGINE_ERROR_CODE btree_elem_arithmetic(const char *key, const uint32_t nkey,
                 new_root_flag = true;
             }
             ret = do_btree_elem_arithmetic(info, bkrtype, bkrange, increment, create,
-                                           delta, initial, eflagp, result, cookie);
+                                           delta, initial, eflagp, result);
             if (ret != ENGINE_SUCCESS) {
                 if (new_root_flag) {
                     /* unlink the root node and free it */
@@ -4388,7 +4384,7 @@ ENGINE_ERROR_CODE btree_apply_item_link(void *engine, const char *key, const uin
         do_item_unlink(old_it, ITEM_UNLINK_NORMAL);
         do_item_release(old_it);
     }
-    new_it = do_btree_item_alloc(key, nkey, attrp, NULL); /* cookie is NULL */
+    new_it = do_btree_item_alloc(key, nkey, attrp);
     if (new_it) {
         /* Copy relevent fields in meta info */
         btree_meta_info *info = (btree_meta_info*)item_get_meta(new_it);
@@ -4440,7 +4436,7 @@ ENGINE_ERROR_CODE btree_apply_elem_insert(void *engine, hash_item *it,
             ret = ENGINE_KEY_ENOENT; break;
         }
 
-        elem = do_btree_elem_alloc(nbkey, neflag, nbytes, NULL);
+        elem = do_btree_elem_alloc(nbkey, neflag, nbytes);
         if (elem == NULL) {
             logger->log(EXTENSION_LOG_WARNING, NULL, "btree_apply_elem_insert failed."
                         " element alloc failed. nbkey=%d neflag=%d nbytes=%d\n", nbkey, neflag, nbytes);
@@ -4449,7 +4445,7 @@ ENGINE_ERROR_CODE btree_apply_elem_insert(void *engine, hash_item *it,
         memcpy(elem->data, bkey, BTREE_REAL_NBKEY(nbkey) + neflag + nbytes);
 
         ret = do_btree_elem_insert(it, elem, true /* replace_if_exist */,
-                                   &replaced, NULL, NULL, NULL);
+                                   &replaced, NULL, NULL);
         if (ret != ENGINE_SUCCESS) {
             do_btree_elem_free(elem);
             logger->log(EXTENSION_LOG_WARNING, NULL, "btree_apply_elem_insert failed."

--- a/engines/default/coll_btree.h
+++ b/engines/default/coll_btree.h
@@ -26,8 +26,7 @@
 ENGINE_ERROR_CODE btree_struct_create(const char *key, const uint32_t nkey,
                                       item_attr *attrp, const void *cookie);
 
-btree_elem_item *btree_elem_alloc(const uint32_t nbkey, const uint32_t neflag, const uint32_t nbytes,
-                                  const void *cookie);
+btree_elem_item *btree_elem_alloc(const uint32_t nbkey, const uint32_t neflag, const uint32_t nbytes);
 
 void btree_elem_free(btree_elem_item *elem);
 

--- a/engines/default/coll_list.c
+++ b/engines/default/coll_list.c
@@ -90,14 +90,14 @@ static int32_t do_list_real_maxcount(int32_t maxcount)
 }
 
 static hash_item *do_list_item_alloc(const void *key, const uint32_t nkey,
-                                     item_attr *attrp, const void *cookie)
+                                     item_attr *attrp)
 {
     uint32_t nbytes = 2; /* "\r\n" */
     uint32_t real_nbytes = META_OFFSET_IN_ITEM(nkey,nbytes)
                          + sizeof(list_meta_info) - nkey;
 
     hash_item *it = do_item_alloc(key, nkey, attrp->flags, attrp->exptime,
-                                  real_nbytes, cookie);
+                                  real_nbytes);
     if (it != NULL) {
         it->iflag |= ITEM_IFLAG_LIST;
         it->nbytes = nbytes; /* NOT real_nbytes */
@@ -121,11 +121,11 @@ static hash_item *do_list_item_alloc(const void *key, const uint32_t nkey,
     return it;
 }
 
-static list_elem_item *do_list_elem_alloc(const uint32_t nbytes, const void *cookie)
+static list_elem_item *do_list_elem_alloc(const uint32_t nbytes)
 {
     size_t ntotal = sizeof(list_elem_item) + nbytes;
 
-    list_elem_item *elem = do_item_mem_alloc(ntotal, LRU_CLSID_FOR_SMALL, cookie);
+    list_elem_item *elem = do_item_mem_alloc(ntotal, LRU_CLSID_FOR_SMALL);
     if (elem != NULL) {
         elem->slabs_clsid = slabs_clsid(ntotal);
         assert(elem->slabs_clsid > 0);
@@ -278,8 +278,7 @@ static uint32_t do_list_elem_get(list_meta_info *info,
 }
 
 static ENGINE_ERROR_CODE do_list_elem_insert(hash_item *it,
-                                             int index, list_elem_item *elem,
-                                             const void *cookie)
+                                             int index, list_elem_item *elem)
 {
     list_meta_info *info = (list_meta_info *)item_get_meta(it);
     uint32_t real_mcnt = (info->mcnt > 0 ? info->mcnt : config->max_list_size);
@@ -363,7 +362,7 @@ ENGINE_ERROR_CODE list_struct_create(const char *key, const uint32_t nkey,
         do_item_release(it);
         ret = ENGINE_KEY_EEXISTS;
     } else {
-        it = do_list_item_alloc(key, nkey, attrp, cookie);
+        it = do_list_item_alloc(key, nkey, attrp);
         if (it == NULL) {
             ret = ENGINE_ENOMEM;
         } else {
@@ -377,11 +376,11 @@ ENGINE_ERROR_CODE list_struct_create(const char *key, const uint32_t nkey,
     return ret;
 }
 
-list_elem_item *list_elem_alloc(const uint32_t nbytes, const void *cookie)
+list_elem_item *list_elem_alloc(const uint32_t nbytes)
 {
     list_elem_item *elem;
     LOCK_CACHE();
-    elem = do_list_elem_alloc(nbytes, cookie);
+    elem = do_list_elem_alloc(nbytes);
     UNLOCK_CACHE();
     return elem;
 }
@@ -422,7 +421,7 @@ ENGINE_ERROR_CODE list_elem_insert(const char *key, const uint32_t nkey,
     LOCK_CACHE();
     ret = do_list_item_find(key, nkey, DONT_UPDATE, &it);
     if (ret == ENGINE_KEY_ENOENT && attrp != NULL) {
-        it = do_list_item_alloc(key, nkey, attrp, cookie);
+        it = do_list_item_alloc(key, nkey, attrp);
         if (it == NULL) {
             ret = ENGINE_ENOMEM;
         } else {
@@ -433,7 +432,7 @@ ENGINE_ERROR_CODE list_elem_insert(const char *key, const uint32_t nkey,
         }
     }
     if (ret == ENGINE_SUCCESS) {
-        ret = do_list_elem_insert(it, index, elem, cookie);
+        ret = do_list_elem_insert(it, index, elem);
         if (ret != ENGINE_SUCCESS && *created) {
             do_item_unlink(it, ITEM_UNLINK_NORMAL);
         }
@@ -683,7 +682,7 @@ ENGINE_ERROR_CODE list_apply_item_link(void *engine, const char *key, const uint
         do_item_unlink(old_it, ITEM_UNLINK_NORMAL);
         do_item_release(old_it);
     }
-    new_it = do_list_item_alloc(key, nkey, attrp, NULL); /* cookie is NULL */
+    new_it = do_list_item_alloc(key, nkey, attrp);
     if (new_it) {
         /* Link the new item into the hash table */
         ret = do_item_link(new_it);
@@ -735,7 +734,7 @@ ENGINE_ERROR_CODE list_apply_elem_insert(void *engine, hash_item *it,
             ret = ENGINE_EINVAL; break;
         }
 
-        elem = do_list_elem_alloc(nbytes, NULL);
+        elem = do_list_elem_alloc(nbytes);
         if (elem == NULL) {
             logger->log(EXTENSION_LOG_WARNING, NULL, "list_apply_elem_insert failed."
                         " element alloc failed. nbytes=%d\n", nbytes);
@@ -743,7 +742,7 @@ ENGINE_ERROR_CODE list_apply_elem_insert(void *engine, hash_item *it,
         }
         memcpy(elem->value, value, nbytes);
 
-        ret = do_list_elem_insert(it, index, elem, NULL);
+        ret = do_list_elem_insert(it, index, elem);
         if (ret != ENGINE_SUCCESS) {
             do_list_elem_free(elem);
             logger->log(EXTENSION_LOG_WARNING, NULL, "list_apply_elem_insert failed."

--- a/engines/default/coll_list.h
+++ b/engines/default/coll_list.h
@@ -26,7 +26,7 @@
 ENGINE_ERROR_CODE list_struct_create(const char *key, const uint32_t nkey,
                                      item_attr *attrp, const void *cookie);
 
-list_elem_item *list_elem_alloc(const uint32_t nbytes, const void *cookie);
+list_elem_item *list_elem_alloc(const uint32_t nbytes);
 
 void list_elem_free(list_elem_item *elem);
 

--- a/engines/default/coll_map.c
+++ b/engines/default/coll_map.c
@@ -109,14 +109,14 @@ static int32_t do_map_real_maxcount(int32_t maxcount)
 }
 
 static hash_item *do_map_item_alloc(const void *key, const uint32_t nkey,
-                                    item_attr *attrp, const void *cookie)
+                                    item_attr *attrp)
 {
     uint32_t nbytes = 2; /* "\r\n" */
     uint32_t real_nbytes = META_OFFSET_IN_ITEM(nkey,nbytes)
                          + sizeof(map_meta_info) - nkey;
 
     hash_item *it = do_item_alloc(key, nkey, attrp->flags, attrp->exptime,
-                                  real_nbytes, cookie);
+                                  real_nbytes);
     if (it != NULL) {
         it->iflag |= ITEM_IFLAG_MAP;
         it->nbytes = nbytes; /* NOT real_nbytes */
@@ -140,11 +140,11 @@ static hash_item *do_map_item_alloc(const void *key, const uint32_t nkey,
     return it;
 }
 
-static map_hash_node *do_map_node_alloc(uint8_t hash_depth, const void *cookie)
+static map_hash_node *do_map_node_alloc(uint8_t hash_depth)
 {
     size_t ntotal = sizeof(map_hash_node);
 
-    map_hash_node *node = do_item_mem_alloc(ntotal, LRU_CLSID_FOR_SMALL, cookie);
+    map_hash_node *node = do_item_mem_alloc(ntotal, LRU_CLSID_FOR_SMALL);
     if (node != NULL) {
         node->slabs_clsid = slabs_clsid(ntotal);
         assert(node->slabs_clsid > 0);
@@ -164,11 +164,11 @@ static void do_map_node_free(map_hash_node *node)
 }
 
 static map_elem_item *do_map_elem_alloc(const int nfield,
-                                        const uint32_t nbytes, const void *cookie)
+                                        const uint32_t nbytes)
 {
     size_t ntotal = sizeof(map_elem_item) + nfield + nbytes;
 
-    map_elem_item *elem = do_item_mem_alloc(ntotal, LRU_CLSID_FOR_SMALL, cookie);
+    map_elem_item *elem = do_item_mem_alloc(ntotal, LRU_CLSID_FOR_SMALL);
     if (elem != NULL) {
         elem->slabs_clsid = slabs_clsid(ntotal);
         assert(elem->slabs_clsid > 0);
@@ -321,8 +321,7 @@ static void do_map_elem_replace(map_meta_info *info,
 }
 
 static ENGINE_ERROR_CODE do_map_elem_link(map_meta_info *info, map_elem_item *elem,
-                                          const bool replace_if_exist, bool *replaced,
-                                          const void *cookie)
+                                          const bool replace_if_exist, bool *replaced)
 {
     assert(info->root != NULL);
     map_hash_node *node = info->root;
@@ -387,7 +386,7 @@ static ENGINE_ERROR_CODE do_map_elem_link(map_meta_info *info, map_elem_item *el
     }
 
     if (node->hcnt[hidx] >= MAP_MAX_HASHCHAIN_SIZE) {
-        map_hash_node *n_node = do_map_node_alloc(node->hdepth+1, cookie);
+        map_hash_node *n_node = do_map_node_alloc(node->hdepth+1);
         if (n_node == NULL) {
             res = ENGINE_ENOMEM;
             return res;
@@ -640,7 +639,7 @@ static map_elem_item *do_map_elem_find(map_hash_node *node, const field_t *field
 
 static ENGINE_ERROR_CODE do_map_elem_update(map_meta_info *info,
                                             const field_t *field, const char *value,
-                                            const uint32_t nbytes, const void *cookie)
+                                            const uint32_t nbytes)
 {
     map_prev_info  pinfo;
     map_elem_item *elem;
@@ -671,7 +670,7 @@ static ENGINE_ERROR_CODE do_map_elem_update(map_meta_info *info,
         }
 #endif
 
-        map_elem_item *new_elem = do_map_elem_alloc(elem->nfield, nbytes, cookie);
+        map_elem_item *new_elem = do_map_elem_alloc(elem->nfield, nbytes);
         if (new_elem == NULL) {
             return ENGINE_ENOMEM;
         }
@@ -720,8 +719,7 @@ static uint32_t do_map_elem_get(map_meta_info *info,
 }
 
 static ENGINE_ERROR_CODE do_map_elem_insert(hash_item *it, map_elem_item *elem,
-                                            const bool replace_if_exist, bool *replaced,
-                                            const void *cookie)
+                                            const bool replace_if_exist, bool *replaced)
 {
     map_meta_info *info = (map_meta_info *)item_get_meta(it);
     ENGINE_ERROR_CODE ret;
@@ -729,7 +727,7 @@ static ENGINE_ERROR_CODE do_map_elem_insert(hash_item *it, map_elem_item *elem,
     /* create the root hash node if it does not exist */
     bool new_root_flag = false;
     if (info->root == NULL) { /* empty map */
-        map_hash_node *r_node = do_map_node_alloc(0, cookie);
+        map_hash_node *r_node = do_map_node_alloc(0);
         if (r_node == NULL) {
             return ENGINE_ENOMEM;
         }
@@ -738,7 +736,7 @@ static ENGINE_ERROR_CODE do_map_elem_insert(hash_item *it, map_elem_item *elem,
     }
 
     /* insert the element */
-    ret = do_map_elem_link(info, elem, replace_if_exist, replaced, cookie);
+    ret = do_map_elem_link(info, elem, replace_if_exist, replaced);
     if (ret != ENGINE_SUCCESS) {
         if (new_root_flag) {
             do_map_node_unlink(info, NULL, 0);
@@ -765,7 +763,7 @@ ENGINE_ERROR_CODE map_struct_create(const char *key, const uint32_t nkey,
         do_item_release(it);
         ret = ENGINE_KEY_EEXISTS;
     } else {
-        it = do_map_item_alloc(key, nkey, attrp, cookie);
+        it = do_map_item_alloc(key, nkey, attrp);
         if (it == NULL) {
             ret = ENGINE_ENOMEM;
         } else {
@@ -779,11 +777,11 @@ ENGINE_ERROR_CODE map_struct_create(const char *key, const uint32_t nkey,
     return ret;
 }
 
-map_elem_item *map_elem_alloc(const int nfield, const uint32_t nbytes, const void *cookie)
+map_elem_item *map_elem_alloc(const int nfield, const uint32_t nbytes)
 {
     map_elem_item *elem;
     LOCK_CACHE();
-    elem = do_map_elem_alloc(nfield, nbytes, cookie);
+    elem = do_map_elem_alloc(nfield, nbytes);
     UNLOCK_CACHE();
     return elem;
 }
@@ -825,7 +823,7 @@ ENGINE_ERROR_CODE map_elem_insert(const char *key, const uint32_t nkey,
     LOCK_CACHE();
     ret = do_map_item_find(key, nkey, DONT_UPDATE, &it);
     if (ret == ENGINE_KEY_ENOENT && attrp != NULL) {
-        it = do_map_item_alloc(key, nkey, attrp, cookie);
+        it = do_map_item_alloc(key, nkey, attrp);
         if (it == NULL) {
             ret = ENGINE_ENOMEM;
         } else {
@@ -836,7 +834,7 @@ ENGINE_ERROR_CODE map_elem_insert(const char *key, const uint32_t nkey,
         }
     }
     if (ret == ENGINE_SUCCESS) {
-        ret = do_map_elem_insert(it, elem, replace_if_exist, replaced, cookie);
+        ret = do_map_elem_insert(it, elem, replace_if_exist, replaced);
         if (ret != ENGINE_SUCCESS && *created) {
             do_item_unlink(it, ITEM_UNLINK_NORMAL);
         }
@@ -862,7 +860,7 @@ ENGINE_ERROR_CODE map_elem_update(const char *key, const uint32_t nkey,
     ret = do_map_item_find(key, nkey, DONT_UPDATE, &it);
     if (ret == ENGINE_SUCCESS) { /* it != NULL */
         map_meta_info *info = (map_meta_info *)item_get_meta(it);
-        ret = do_map_elem_update(info, field, value, nbytes, cookie);
+        ret = do_map_elem_update(info, field, value, nbytes);
         do_item_release(it);
     }
     UNLOCK_CACHE();
@@ -1065,7 +1063,7 @@ ENGINE_ERROR_CODE map_apply_item_link(void *engine, const char *key, const uint3
         do_item_unlink(old_it, ITEM_UNLINK_NORMAL);
         do_item_release(old_it);
     }
-    new_it = do_map_item_alloc(key, nkey, attrp, NULL); /* cookie is NULL */
+    new_it = do_map_item_alloc(key, nkey, attrp);
     if (new_it) {
         /* Link the new item into the hash table */
         ret = do_item_link(new_it);
@@ -1109,7 +1107,7 @@ ENGINE_ERROR_CODE map_apply_elem_insert(void *engine, hash_item *it,
             ret = ENGINE_KEY_ENOENT; break;
         }
 
-        elem = do_map_elem_alloc(nfield, nbytes, NULL);
+        elem = do_map_elem_alloc(nfield, nbytes);
         if (elem == NULL) {
             logger->log(EXTENSION_LOG_WARNING, NULL, "map_apply_elem_insert failed."
                         " element alloc failed. nfield=%d nbytes=%d\n", nfield, nbytes);
@@ -1117,7 +1115,7 @@ ENGINE_ERROR_CODE map_apply_elem_insert(void *engine, hash_item *it,
         }
         memcpy(elem->data, field, nfield + nbytes);
 
-        ret = do_map_elem_insert(it, elem, true /* replace_if_exist */, &replaced, NULL);
+        ret = do_map_elem_insert(it, elem, true /* replace_if_exist */, &replaced);
         if (ret != ENGINE_SUCCESS) {
             do_map_elem_free(elem);
             logger->log(EXTENSION_LOG_WARNING, NULL, "map_apply_elem_insert failed."

--- a/engines/default/coll_map.h
+++ b/engines/default/coll_map.h
@@ -26,8 +26,7 @@
 ENGINE_ERROR_CODE map_struct_create(const char *key, const uint32_t nkey,
                                     item_attr *attrp, const void *cookie);
 
-map_elem_item *map_elem_alloc(const int nfield,
-                              const uint32_t nbytes, const void *cookie);
+map_elem_item *map_elem_alloc(const int nfield, const uint32_t nbytes);
 
 void map_elem_free(map_elem_item *elem);
 

--- a/engines/default/coll_set.c
+++ b/engines/default/coll_set.c
@@ -149,14 +149,14 @@ static int32_t do_set_real_maxcount(int32_t maxcount)
 }
 
 static hash_item *do_set_item_alloc(const void *key, const uint32_t nkey,
-                                    item_attr *attrp, const void *cookie)
+                                    item_attr *attrp)
 {
     uint32_t nbytes = 2; /* "\r\n" */
     uint32_t real_nbytes = META_OFFSET_IN_ITEM(nkey,nbytes)
                          + sizeof(set_meta_info) - nkey;
 
     hash_item *it = do_item_alloc(key, nkey, attrp->flags, attrp->exptime,
-                                  real_nbytes, cookie);
+                                  real_nbytes);
     if (it != NULL) {
         it->iflag |= ITEM_IFLAG_SET;
         it->nbytes = nbytes; /* NOT real_nbytes */
@@ -180,11 +180,11 @@ static hash_item *do_set_item_alloc(const void *key, const uint32_t nkey,
     return it;
 }
 
-static set_hash_node *do_set_node_alloc(uint8_t hash_depth, const void *cookie)
+static set_hash_node *do_set_node_alloc(uint8_t hash_depth)
 {
     size_t ntotal = sizeof(set_hash_node);
 
-    set_hash_node *node = do_item_mem_alloc(ntotal, LRU_CLSID_FOR_SMALL, cookie);
+    set_hash_node *node = do_item_mem_alloc(ntotal, LRU_CLSID_FOR_SMALL);
     if (node != NULL) {
         node->slabs_clsid = slabs_clsid(ntotal);
         assert(node->slabs_clsid > 0);
@@ -203,11 +203,11 @@ static void do_set_node_free(set_hash_node *node)
     do_item_mem_free(node, sizeof(set_hash_node));
 }
 
-static set_elem_item *do_set_elem_alloc(const uint32_t nbytes, const void *cookie)
+static set_elem_item *do_set_elem_alloc(const uint32_t nbytes)
 {
     size_t ntotal = sizeof(set_elem_item) + nbytes;
 
-    set_elem_item *elem = do_item_mem_alloc(ntotal, LRU_CLSID_FOR_SMALL, cookie);
+    set_elem_item *elem = do_item_mem_alloc(ntotal, LRU_CLSID_FOR_SMALL);
     if (elem != NULL) {
         elem->slabs_clsid = slabs_clsid(ntotal);
         assert(elem->slabs_clsid > 0);
@@ -315,8 +315,7 @@ static void do_set_node_unlink(set_meta_info *info,
     do_set_node_free(node);
 }
 
-static ENGINE_ERROR_CODE do_set_elem_link(set_meta_info *info, set_elem_item *elem,
-                                          const void *cookie)
+static ENGINE_ERROR_CODE do_set_elem_link(set_meta_info *info, set_elem_item *elem)
 {
     assert(info->root != NULL);
     set_hash_node *node = info->root;
@@ -345,7 +344,7 @@ static ENGINE_ERROR_CODE do_set_elem_link(set_meta_info *info, set_elem_item *el
     }
 
     if (node->hcnt[hidx] >= SET_MAX_HASHCHAIN_SIZE) {
-        set_hash_node *n_node = do_set_node_alloc(node->hdepth+1, cookie);
+        set_hash_node *n_node = do_set_node_alloc(node->hdepth+1);
         if (n_node == NULL) {
             return ENGINE_ENOMEM;
         }
@@ -684,8 +683,7 @@ static uint32_t do_set_elem_get(set_meta_info *info,
     return fcnt;
 }
 
-static ENGINE_ERROR_CODE do_set_elem_insert(hash_item *it, set_elem_item *elem,
-                                            const void *cookie)
+static ENGINE_ERROR_CODE do_set_elem_insert(hash_item *it, set_elem_item *elem)
 {
     set_meta_info *info = (set_meta_info *)item_get_meta(it);
     uint32_t real_mcnt = (info->mcnt > 0 ? info->mcnt : config->max_set_size);
@@ -708,7 +706,7 @@ static ENGINE_ERROR_CODE do_set_elem_insert(hash_item *it, set_elem_item *elem,
     /* create the root hash node if it does not exist */
     bool new_root_flag = false;
     if (info->root == NULL) { /* empty set */
-        set_hash_node *r_node = do_set_node_alloc(0, cookie);
+        set_hash_node *r_node = do_set_node_alloc(0);
         if (r_node == NULL) {
             return ENGINE_ENOMEM;
         }
@@ -717,7 +715,7 @@ static ENGINE_ERROR_CODE do_set_elem_insert(hash_item *it, set_elem_item *elem,
     }
 
     /* insert the element */
-    ret = do_set_elem_link(info, elem, cookie);
+    ret = do_set_elem_link(info, elem);
     if (ret != ENGINE_SUCCESS) {
         if (new_root_flag) {
             do_set_node_unlink(info, NULL, 0);
@@ -745,7 +743,7 @@ ENGINE_ERROR_CODE set_struct_create(const char *key, const uint32_t nkey,
         do_item_release(it);
         ret = ENGINE_KEY_EEXISTS;
     } else {
-        it = do_set_item_alloc(key, nkey, attrp, cookie);
+        it = do_set_item_alloc(key, nkey, attrp);
         if (it == NULL) {
             ret = ENGINE_ENOMEM;
         } else {
@@ -759,11 +757,11 @@ ENGINE_ERROR_CODE set_struct_create(const char *key, const uint32_t nkey,
     return ret;
 }
 
-set_elem_item *set_elem_alloc(const uint32_t nbytes, const void *cookie)
+set_elem_item *set_elem_alloc(const uint32_t nbytes)
 {
     set_elem_item *elem;
     LOCK_CACHE();
-    elem = do_set_elem_alloc(nbytes, cookie);
+    elem = do_set_elem_alloc(nbytes);
     UNLOCK_CACHE();
     return elem;
 }
@@ -803,7 +801,7 @@ ENGINE_ERROR_CODE set_elem_insert(const char *key, const uint32_t nkey,
     LOCK_CACHE();
     ret = do_set_item_find(key, nkey, DONT_UPDATE, &it);
     if (ret == ENGINE_KEY_ENOENT && attrp != NULL) {
-        it = do_set_item_alloc(key, nkey, attrp, cookie);
+        it = do_set_item_alloc(key, nkey, attrp);
         if (it == NULL) {
             ret = ENGINE_ENOMEM;
         } else {
@@ -814,7 +812,7 @@ ENGINE_ERROR_CODE set_elem_insert(const char *key, const uint32_t nkey,
         }
     }
     if (ret == ENGINE_SUCCESS) {
-        ret = do_set_elem_insert(it, elem, cookie);
+        ret = do_set_elem_insert(it, elem);
         if (ret != ENGINE_SUCCESS && *created) {
             do_item_unlink(it, ITEM_UNLINK_NORMAL);
         }
@@ -1046,7 +1044,7 @@ ENGINE_ERROR_CODE set_apply_item_link(void *engine, const char *key, const uint3
         do_item_unlink(old_it, ITEM_UNLINK_NORMAL);
         do_item_release(old_it);
     }
-    new_it = do_set_item_alloc(key, nkey, attrp, NULL); /* cookie is NULL */
+    new_it = do_set_item_alloc(key, nkey, attrp);
     if (new_it) {
         /* Link the new item into the hash table */
         ret = do_item_link(new_it);
@@ -1088,7 +1086,7 @@ ENGINE_ERROR_CODE set_apply_elem_insert(void *engine, hash_item *it,
             ret = ENGINE_KEY_ENOENT; break;
         }
 
-        elem = do_set_elem_alloc(nbytes, NULL);
+        elem = do_set_elem_alloc(nbytes);
         if (elem == NULL) {
             logger->log(EXTENSION_LOG_WARNING, NULL, "set_apply_elem_insert failed."
                         " element alloc failed. nbytes=%d\n", nbytes);
@@ -1096,7 +1094,7 @@ ENGINE_ERROR_CODE set_apply_elem_insert(void *engine, hash_item *it,
         }
         memcpy(elem->value, value, nbytes);
 
-        ret = do_set_elem_insert(it, elem, NULL);
+        ret = do_set_elem_insert(it, elem);
         if (ret != ENGINE_SUCCESS) {
             do_set_elem_free(elem);
             logger->log(EXTENSION_LOG_WARNING, NULL, "set_apply_elem_insert failed."

--- a/engines/default/coll_set.h
+++ b/engines/default/coll_set.h
@@ -26,7 +26,7 @@
 ENGINE_ERROR_CODE set_struct_create(const char *key, const uint32_t nkey,
                                     item_attr *attrp, const void *cookie);
 
-set_elem_item *set_elem_alloc(const uint32_t nbytes, const void *cookie);
+set_elem_item *set_elem_alloc(const uint32_t nbytes);
 
 void set_elem_free(set_elem_item *elem);
 

--- a/engines/default/default_engine.c
+++ b/engines/default/default_engine.c
@@ -348,7 +348,7 @@ default_item_allocate(ENGINE_HANDLE* handle, const void* cookie,
     ENGINE_ERROR_CODE ret = ENGINE_EINVAL;
 
     ACTION_BEFORE_WRITE(cookie, key, nkey);
-    it = item_alloc(key, nkey, flags, exptime, nbytes, cookie);
+    it = item_alloc(key, nkey, flags, exptime, nbytes);
     ACTION_AFTER_WRITE(cookie, get_handle(handle), ret);
     if (it != NULL) {
         item_set_cas(it, cas);
@@ -415,7 +415,7 @@ default_store(ENGINE_HANDLE* handle, const void *cookie,
     VBUCKET_GUARD(engine, vbucket);
 
     ACTION_BEFORE_WRITE(cookie, item_get_key(it), it->nkey);
-    ret = item_store(it, cas, operation, cookie);
+    ret = item_store(it, cas, operation);
     ACTION_AFTER_WRITE(cookie, engine, ret);
     return ret;
 }
@@ -479,7 +479,7 @@ default_list_elem_alloc(ENGINE_HANDLE* handle, const void* cookie,
     ENGINE_ERROR_CODE ret = ENGINE_EINVAL; // See ACTION_AFTER_WRITE()
 
     ACTION_BEFORE_WRITE(cookie, key, nkey);
-    elem = list_elem_alloc(nbytes, cookie);
+    elem = list_elem_alloc(nbytes);
     ACTION_AFTER_WRITE(cookie, get_handle(handle), ret);
     if (elem != NULL) {
         *eitem = elem;
@@ -587,7 +587,7 @@ default_set_elem_alloc(ENGINE_HANDLE* handle, const void* cookie,
     ENGINE_ERROR_CODE ret = ENGINE_EINVAL; // See ACTION_AFTER_WRITE()
 
     ACTION_BEFORE_WRITE(cookie, key, nkey);
-    elem = set_elem_alloc(nbytes, cookie);
+    elem = set_elem_alloc(nbytes);
     ACTION_AFTER_WRITE(cookie, get_handle(handle), ret);
     if (elem != NULL) {
         *eitem = elem;
@@ -711,7 +711,7 @@ default_map_elem_alloc(ENGINE_HANDLE* handle, const void* cookie,
     ENGINE_ERROR_CODE ret = ENGINE_EINVAL; // See ACTION_AFTER_WRITE()
 
     ACTION_BEFORE_WRITE(cookie, key, nkey);
-    elem = map_elem_alloc(nfield, nbytes, cookie);
+    elem = map_elem_alloc(nfield, nbytes);
     ACTION_AFTER_WRITE(cookie, get_handle(handle), ret);
     if (elem != NULL) {
         *eitem = elem;
@@ -836,7 +836,7 @@ default_btree_elem_alloc(ENGINE_HANDLE* handle, const void* cookie,
     ENGINE_ERROR_CODE ret = ENGINE_EINVAL; // See ACTION_AFTER_WRITE()
 
     ACTION_BEFORE_WRITE(cookie, key, nkey);
-    elem = btree_elem_alloc(nbkey, neflag, nbytes, cookie);
+    elem = btree_elem_alloc(nbkey, neflag, nbytes);
     ACTION_AFTER_WRITE(cookie, get_handle(handle), ret);
     if (elem != NULL) {
         *eitem = elem;

--- a/engines/default/item_base.c
+++ b/engines/default/item_base.c
@@ -173,7 +173,7 @@ static inline void do_item_stat_reclaim(const unsigned int lruid)
 
 static inline void do_item_stat_evict(const unsigned int lruid,
                                       rel_time_t current_time,
-                                      hash_item *it, const void *cookie)
+                                      hash_item *it)
 {
     itemsp->itemstats[lruid].evicted++;
     itemsp->itemstats[lruid].evicted_time = current_time - it->time;
@@ -183,9 +183,7 @@ static inline void do_item_stat_evict(const unsigned int lruid,
     LOCK_STATS();
     statsp->evictions++;
     UNLOCK_STATS();
-    if (cookie != NULL) {
-        svstat->evicting(cookie, item_get_key(it), it->nkey);
-    }
+    svstat->evicting(item_get_key(it), it->nkey);
 }
 
 static inline void do_item_stat_outofmemory(const unsigned int lruid)
@@ -621,10 +619,10 @@ static void do_item_invalidate(hash_item *it, const unsigned int lruid, bool imm
 }
 
 static void do_item_evict(hash_item *it, const unsigned int lruid,
-                          rel_time_t current_time, const void *cookie)
+                          rel_time_t current_time)
 {
     /* increment # of evicted */
-    do_item_stat_evict(lruid, current_time, it, cookie);
+    do_item_stat_evict(lruid, current_time, it);
 
     /* unlink the item */
     if (IS_COLL_ITEM(it)) {
@@ -647,8 +645,7 @@ static void do_item_repair(hash_item *it, const unsigned int lruid)
     do_item_unlink(it, ITEM_UNLINK_EVICT);
 }
 
-static uint32_t do_item_regain(const uint32_t count, rel_time_t current_time,
-                               const void *cookie)
+static uint32_t do_item_regain(const uint32_t count, rel_time_t current_time)
 {
     hash_item *previt;
     hash_item *search;
@@ -667,7 +664,7 @@ static uint32_t do_item_regain(const uint32_t count, rel_time_t current_time,
         previt = search->prev;
         if (search->refcount == 0) {
             if (do_item_isvalid(search, current_time)) {
-                do_item_evict(search, clsid, current_time, cookie);
+                do_item_evict(search, clsid, current_time);
             } else {
                 do_item_invalidate(search, clsid, true);
             }
@@ -687,8 +684,7 @@ static uint32_t do_item_regain(const uint32_t count, rel_time_t current_time,
 
 //static void *do_item_mem_alloc(const size_t ntotal, const unsigned int clsid,
 //                               const void *cookie)
-void *do_item_mem_alloc(const size_t ntotal, const unsigned int clsid,
-                        const void *cookie)
+void *do_item_mem_alloc(const size_t ntotal, const unsigned int clsid)
 {
     hash_item *it = NULL;
 
@@ -728,7 +724,7 @@ void *do_item_mem_alloc(const size_t ntotal, const unsigned int clsid,
     if (config->evict_to_free && lruid == LRU_CLSID_FOR_SMALL) {
         int current_ssl = slabs_space_shortage_level();
         if (current_ssl > 0) {
-            (void)do_item_regain(current_ssl, current_time, cookie);
+            (void)do_item_regain(current_ssl, current_time);
         }
     }
 
@@ -839,7 +835,7 @@ void *do_item_mem_alloc(const size_t ntotal, const unsigned int clsid,
             previt = search->prev;
             if (search->refcount == 0) {
                 if (do_item_isvalid(search, current_time)) {
-                    do_item_evict(search, lruid, current_time, cookie);
+                    do_item_evict(search, lruid, current_time);
                     it = slabs_alloc(ntotal, clsid_based_on_ntotal);
                 } else {
                     it = do_item_reclaim(search, ntotal, clsid_based_on_ntotal, lruid);
@@ -921,11 +917,11 @@ void do_item_mem_free(void *item, size_t ntotal)
 /*
 static hash_item *do_item_alloc(const void *key, const uint32_t nkey,
                                 const uint32_t flags, const rel_time_t exptime,
-                                const uint32_t nbytes, const void *cookie)
+                                const uint32_t nbytes)
 */
 hash_item *do_item_alloc(const void *key, const uint32_t nkey,
                          const uint32_t flags, const rel_time_t exptime,
-                         const uint32_t nbytes, const void *cookie)
+                         const uint32_t nbytes)
 {
     assert(nkey > 0);
     hash_item *it = NULL;
@@ -943,7 +939,7 @@ hash_item *do_item_alloc(const void *key, const uint32_t nkey,
     }
 #endif
 
-    it = do_item_mem_alloc(ntotal, id, cookie);
+    it = do_item_mem_alloc(ntotal, id);
     if (it == NULL)  {
         return NULL;
     }
@@ -1286,7 +1282,7 @@ static void *collection_delete_thread(void *arg)
                 LOCK_CACHE();
                 if (config->evict_to_free) {
                     rel_time_t current_time = svcore->get_current_time();
-                    evict_count = do_item_regain(current_ssl, current_time, NULL);
+                    evict_count = do_item_regain(current_ssl, current_time);
                 }
                 UNLOCK_CACHE();
             }

--- a/engines/default/item_base.h
+++ b/engines/default/item_base.h
@@ -360,13 +360,12 @@ void do_coll_space_decr(coll_meta_info *info, ENGINE_ITEM_TYPE item_type,
 /* item functions */
 bool do_item_isvalid(hash_item *it, rel_time_t current_time);
 
-void *do_item_mem_alloc(const size_t ntotal, const unsigned int clsid,
-                        const void *cookie);
+void *do_item_mem_alloc(const size_t ntotal, const unsigned int clsid);
 void  do_item_mem_free(void *item, size_t ntotal);
 
 hash_item *do_item_alloc(const void *key, const uint32_t nkey,
                          const uint32_t flags, const rel_time_t exptime,
-                         const uint32_t nbytes, const void *cookie);
+                         const uint32_t nbytes);
 void       do_item_free(hash_item *it);
 
 ENGINE_ERROR_CODE do_item_link(hash_item *it);

--- a/engines/default/items.c
+++ b/engines/default/items.c
@@ -73,7 +73,7 @@ static inline void TRYLOCK_CACHE(int ntries)
  *
  * Returns the state of storage.
  */
-static ENGINE_ERROR_CODE do_item_store_set(hash_item *it, uint64_t *cas, const void *cookie)
+static ENGINE_ERROR_CODE do_item_store_set(hash_item *it, uint64_t *cas)
 {
     hash_item *old_it;
     ENGINE_ERROR_CODE stored;
@@ -96,7 +96,7 @@ static ENGINE_ERROR_CODE do_item_store_set(hash_item *it, uint64_t *cas, const v
     return stored;
 }
 
-static ENGINE_ERROR_CODE do_item_store_add(hash_item *it, uint64_t *cas, const void *cookie)
+static ENGINE_ERROR_CODE do_item_store_add(hash_item *it, uint64_t *cas)
 {
     hash_item *old_it;
     ENGINE_ERROR_CODE stored;
@@ -120,7 +120,7 @@ static ENGINE_ERROR_CODE do_item_store_add(hash_item *it, uint64_t *cas, const v
     return stored;
 }
 
-static ENGINE_ERROR_CODE do_item_store_replace(hash_item *it, uint64_t *cas, const void *cookie)
+static ENGINE_ERROR_CODE do_item_store_replace(hash_item *it, uint64_t *cas)
 {
     hash_item *old_it;
     ENGINE_ERROR_CODE stored;
@@ -141,7 +141,7 @@ static ENGINE_ERROR_CODE do_item_store_replace(hash_item *it, uint64_t *cas, con
     return stored;
 }
 
-static ENGINE_ERROR_CODE do_item_store_cas(hash_item *it, uint64_t *cas, const void *cookie)
+static ENGINE_ERROR_CODE do_item_store_cas(hash_item *it, uint64_t *cas)
 {
     hash_item *old_it;
     ENGINE_ERROR_CODE stored;
@@ -174,8 +174,7 @@ static ENGINE_ERROR_CODE do_item_store_cas(hash_item *it, uint64_t *cas, const v
 }
 
 static ENGINE_ERROR_CODE do_item_store_attach(hash_item *it, uint64_t *cas,
-                                              ENGINE_STORE_OPERATION operation,
-                                              const void *cookie)
+                                              ENGINE_STORE_OPERATION operation)
 {
     hash_item *old_it;
     ENGINE_ERROR_CODE stored;
@@ -195,8 +194,7 @@ static ENGINE_ERROR_CODE do_item_store_attach(hash_item *it, uint64_t *cas,
         /* we have it and old_it here - alloc memory to hold both */
         hash_item *new_it = do_item_alloc(item_get_key(it), it->nkey,
                                           old_it->flags, old_it->exptime,
-                                          it->nbytes + old_it->nbytes - 2 /* CRLF */,
-                                          cookie);
+                                          it->nbytes + old_it->nbytes - 2 /* CRLF */);
         if (new_it) {
             /* copy data from it and old_it to new_it */
             if (operation == OPERATION_APPEND) {
@@ -235,7 +233,7 @@ static ENGINE_ERROR_CODE do_item_store_attach(hash_item *it, uint64_t *cas,
  * returns a response string to send back to the client.
  */
 static ENGINE_ERROR_CODE do_add_delta(hash_item *it, const bool incr, const int64_t delta,
-                                      uint64_t *rcas, uint64_t *result, const void *cookie)
+                                      uint64_t *rcas, uint64_t *result)
 {
     const char *ptr;
     uint64_t value;
@@ -262,7 +260,7 @@ static ENGINE_ERROR_CODE do_add_delta(hash_item *it, const bool incr, const int6
         return ENGINE_EINVAL;
     }
     hash_item *new_it = do_item_alloc(item_get_key(it), it->nkey,
-                                      it->flags, it->exptime, res, cookie);
+                                      it->flags, it->exptime, res);
     if (new_it == NULL) {
         return ENGINE_ENOMEM;
     }
@@ -281,12 +279,12 @@ static ENGINE_ERROR_CODE do_add_delta(hash_item *it, const bool incr, const int6
  */
 hash_item *item_alloc(const void *key, const uint32_t nkey,
                       const uint32_t flags, rel_time_t exptime,
-                      const uint32_t nbytes, const void *cookie)
+                      const uint32_t nbytes)
 {
     hash_item *it;
     LOCK_CACHE();
     /* key can be NULL */
-    it = do_item_alloc(key, nkey, flags, exptime, nbytes, cookie);
+    it = do_item_alloc(key, nkey, flags, exptime, nbytes);
     UNLOCK_CACHE();
     return it;
 }
@@ -319,8 +317,7 @@ void item_release(hash_item *item)
  * Stores an item in the cache (high level, obeys set/add/replace semantics)
  */
 ENGINE_ERROR_CODE item_store(hash_item *item, uint64_t *cas,
-                             ENGINE_STORE_OPERATION operation,
-                             const void *cookie)
+                             ENGINE_STORE_OPERATION operation)
 {
     ENGINE_ERROR_CODE ret;
     PERSISTENCE_ACTION_BEGIN(cookie, UPD_STORE);
@@ -328,20 +325,20 @@ ENGINE_ERROR_CODE item_store(hash_item *item, uint64_t *cas,
     LOCK_CACHE();
     switch (operation) {
       case OPERATION_SET:
-           ret = do_item_store_set(item, cas, cookie);
+           ret = do_item_store_set(item, cas);
            break;
       case OPERATION_ADD:
-           ret = do_item_store_add(item, cas, cookie);
+           ret = do_item_store_add(item, cas);
            break;
       case OPERATION_REPLACE:
-           ret = do_item_store_replace(item, cas, cookie);
+           ret = do_item_store_replace(item, cas);
            break;
       case OPERATION_CAS:
-           ret = do_item_store_cas(item, cas, cookie);
+           ret = do_item_store_cas(item, cas);
            break;
       case OPERATION_PREPEND:
       case OPERATION_APPEND:
-           ret = do_item_store_attach(item, cas, operation, cookie);
+           ret = do_item_store_attach(item, cas, operation);
            break;
       default:
            ret = ENGINE_NOT_STORED;
@@ -369,7 +366,7 @@ ENGINE_ERROR_CODE item_arithmetic(const void *key, const uint32_t nkey,
         if (IS_COLL_ITEM(it)) {
             ret = ENGINE_EBADTYPE;
         } else {
-            ret = do_add_delta(it, increment, delta, cas, result, cookie);
+            ret = do_add_delta(it, increment, delta, cas, result);
             do_item_release(it);
         }
     } else {
@@ -377,10 +374,10 @@ ENGINE_ERROR_CODE item_arithmetic(const void *key, const uint32_t nkey,
             char buffer[128];
             int len = snprintf(buffer, sizeof(buffer), "%"PRIu64"\r\n", initial);
 
-            it = do_item_alloc(key, nkey, flags, exptime, len, cookie);
+            it = do_item_alloc(key, nkey, flags, exptime, len);
             if (it) {
                 memcpy((void*)item_get_data(it), buffer, len);
-                ret = do_item_store_add(it, cas, cookie);
+                ret = do_item_store_add(it, cas);
                 if (ret == ENGINE_SUCCESS) {
                     *result = initial;
                 }
@@ -1732,7 +1729,7 @@ ENGINE_ERROR_CODE item_apply_kv_link(void *engine, const char *key, const uint32
 
     LOCK_CACHE();
     old_it = do_item_get(key, nkey, DONT_UPDATE);
-    new_it = do_item_alloc(key, nkey, flags, exptime, nbytes, NULL); /* cookie is NULL */
+    new_it = do_item_alloc(key, nkey, flags, exptime, nbytes);
     if (new_it) {
         /* Assume data is small, and copying with lock held is okay : FIXME */
         memcpy(item_get_data(new_it), value, nbytes);

--- a/engines/default/items.h
+++ b/engines/default/items.h
@@ -40,7 +40,7 @@
  */
 hash_item *item_alloc(const void *key, const uint32_t nkey,
                       const uint32_t flags, rel_time_t exptime,
-                      const uint32_t nbytes, const void *cookie);
+                      const uint32_t nbytes);
 
 /**
  * Get an item from the cache
@@ -119,8 +119,7 @@ void item_release(hash_item *it);
  *       there so that we can get it from the item instead?
  */
 ENGINE_ERROR_CODE item_store(hash_item *item,
-                             uint64_t *cas, ENGINE_STORE_OPERATION operation,
-                             const void *cookie);
+                             uint64_t *cas, ENGINE_STORE_OPERATION operation);
 
 ENGINE_ERROR_CODE item_arithmetic(const void *key, const uint32_t nkey,
                                   const bool increment,

--- a/include/memcached/server_api.h
+++ b/include/memcached/server_api.h
@@ -188,8 +188,7 @@ extern "C" {
         /**
          * Tell the server we've evicted an item.
          */
-        void (*evicting)(const void *cookie,
-                         const void *key,
+        void (*evicting)(const void *key,
                          int nkey);
     } SERVER_STAT_API;
 

--- a/memcached.c
+++ b/memcached.c
@@ -15667,7 +15667,7 @@ static void release_independent_stats(void *stats)
     threadlocal_stats_destroy(stats);
 }
 
-static void count_eviction(const void *cookie, const void *key, const int nkey)
+static void count_eviction(const void *key, const int nkey)
 {
     TK(default_topkeys, evictions, key, nkey, get_current_time());
 }

--- a/mock_server.c
+++ b/mock_server.c
@@ -121,9 +121,7 @@ static void mock_release_independent_stats(void *stats) {
     free(mockstats);
 }
 
-static void mock_count_eviction(const void *cookie, const void *key, const int nkey) {
-    struct mock_connstruct *c = (struct mock_connstruct *)cookie;
-    c->evictions++;
+static void mock_count_eviction(const void *key, const int nkey) {
 }
 
 /**


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/844#issuecomment-4666741181

### ⌨️ What I did

hash tree 모듈 설계 중 `htree_elem_insert`, `htree_elem_add`의 인터페이스를 정의하는 과정에서,
node alloc 시 전달되던 `cookie`가 실제로 필요한 인자인지 검토했습니다.

추적 결과, `cookie`는 `do_item_mem_alloc` → `do_item_regain` → `do_item_evict` → `do_item_stat_evict` 체인을 통해
eviction 발생 시 `svstat->evicting(cookie, key, nkey)` 콜백을 호출하기 위해 전달되고 있었습니다.

그러나 eviction 통계는 connection별로 분리하지 않고 전역적으로 기록하고 있었으며,
`cookie`(connection 정보)는 이 경로 전체에서 불필요한 파라미터였습니다.

이는 EE 코드에서도 동일하게 확인되었습니다.

> https://github.com/jam2in/arcus-memcached-EE/blob/memc_repl/engines/default/item_base.c#L242-L257
> https://github.com/naver/arcus-memcached/blob/develop/engines/default/item_base.c#L174-L189
> => EE, CE 모두 cookie->evictions++가 아닌 전역 evictions++
> 
> https://github.com/jam2in/arcus-memcached-EE/blob/554e6dc450292b737787bd46ed7f98462bfecc06/memcached.c#L16023-L16026
> https://github.com/naver/arcus-memcached/blob/develop/memcached.c#L15670-L15673
> => EE, CE 모두 count_eviction에서 cookie 사용하지 않음
> 
> 따라서 EE 또한 `do_item_stat_evict`의 `cookie` 파라미터 제거 가능

따라서 `svstat->evicting` 콜백 시그니처에서 `cookie`를 제거하고,
이를 전달하기 위해 존재하던 하위 함수들(`do_item_stat_evict`, `do_item_evict`, `do_item_regain`,
`do_item_mem_alloc`, `do_item_alloc`, 각 컬렉션의 node/elem alloc 함수들)에서도 `cookie` 파라미터를 일괄 제거했습니다.

https://gist.github.com/zhy2on/22799e8d2e789139c0142a5d389d0598
이에 따라 `htree_elem_insert`, `htree_elem_add`도 cookie 파라미터 없이 구현할 예정입니다.