### PR TITLE
INTERNAL: Unify do_set_elem_find and do_map_elem_find

### DIFF
--- a/engines/default/coll_map.c
+++ b/engines/default/coll_map.c
@@ -609,12 +609,15 @@ static uint32_t do_map_elem_delete(map_meta_info *info, const int numfields,
     return delcnt;
 }
 
-static map_elem_item *do_map_elem_find(map_hash_node *node, const field_t *field, map_prev_info *pinfo)
+static map_elem_item *do_map_elem_find(map_meta_info *info,
+                                       const void *key, uint16_t nkey,
+                                       map_prev_info *pinfo)
 {
-    map_elem_item *elem = NULL;
-    map_elem_item *prev = NULL;
-    int hval = genhash_string_hash(field->value, field->length);
-    int hidx = -1;
+    if (info->root == NULL) return NULL;
+
+    map_hash_node *node = info->root;
+    int hval = genhash_string_hash(key, nkey);
+    int hidx;
 
     while (node != NULL) {
         hidx = MAP_GET_HASHIDX(hval, node->hdepth);
@@ -622,9 +625,11 @@ static map_elem_item *do_map_elem_find(map_hash_node *node, const field_t *field
             break;
         node = node->htab[hidx];
     }
-    assert(node != NULL);
+
+    map_elem_item *prev = NULL;
+    map_elem_item *elem;
     for (elem = node->htab[hidx]; elem != NULL; elem = elem->next) {
-        if (map_hash_eq(hval, field->value, field->length, elem->hval, elem->data, elem->nfield)) {
+        if (map_hash_eq(hval, key, nkey, elem->hval, elem->data, elem->nfield)) {
             if (pinfo != NULL) {
                 pinfo->node = node;
                 pinfo->prev = prev;
@@ -648,7 +653,7 @@ static ENGINE_ERROR_CODE do_map_elem_update(map_meta_info *info,
         return ENGINE_ELEM_ENOENT;
     }
 
-    elem = do_map_elem_find(info->root, field, &pinfo);
+    elem = do_map_elem_find(info, field->value, field->length, &pinfo);
     if (elem == NULL) {
         return ENGINE_ELEM_ENOENT;
     }

--- a/engines/default/coll_set.c
+++ b/engines/default/coll_set.c
@@ -101,6 +101,11 @@ static bool hash_insert(hash_table *ht, int key)
 /*
  * SET collection manangement
  */
+typedef struct _set_prev_info {
+    set_hash_node *node;
+    set_elem_item *prev;
+    uint16_t       hidx;
+} set_prev_info;
 
 #define SET_GET_HASHIDX(hval, hdepth) \
         (((hval) & (SET_HASHIDX_MASK << ((hdepth)*4))) >> ((hdepth)*4))
@@ -402,28 +407,37 @@ static void do_set_elem_unlink(set_meta_info *info,
     }
 }
 
-static set_elem_item *do_set_elem_find(set_meta_info *info, const char *val, const int vlen)
+static set_elem_item *do_set_elem_find(set_meta_info *info,
+                                       const void *key, uint16_t nkey,
+                                       set_prev_info *pinfo)
 {
-    set_elem_item *elem = NULL;
+    if (info->root == NULL) return NULL;
 
-    if (info->root != NULL) {
-        set_hash_node *node = info->root;
-        int hval = genhash_string_hash(val, vlen);
-        int hidx = 0;
+    set_hash_node *node = info->root;
+    int hval = genhash_string_hash(key, nkey);
+    int hidx;
 
-        while (node != NULL) {
-            hidx = SET_GET_HASHIDX(hval, node->hdepth);
-            if (node->hcnt[hidx] >= 0) /* set element hash chain */
-                break;
-            node = node->htab[hidx];
-        }
-        assert(node != NULL);
-
-        for (elem = node->htab[hidx]; elem != NULL; elem = elem->next) {
-            if (set_hash_eq(hval, val, vlen, elem->hval, elem->value, elem->nbytes))
-                break;
-        }
+    while (node != NULL) {
+        hidx = SET_GET_HASHIDX(hval, node->hdepth);
+        if (node->hcnt[hidx] >= 0)
+            break;
+        node = node->htab[hidx];
     }
+
+    set_elem_item *prev = NULL;
+    set_elem_item *elem;
+    for (elem = node->htab[hidx]; elem != NULL; elem = elem->next) {
+        if (set_hash_eq(hval, key, nkey, elem->hval, elem->value, elem->nbytes)) {
+            if (pinfo != NULL) {
+                pinfo->node = node;
+                pinfo->prev = prev;
+                pinfo->hidx = hidx;
+            }
+            break;
+        }
+        prev = elem;
+    }
+
     return elem;
 }
 
@@ -873,7 +887,7 @@ ENGINE_ERROR_CODE set_elem_exist(const char *key, const uint32_t nkey,
             if ((info->mflags & COLL_META_FLAG_READABLE) == 0) {
                 ret = ENGINE_UNREADABLE; break;
             }
-            if (do_set_elem_find(info, value, nbytes) != NULL)
+            if (do_set_elem_find(info, value, nbytes, NULL) != NULL)
                 *exist = true;
             else
                 *exist = false;


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/844#issuecomment-4278095307

### ⌨️ What I did
`do_set_elem_find`와 `do_map_elem_find`의 시그니처와 내부 구조를 통일했습니다. 이후 두 함수를 [`htree_elem_find`](https://gist.github.com/zhy2on/22799e8d2e789139c0142a5d389d0598)로 추출하기 위한 사전 작업입니다.

**시그니처 통일**
- 두 함수 모두 `*_meta_info *info, const void *key, uint16_t nkey, *_prev_info *pinfo` 형태로 변경
- `do_map_elem_find`는 기존에 `map_hash_node *node`와 `field_t *field`를 직접 받았으나, `map_meta_info *info`와 raw `(key, nkey)`를 받도록 변경

**내부 구조 통일**
- `root == NULL` 체크를 함수 내부 초입으로 이동
- `prev` 추적 및 `pinfo` 채우기를 루프 밖으로 분리

**`set_prev_info` 구조체 추가**
- map의 `map_prev_info`에 대응하는 `set_prev_info` 구조체 추가

**향후 계획**
- 두 함수는 `htree_elem_find(htree_meta *info, const void *key, uint16_t nkey, htree_elem_pos *pos)`로 추출될 예정입니다.
- `*_prev_info`는 `htree_elem_pos`로 통합되며, `htree_elem_insert` 내부에서 중복 체크와 삽입 위치 탐색을 한 번에 처리하는 데 활용됩니다.
