### PR TITLE
INTERNAL: Extract htree layer functions from map/set elem insert and update

### DIFF
--- a/engines/default/coll_map.c
+++ b/engines/default/coll_map.c
@@ -221,11 +221,6 @@ static void do_map_node_link(map_meta_info *info,
         par_node->htab[par_hidx] = node;
         par_node->hcnt[par_hidx] = -1; /* child hash node */
     }
-
-    if (1) { /* apply memory space */
-        size_t stotal = slabs_space_size(sizeof(map_hash_node));
-        do_coll_space_incr((coll_meta_info *)info, ITEM_TYPE_MAP, stotal);
-    }
 }
 
 static void do_map_node_unlink(map_meta_info *info,
@@ -277,24 +272,54 @@ static void do_map_node_unlink(map_meta_info *info,
     do_map_node_free(node);
 }
 
-static void do_map_elem_replace(map_meta_info *info,
-                                map_prev_info *pinfo, map_elem_item *new_elem)
+static map_elem_item *do_map_elem_find(map_meta_info *info,
+                                       const int hval,
+                                       const void *key, uint16_t nkey,
+                                       map_prev_info *pinfo)
+{
+    if (info->root == NULL) {
+        return NULL;
+    }
+
+    map_hash_node *node = info->root;
+    int hidx;
+
+    while (node != NULL) {
+        hidx = MAP_GET_HASHIDX(hval, node->hdepth);
+        if (node->hcnt[hidx] >= 0) /* map element hash chain */
+            break;
+        node = node->htab[hidx];
+    }
+
+    map_elem_item *prev = NULL;
+    map_elem_item *elem;
+    for (elem = node->htab[hidx]; elem != NULL; elem = elem->next) {
+        if (map_hash_eq(hval, key, nkey, elem->hval, elem->data, elem->nfield)) {
+            break;
+        }
+        prev = elem;
+    }
+
+    if (pinfo != NULL) {
+        pinfo->node = node;
+        pinfo->prev = prev;
+        pinfo->hidx = hidx;
+    }
+    return elem;
+}
+
+static map_elem_item *do_htree_elem_replace(map_meta_info *info,
+                                            map_prev_info *pinfo, map_elem_item *new_elem)
 {
     map_elem_item *prev = pinfo->prev;
     map_elem_item *old_elem;
-    size_t old_stotal;
-    size_t new_stotal;
 
     if (prev != NULL) {
         old_elem = prev->next;
     } else {
         old_elem = (map_elem_item *)pinfo->node->htab[pinfo->hidx];
     }
-
-    old_stotal = slabs_space_size(do_map_elem_ntotal(old_elem));
-    new_stotal = slabs_space_size(do_map_elem_ntotal(new_elem));
-
-    CLOG_MAP_ELEM_INSERT(info, old_elem, new_elem);
+    assert(new_elem->hval == old_elem->hval);
 
     new_elem->next = old_elem->next;
     if (prev != NULL) {
@@ -306,120 +331,63 @@ static void do_map_elem_replace(map_meta_info *info,
 
     old_elem->linked--;
     assert(old_elem->linked == 0);
-    if (old_elem->refcount == 0) {
-        do_map_elem_free(old_elem);
-    }
 
-    if (new_stotal != old_stotal) {
-        assert(info->stotal > 0);
-        if (new_stotal > old_stotal) {
-            do_coll_space_incr((coll_meta_info *)info, ITEM_TYPE_MAP, (new_stotal-old_stotal));
-        } else {
-            do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_MAP, (old_stotal-new_stotal));
-        }
-    }
+    return old_elem;
 }
 
-static ENGINE_ERROR_CODE do_map_elem_link(map_meta_info *info, map_elem_item *elem,
-                                          const bool replace_if_exist, bool *replaced)
+static ENGINE_ERROR_CODE do_htree_elem_link(map_meta_info *info,
+                                            map_hash_node *node, int hidx,
+                                            map_elem_item *elem, size_t *space_increased)
 {
-    assert(info->root != NULL);
-    map_hash_node *node = info->root;
-    map_elem_item *prev = NULL;
-    map_elem_item *find;
-    map_prev_info pinfo;
-    ENGINE_ERROR_CODE res = ENGINE_SUCCESS;
-
-    int hidx = -1;
-
-    /* map hash value */
-    elem->hval = genhash_string_hash(elem->data, elem->nfield);
-
-    while (node != NULL) {
-        hidx = MAP_GET_HASHIDX(elem->hval, node->hdepth);
-        if (node->hcnt[hidx] >= 0) /* map element hash chain */
-            break;
-        node = node->htab[hidx];
-    }
-    assert(node != NULL);
-    for (find = node->htab[hidx]; find != NULL; find = find->next) {
-        if (map_hash_eq(elem->hval, elem->data, elem->nfield,
-                        find->hval, find->data, find->nfield))
-            break;
-        prev = find;
-    }
-
-    if (find != NULL) {
-        if (replace_if_exist) {
-#ifdef ENABLE_STICKY_ITEM
-            /* sticky memory limit check */
-            if (IS_STICKY_COLLFLG(info)) {
-                if (find->nbytes < elem->nbytes) {
-                    if (do_item_sticky_overflowed())
-                        return ENGINE_ENOMEM;
-                }
-            }
-#endif
-            pinfo.node = node;
-            pinfo.prev = prev;
-            pinfo.hidx = hidx;
-            do_map_elem_replace(info, &pinfo, elem);
-            if (replaced) *replaced = true;
-            return ENGINE_SUCCESS;
-        } else {
-            return ENGINE_ELEM_EEXISTS;
-        }
-    }
-
-#ifdef ENABLE_STICKY_ITEM
-    /* sticky memory limit check */
-    if (IS_STICKY_COLLFLG(info)) {
-        if (do_item_sticky_overflowed())
-            return ENGINE_ENOMEM;
-    }
-#endif
-
-    /* overflow check */
-    assert(info->ovflact == OVFL_ERROR);
-    if (info->ccnt >= (info->mcnt > 0 ? info->mcnt : config->max_map_size)) {
-        return ENGINE_EOVERFLOW;
-    }
-
     if (node->hcnt[hidx] >= MAP_MAX_HASHCHAIN_SIZE) {
         map_hash_node *n_node = do_map_node_alloc(node->hdepth+1);
         if (n_node == NULL) {
-            res = ENGINE_ENOMEM;
-            return res;
+            return ENGINE_ENOMEM;
         }
         do_map_node_link(info, node, hidx, n_node);
+        *space_increased += slabs_space_size(sizeof(map_hash_node));
 
         node = n_node;
         hidx = MAP_GET_HASHIDX(elem->hval, node->hdepth);
     }
 
-    CLOG_MAP_ELEM_INSERT(info, NULL, elem);
-
+    elem->linked++;
     elem->next = node->htab[hidx];
     node->htab[hidx] = elem;
     node->hcnt[hidx] += 1;
     node->tot_elem_cnt += 1;
-    elem->linked++;
 
     map_hash_node *par_node = info->root;
     while (par_node != node) {
         par_node->tot_elem_cnt += 1;
-        hidx = MAP_GET_HASHIDX(elem->hval, par_node->hdepth);
-        assert(par_node->hcnt[hidx] == -1);
-        par_node = par_node->htab[hidx];
+        int par_hidx = MAP_GET_HASHIDX(elem->hval, par_node->hdepth);
+        assert(par_node->hcnt[par_hidx] == -1);
+        par_node = par_node->htab[par_hidx];
     }
-    info->ccnt++;
+    return ENGINE_SUCCESS;
+}
 
-    if (1) { /* apply memory space */
-        size_t stotal = slabs_space_size(do_map_elem_ntotal(elem));
-        do_coll_space_incr((coll_meta_info *)info, ITEM_TYPE_MAP, stotal);
+static ENGINE_ERROR_CODE do_htree_elem_add(map_meta_info *info, map_elem_item *elem,
+                                           map_prev_info *pinfo, size_t *space_increased)
+{
+    map_hash_node *node;
+    int hidx;
+
+    if (info->root == NULL) {
+        node = do_map_node_alloc(0);
+        if (node == NULL) {
+            return ENGINE_ENOMEM;
+        }
+        do_map_node_link(info, NULL, 0, node);
+        *space_increased += slabs_space_size(sizeof(map_hash_node));
+
+        hidx = MAP_GET_HASHIDX(elem->hval, 0);
+        return do_htree_elem_link(info, node, hidx, elem, space_increased);
     }
 
-    return res;
+    node = pinfo->node;
+    hidx = pinfo->hidx;
+    return do_htree_elem_link(info, node, hidx, elem, space_increased);
 }
 
 static void do_map_elem_unlink(map_meta_info *info,
@@ -609,37 +577,40 @@ static uint32_t do_map_elem_delete(map_meta_info *info, const int numfields,
     return delcnt;
 }
 
-static map_elem_item *do_map_elem_find(map_meta_info *info,
-                                       const void *key, uint16_t nkey,
-                                       map_prev_info *pinfo)
+static ENGINE_ERROR_CODE do_map_elem_replace(map_meta_info *info, map_prev_info *pinfo,
+                                             map_elem_item *new_elem)
 {
-    if (info->root == NULL) return NULL;
-
-    map_hash_node *node = info->root;
-    int hval = genhash_string_hash(key, nkey);
-    int hidx;
-
-    while (node != NULL) {
-        hidx = MAP_GET_HASHIDX(hval, node->hdepth);
-        if (node->hcnt[hidx] >= 0) /* map element hash chain */
-            break;
-        node = node->htab[hidx];
-    }
-
-    map_elem_item *prev = NULL;
-    map_elem_item *elem;
-    for (elem = node->htab[hidx]; elem != NULL; elem = elem->next) {
-        if (map_hash_eq(hval, key, nkey, elem->hval, elem->data, elem->nfield)) {
-            if (pinfo != NULL) {
-                pinfo->node = node;
-                pinfo->prev = prev;
-                pinfo->hidx = hidx;
-            }
-            break;
+    map_elem_item *old_elem = (pinfo->prev != NULL) ? pinfo->prev->next
+                                                    : (map_elem_item *)pinfo->node->htab[pinfo->hidx];
+#ifdef ENABLE_STICKY_ITEM
+    /* sticky memory limit check */
+    if (IS_STICKY_COLLFLG(info)) {
+        if (old_elem->nbytes < new_elem->nbytes) {
+            if (do_item_sticky_overflowed())
+                return ENGINE_ENOMEM;
         }
-        prev = elem;
     }
-    return elem;
+#endif
+    map_elem_item *replaced = do_htree_elem_replace(info, pinfo, new_elem);
+    assert(replaced == old_elem);
+
+    CLOG_MAP_ELEM_INSERT(info, old_elem, new_elem);
+
+    size_t old_stotal = slabs_space_size(do_map_elem_ntotal(old_elem));
+    size_t new_stotal = slabs_space_size(do_map_elem_ntotal(new_elem));
+
+    if (new_stotal != old_stotal) {
+        assert(info->stotal > 0);
+        if (new_stotal > old_stotal)
+            do_coll_space_incr((coll_meta_info *)info, ITEM_TYPE_MAP, (new_stotal-old_stotal));
+        else
+            do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_MAP, (old_stotal-new_stotal));
+    }
+
+    if (old_elem->refcount == 0) {
+        do_map_elem_free(old_elem);
+    }
+    return ENGINE_SUCCESS;
 }
 
 static ENGINE_ERROR_CODE do_map_elem_update(map_meta_info *info,
@@ -653,7 +624,9 @@ static ENGINE_ERROR_CODE do_map_elem_update(map_meta_info *info,
         return ENGINE_ELEM_ENOENT;
     }
 
-    elem = do_map_elem_find(info, field->value, field->length, &pinfo);
+    int hval = genhash_string_hash(field->value, field->length);
+    elem = do_map_elem_find(info, hval, field->value, field->length, &pinfo);
+
     if (elem == NULL) {
         return ENGINE_ELEM_ENOENT;
     }
@@ -665,16 +638,6 @@ static ENGINE_ERROR_CODE do_map_elem_update(map_meta_info *info,
         CLOG_MAP_ELEM_INSERT(info, elem, elem);
     } else {
         /* old body size != new body size */
-#ifdef ENABLE_STICKY_ITEM
-        /* sticky memory limit check */
-        if (IS_STICKY_COLLFLG(info)) {
-            if (elem->nbytes < nbytes) {
-                if (do_item_sticky_overflowed())
-                    return ENGINE_ENOMEM;
-            }
-        }
-#endif
-
         map_elem_item *new_elem = do_map_elem_alloc(elem->nfield, nbytes);
         if (new_elem == NULL) {
             return ENGINE_ENOMEM;
@@ -686,7 +649,11 @@ static ENGINE_ERROR_CODE do_map_elem_update(map_meta_info *info,
         new_elem->hval = elem->hval;
 
         /* replace the element */
-        do_map_elem_replace(info, &pinfo, new_elem);
+        ENGINE_ERROR_CODE ret = do_map_elem_replace(info, &pinfo, new_elem);
+        if (ret != ENGINE_SUCCESS) {
+            do_map_elem_free(new_elem);
+            return ret;
+        }
     }
 
     return ENGINE_SUCCESS;
@@ -728,25 +695,50 @@ static ENGINE_ERROR_CODE do_map_elem_insert(hash_item *it, map_elem_item *elem,
 {
     map_meta_info *info = (map_meta_info *)item_get_meta(it);
     ENGINE_ERROR_CODE ret;
+    map_prev_info pinfo;
+    map_elem_item *find;
 
-    /* create the root hash node if it does not exist */
-    bool new_root_flag = false;
-    if (info->root == NULL) { /* empty map */
-        map_hash_node *r_node = do_map_node_alloc(0);
-        if (r_node == NULL) {
-            return ENGINE_ENOMEM;
+    /* map hash value */
+    elem->hval = genhash_string_hash(elem->data, elem->nfield);
+    find = do_map_elem_find(info, elem->hval, elem->data, elem->nfield, &pinfo);
+
+    if (find != NULL) {
+        if (!replace_if_exist) {
+            return ENGINE_ELEM_EEXISTS;
         }
-        do_map_node_link(info, NULL, 0, r_node);
-        new_root_flag = true;
+        ENGINE_ERROR_CODE ret = do_map_elem_replace(info, &pinfo, elem);
+        if (ret != ENGINE_SUCCESS) {
+            return ret;
+        }
+        if (replaced) *replaced = true;
+        return ENGINE_SUCCESS;
     }
 
-    /* insert the element */
-    ret = do_map_elem_link(info, elem, replace_if_exist, replaced);
+#ifdef ENABLE_STICKY_ITEM
+    /* sticky memory limit check */
+    if (IS_STICKY_COLLFLG(info)) {
+        if (do_item_sticky_overflowed())
+            return ENGINE_ENOMEM;
+    }
+#endif
+
+    /* overflow check */
+    assert(info->ovflact == OVFL_ERROR);
+    if (info->ccnt >= (info->mcnt > 0 ? info->mcnt : config->max_map_size)) {
+        return ENGINE_EOVERFLOW;
+    }
+
+    size_t space_increased = 0;
+    ret = do_htree_elem_add(info, elem, &pinfo, &space_increased);
     if (ret != ENGINE_SUCCESS) {
-        if (new_root_flag) {
-            do_map_node_unlink(info, NULL, 0);
-        }
         return ret;
+    }
+
+    CLOG_MAP_ELEM_INSERT(info, NULL, elem);
+    info->ccnt++;
+    if (1) { /* apply memory space */
+        size_t stotal = slabs_space_size(do_map_elem_ntotal(elem)) + space_increased;
+        do_coll_space_incr((coll_meta_info *)info, ITEM_TYPE_MAP, stotal);
     }
 
     return ENGINE_SUCCESS;

--- a/engines/default/coll_set.c
+++ b/engines/default/coll_set.c
@@ -264,11 +264,6 @@ static void do_set_node_link(set_meta_info *info,
         par_node->htab[par_hidx] = node;
         par_node->hcnt[par_hidx] = -1; /* child hash node */
     }
-
-    if (1) { /* apply memory space */
-        size_t stotal = slabs_space_size(sizeof(set_hash_node));
-        do_coll_space_incr((coll_meta_info *)info, ITEM_TYPE_SET, stotal);
-    }
 }
 
 static void do_set_node_unlink(set_meta_info *info,
@@ -320,66 +315,103 @@ static void do_set_node_unlink(set_meta_info *info,
     do_set_node_free(node);
 }
 
-static ENGINE_ERROR_CODE do_set_elem_link(set_meta_info *info, set_elem_item *elem)
+static set_elem_item *do_set_elem_find(set_meta_info *info,
+                                       const int hval,
+                                       const void *key, uint16_t nkey,
+                                       set_prev_info *pinfo)
 {
-    assert(info->root != NULL);
-    set_hash_node *node = info->root;
-    set_elem_item *find;
-    int hidx = -1;
+    if (info->root == NULL) {
+        return NULL;
+    }
 
-    /* set hash value */
-    elem->hval = genhash_string_hash(elem->value, elem->nbytes);
+    set_hash_node *node = info->root;
+    int hidx;
 
     while (node != NULL) {
-        hidx = SET_GET_HASHIDX(elem->hval, node->hdepth);
-        if (node->hcnt[hidx] >= 0) /* set element hash chain */
+        hidx = SET_GET_HASHIDX(hval, node->hdepth);
+        if (node->hcnt[hidx] >= 0)
             break;
         node = node->htab[hidx];
     }
-    assert(node != NULL);
-    assert(hidx != -1);
 
-    for (find = node->htab[hidx]; find != NULL; find = find->next) {
-        if (set_hash_eq(elem->hval, elem->value, elem->nbytes,
-                        find->hval, find->value, find->nbytes))
+    set_elem_item *prev = NULL;
+    set_elem_item *elem;
+    for (elem = node->htab[hidx]; elem != NULL; elem = elem->next) {
+        if (set_hash_eq(hval, key, nkey, elem->hval, elem->value, elem->nbytes))
             break;
-    }
-    if (find != NULL) {
-        return ENGINE_ELEM_EEXISTS;
+        prev = elem;
     }
 
+    if (pinfo != NULL) {
+        pinfo->node = node;
+        pinfo->prev = prev;
+        pinfo->hidx = hidx;
+    }
+
+    return elem;
+}
+
+static ENGINE_ERROR_CODE do_htree_elem_link(set_meta_info *info,
+                                            set_hash_node *node, int hidx,
+                                            set_elem_item *elem, size_t *space_increased)
+{
     if (node->hcnt[hidx] >= SET_MAX_HASHCHAIN_SIZE) {
         set_hash_node *n_node = do_set_node_alloc(node->hdepth+1);
         if (n_node == NULL) {
             return ENGINE_ENOMEM;
         }
         do_set_node_link(info, node, hidx, n_node);
+        *space_increased += slabs_space_size(sizeof(set_hash_node));
 
         node = n_node;
         hidx = SET_GET_HASHIDX(elem->hval, node->hdepth);
     }
 
+    elem->linked++;
     elem->next = node->htab[hidx];
     node->htab[hidx] = elem;
     node->hcnt[hidx] += 1;
     node->tot_elem_cnt += 1;
-    elem->linked++;
 
     set_hash_node *par_node = info->root;
     while (par_node != node) {
         par_node->tot_elem_cnt += 1;
-        hidx = SET_GET_HASHIDX(elem->hval, par_node->hdepth);
-        assert(par_node->hcnt[hidx] == -1);
-        par_node = par_node->htab[hidx];
+        int par_hidx = SET_GET_HASHIDX(elem->hval, par_node->hdepth);
+        assert(par_node->hcnt[par_hidx] == -1);
+        par_node = par_node->htab[par_hidx];
     }
-    info->ccnt++;
-
-    if (1) { /* apply memory space */
-        size_t stotal = slabs_space_size(do_set_elem_ntotal(elem));
-        do_coll_space_incr((coll_meta_info *)info, ITEM_TYPE_SET, stotal);
-    }
-
     return ENGINE_SUCCESS;
+}
+
+static ENGINE_ERROR_CODE do_htree_elem_insert(set_meta_info *info, set_elem_item *elem,
+                                              size_t *space_increased)
+{
+    set_hash_node *node;
+    int hidx;
+    /* create the root hash node if it does not exist */
+    if (info->root == NULL) {
+        node = do_set_node_alloc(0);
+        if (node == NULL) {
+            return ENGINE_ENOMEM;
+        }
+        do_set_node_link(info, NULL, 0, node);
+        *space_increased += slabs_space_size(sizeof(set_hash_node));
+
+        hidx = SET_GET_HASHIDX(elem->hval, 0);
+        return do_htree_elem_link(info, node, hidx, elem, space_increased);
+    }
+
+    set_elem_item *find;
+    set_prev_info pinfo;
+
+    find = do_set_elem_find(info, elem->hval, elem->value, elem->nbytes, &pinfo);
+    if (find != NULL) {
+        return ENGINE_ELEM_EEXISTS;
+    }
+
+    node = pinfo.node;
+    hidx = pinfo.hidx;
+    return do_htree_elem_link(info, node, hidx, elem, space_increased);
 }
 
 static void do_set_elem_unlink(set_meta_info *info,
@@ -405,40 +437,6 @@ static void do_set_elem_unlink(set_meta_info *info,
     if (elem->refcount == 0) {
         do_set_elem_free(elem);
     }
-}
-
-static set_elem_item *do_set_elem_find(set_meta_info *info,
-                                       const void *key, uint16_t nkey,
-                                       set_prev_info *pinfo)
-{
-    if (info->root == NULL) return NULL;
-
-    set_hash_node *node = info->root;
-    int hval = genhash_string_hash(key, nkey);
-    int hidx;
-
-    while (node != NULL) {
-        hidx = SET_GET_HASHIDX(hval, node->hdepth);
-        if (node->hcnt[hidx] >= 0)
-            break;
-        node = node->htab[hidx];
-    }
-
-    set_elem_item *prev = NULL;
-    set_elem_item *elem;
-    for (elem = node->htab[hidx]; elem != NULL; elem = elem->next) {
-        if (set_hash_eq(hval, key, nkey, elem->hval, elem->value, elem->nbytes)) {
-            if (pinfo != NULL) {
-                pinfo->node = node;
-                pinfo->prev = prev;
-                pinfo->hidx = hidx;
-            }
-            break;
-        }
-        prev = elem;
-    }
-
-    return elem;
 }
 
 static ENGINE_ERROR_CODE do_set_elem_delete_by_value(set_meta_info *info, set_hash_node *node,
@@ -703,6 +701,9 @@ static ENGINE_ERROR_CODE do_set_elem_insert(hash_item *it, set_elem_item *elem)
     uint32_t real_mcnt = (info->mcnt > 0 ? info->mcnt : config->max_set_size);
     ENGINE_ERROR_CODE ret;
 
+    /* set hash value */
+    elem->hval = genhash_string_hash(elem->value, elem->nbytes);
+
 #ifdef ENABLE_STICKY_ITEM
     /* sticky memory limit check */
     if (IS_STICKY_EXPTIME(it->exptime)) {
@@ -717,27 +718,19 @@ static ENGINE_ERROR_CODE do_set_elem_insert(hash_item *it, set_elem_item *elem)
         return ENGINE_EOVERFLOW;
     }
 
-    /* create the root hash node if it does not exist */
-    bool new_root_flag = false;
-    if (info->root == NULL) { /* empty set */
-        set_hash_node *r_node = do_set_node_alloc(0);
-        if (r_node == NULL) {
-            return ENGINE_ENOMEM;
-        }
-        do_set_node_link(info, NULL, 0, r_node);
-        new_root_flag = true;
-    }
-
-    /* insert the element */
-    ret = do_set_elem_link(info, elem);
+    size_t space_increased = 0;
+    ret = do_htree_elem_insert(info, elem, &space_increased);
     if (ret != ENGINE_SUCCESS) {
-        if (new_root_flag) {
-            do_set_node_unlink(info, NULL, 0);
-        }
         return ret;
     }
 
     CLOG_SET_ELEM_INSERT(info, elem);
+    info->ccnt++;
+    if (1) { /* apply memory space */
+        size_t stotal = slabs_space_size(do_set_elem_ntotal(elem)) + space_increased;
+        do_coll_space_incr((coll_meta_info *)info, ITEM_TYPE_SET, stotal);
+    }
+
     return ENGINE_SUCCESS;
 }
 
@@ -887,7 +880,8 @@ ENGINE_ERROR_CODE set_elem_exist(const char *key, const uint32_t nkey,
             if ((info->mflags & COLL_META_FLAG_READABLE) == 0) {
                 ret = ENGINE_UNREADABLE; break;
             }
-            if (do_set_elem_find(info, value, nbytes, NULL) != NULL)
+            int hval = genhash_string_hash(value, nbytes);
+            if (do_set_elem_find(info, hval, value, nbytes, NULL) != NULL)
                 *exist = true;
             else
                 *exist = false;


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/844#issuecomment-4278095307


### ⌨️ What I did

- hash tree 모듈 추출을 위한 사전 작업으로, `do_set_elem_insert`와 `do_map_elem_insert`의 hash tree 조작 로직을 `do_htree_elem_insert`, `do_htree_elem_replace`로 분리했습니다.

- hash tree layer는 node 탐색, 중복 체크, node split, chain 연결, `elem->linked` 갱신, `hval` 세팅을 담당하고, collection layer에는 `info->ccnt` 갱신, space accounting, CLOG, elem alloc/free를 유지했습니다.

- node 생성 시 발생하는 space는 `do_htree_elem_insert`가 `space_increased`로 올려주고, collection layer에서 일괄 처리합니다.

- set은 sticky limit check → overflow check → `htree_elem_insert` 순서로 처리합니다.

- map은 `do_map_elem_find`로 먼저 탐색하고, 찾은 경우 `replace_if_exist=true`일 때만 해당 position에 `htree_elem_replace`를 수행하며, 찾지 못한 경우 set과 동일한 insert 경로를 탑니다.

- 현재 `do_map_elem_find`는 elem을 찾았을 때만 position을 채워서 반환하기 때문에, 찾지 못한 경우 `do_htree_elem_insert` 내부에서 position을 재탐색합니다. 추후 `do_map_elem_find`가 찾지 못했을 때도 마지막 탐색 위치를 채워서 반환하도록 변경하면, 해당 position을 `htree_elem_add()`에 바로 활용할 수 있습니다.

