### PR TITLE
INTERNAL: Separate htree and collection layer in map/set elem delete and get

### DIFF
--- a/engines/default/coll_map.c
+++ b/engines/default/coll_map.c
@@ -263,11 +263,6 @@ static void do_map_node_unlink(map_meta_info *info,
         par_node->hcnt[par_hidx] = fcnt;
     }
 
-    if (info->stotal > 0) { /* apply memory space */
-        size_t stotal = slabs_space_size(sizeof(map_hash_node));
-        do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_MAP, stotal);
-    }
-
     /* free the node */
     do_map_node_free(node);
 }
@@ -392,23 +387,25 @@ static ENGINE_ERROR_CODE do_htree_elem_add(map_meta_info *info, map_elem_item *e
 
 static void do_map_elem_unlink(map_meta_info *info,
                                map_hash_node *node, const int hidx,
-                               map_elem_item *prev, map_elem_item *elem,
-                               enum elem_delete_cause cause)
+                               map_elem_item *prev, map_elem_item *elem)
 {
     if (prev != NULL) prev->next = elem->next;
     else              node->htab[hidx] = elem->next;
     elem->linked--;
     node->hcnt[hidx] -= 1;
     node->tot_elem_cnt -= 1;
-    info->ccnt--;
+}
 
+static void do_map_elem_delete_post(map_meta_info *info,
+                                    map_elem_item *elem,
+                                    enum elem_delete_cause cause)
+{
     CLOG_MAP_ELEM_DELETE(info, elem, cause);
-
+    info->ccnt--;
     if (info->stotal > 0) { /* apply memory space */
         size_t stotal = slabs_space_size(do_map_elem_ntotal(elem));
         do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_MAP, stotal);
     }
-
     assert(elem->linked == 0);
     if (elem->refcount == 0) {
         do_map_elem_free(elem);
@@ -417,7 +414,7 @@ static void do_map_elem_unlink(map_meta_info *info,
 
 static bool do_map_elem_get_by_field(map_meta_info *info, map_hash_node *node, const int hval,
                                      const field_t *field, const bool delete,
-                                     map_elem_item **elem_array)
+                                     map_elem_item **elem_array, size_t *space_decreased)
 {
     assert(elem_array != NULL);
     bool ret;
@@ -425,10 +422,11 @@ static bool do_map_elem_get_by_field(map_meta_info *info, map_hash_node *node, c
 
     if (node->hcnt[hidx] == -1) {
         map_hash_node *child_node = node->htab[hidx];
-        ret = do_map_elem_get_by_field(info, child_node, hval, field, delete, elem_array);
+        ret = do_map_elem_get_by_field(info, child_node, hval, field, delete, elem_array, space_decreased);
         if (ret && delete) {
             if (child_node->tot_elem_cnt < (MAP_MAX_HASHCHAIN_SIZE/2)) {
                 do_map_node_unlink(info, node, hidx);
+                *space_decreased += slabs_space_size(sizeof(map_hash_node));
             }
             node->tot_elem_cnt -= 1;
         }
@@ -442,7 +440,7 @@ static bool do_map_elem_get_by_field(map_meta_info *info, map_hash_node *node, c
                     elem->refcount++;
                     elem_array[0] = elem;
                     if (delete) {
-                        do_map_elem_unlink(info, node, hidx, prev, elem, ELEM_DELETE_NORMAL);
+                        do_map_elem_unlink(info, node, hidx, prev, elem);
                     }
                     ret = true;
                     break;
@@ -455,30 +453,30 @@ static bool do_map_elem_get_by_field(map_meta_info *info, map_hash_node *node, c
     return ret;
 }
 
-static bool do_map_elem_delete_by_field(map_meta_info *info, map_hash_node *node, const int hval,
-                                        const field_t *field)
+static map_elem_item *do_map_elem_delete_by_field(map_meta_info *info, map_hash_node *node, const int hval,
+                                                  const field_t *field, size_t *space_decreased)
 {
-    bool ret;
+    map_elem_item *deleted = NULL;
     int hidx = MAP_GET_HASHIDX(hval, node->hdepth);
 
     if (node->hcnt[hidx] == -1) {
         map_hash_node *child_node = node->htab[hidx];
-        ret = do_map_elem_delete_by_field(info, child_node, hval, field);
-        if (ret) {
+        deleted = do_map_elem_delete_by_field(info, child_node, hval, field, space_decreased);
+        if (deleted) {
             if (child_node->tot_elem_cnt < (MAP_MAX_HASHCHAIN_SIZE/2)) {
                 do_map_node_unlink(info, node, hidx);
+                *space_decreased += slabs_space_size(sizeof(map_hash_node));
             }
             node->tot_elem_cnt -= 1;
         }
     } else {
-        ret = false;
         if (node->hcnt[hidx] > 0) {
             map_elem_item *prev = NULL;
             map_elem_item *elem = node->htab[hidx];
             while (elem != NULL) {
                 if (map_hash_eq(hval, field->value, field->length, elem->hval, elem->data, elem->nfield)) {
-                    do_map_elem_unlink(info, node, hidx, prev, elem, ELEM_DELETE_NORMAL);
-                    ret = true;
+                    do_map_elem_unlink(info, node, hidx, prev, elem);
+                    deleted = elem;
                     break;
                 }
                 prev = elem;
@@ -486,11 +484,11 @@ static bool do_map_elem_delete_by_field(map_meta_info *info, map_hash_node *node
             }
         }
     }
-    return ret;
+    return deleted;
 }
 
 static int do_map_elem_get_all(map_meta_info *info, map_hash_node *node,
-                               const bool delete, map_elem_item **elem_array)
+                               const bool delete, map_elem_item **elem_array, size_t *space_decreased)
 {
     assert(elem_array != NULL);
     int hidx;
@@ -499,11 +497,12 @@ static int do_map_elem_get_all(map_meta_info *info, map_hash_node *node,
     for (hidx = 0; hidx < MAP_HASHTAB_SIZE; hidx++) {
         if (node->hcnt[hidx] == -1) {
             map_hash_node *child_node = (map_hash_node *)node->htab[hidx];
-            int ecnt = do_map_elem_get_all(info, child_node, delete, &elem_array[fcnt]);
+            int ecnt = do_map_elem_get_all(info, child_node, delete, &elem_array[fcnt], space_decreased);
             fcnt += ecnt;
             if (delete) {
                 if (child_node->tot_elem_cnt < (MAP_MAX_HASHCHAIN_SIZE/2)) {
                     do_map_node_unlink(info, node, hidx);
+                    *space_decreased += slabs_space_size(sizeof(map_hash_node));
                 }
                 node->tot_elem_cnt -= ecnt;
             }
@@ -513,7 +512,7 @@ static int do_map_elem_get_all(map_meta_info *info, map_hash_node *node,
                 elem->refcount++;
                 elem_array[fcnt] = elem;
                 fcnt++;
-                if (delete) do_map_elem_unlink(info, node, hidx, NULL, elem, ELEM_DELETE_NORMAL);
+                if (delete) do_map_elem_unlink(info, node, hidx, NULL, elem);
                 elem = (delete ? node->htab[hidx] : elem->next);
             }
         }
@@ -522,7 +521,8 @@ static int do_map_elem_get_all(map_meta_info *info, map_hash_node *node,
 }
 
 static int do_map_elem_delete_by_count(map_meta_info *info, map_hash_node *node,
-                                       const uint32_t count, enum elem_delete_cause cause)
+                                       const uint32_t count, map_elem_item **deleted_head,
+                                       size_t *space_decreased)
 {
     int hidx;
     int fcnt = 0;
@@ -531,17 +531,23 @@ static int do_map_elem_delete_by_count(map_meta_info *info, map_hash_node *node,
         if (node->hcnt[hidx] == -1) {
             map_hash_node *child_node = (map_hash_node *)node->htab[hidx];
             int rcnt = (count > 0 ? (count - fcnt) : 0);
-            int ecnt = do_map_elem_delete_by_count(info, child_node, rcnt, cause);
+            int ecnt = do_map_elem_delete_by_count(info, child_node, rcnt, deleted_head, space_decreased);
             fcnt += ecnt;
             if (child_node->tot_elem_cnt < (MAP_MAX_HASHCHAIN_SIZE/2)) {
                 do_map_node_unlink(info, node, hidx);
+                *space_decreased += slabs_space_size(sizeof(map_hash_node));
             }
             node->tot_elem_cnt -= ecnt;
         } else if (node->hcnt[hidx] > 0) {
             map_elem_item *elem = node->htab[hidx];
             while (elem != NULL) {
                 fcnt++;
-                do_map_elem_unlink(info, node, hidx, NULL, elem, cause);
+                do_map_elem_unlink(info, node, hidx, NULL, elem);
+
+                /* link deleted elem into list; returned to caller */
+                elem->next = *deleted_head;
+                *deleted_head = elem;
+
                 if (count > 0 && fcnt >= count) break;
                 elem = node->htab[hidx];
             }
@@ -556,22 +562,42 @@ static uint32_t do_map_elem_delete(map_meta_info *info, const int numfields,
 {
     uint32_t delcnt = 0;
     enum elem_delete_cause cause = ELEM_DELETE_NORMAL;
+    size_t space_decreased = 0;
+    map_elem_item *deleted = NULL;
 
     if (info->root != NULL) {
         CLOG_ELEM_DELETE_BEGIN((coll_meta_info*)info, numfields, cause);
         if (numfields == 0) {
-            delcnt = do_map_elem_delete_by_count(info, info->root, 0, cause);
+            map_elem_item *deleted_head = NULL;
+            delcnt = do_map_elem_delete_by_count(info, info->root, 0, &deleted_head, &space_decreased);
+
+            deleted = deleted_head;
+            while (deleted != NULL) {
+                map_elem_item *next = deleted->next;
+                do_map_elem_delete_post(info, deleted, cause);
+                deleted = next;
+            }
         } else {
             for (int ii = 0; ii < numfields; ii++) {
                 int hval = genhash_string_hash(flist[ii].value, flist[ii].length);
-                if (do_map_elem_delete_by_field(info, info->root, hval, &flist[ii])) {
+
+                deleted = do_map_elem_delete_by_field(info, info->root, hval, &flist[ii], &space_decreased);
+                if (deleted != NULL) {
+                    do_map_elem_delete_post(info, deleted, cause);
                     delcnt++;
                 }
             }
         }
+
         if (info->root->tot_elem_cnt == 0) {
             do_map_node_unlink(info, NULL, 0);
+            space_decreased += slabs_space_size(sizeof(map_hash_node));
         }
+
+        if (info->stotal > 0 && space_decreased > 0) { /* apply memory space */
+            do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_MAP, space_decreased);
+        }
+
         CLOG_ELEM_DELETE_END((coll_meta_info*)info, cause);
     }
     return delcnt;
@@ -666,25 +692,36 @@ static uint32_t do_map_elem_get(map_meta_info *info,
     assert(info->root);
     uint32_t fcnt = 0;
     enum elem_delete_cause cause = ELEM_DELETE_NORMAL;
+    size_t space_decreased = 0;
 
     if (delete) {
         CLOG_ELEM_DELETE_BEGIN((coll_meta_info*)info, numfields, cause);
     }
     if (numfields == 0) {
-        fcnt = do_map_elem_get_all(info, info->root, delete, elem_array);
+        fcnt = do_map_elem_get_all(info, info->root, delete, elem_array, &space_decreased);
+        if (delete) {
+            for (int ii = 0; ii < fcnt; ii++) {
+                do_map_elem_delete_post(info, elem_array[ii], cause);
+            }
+        }
     } else {
         for (int ii = 0; ii < numfields; ii++) {
             int hval = genhash_string_hash(flist[ii].value, flist[ii].length);
             if (do_map_elem_get_by_field(info, info->root, hval, &flist[ii],
-                                         delete, &elem_array[fcnt])) {
+                                         delete, &elem_array[fcnt], &space_decreased)) {
+                if (delete) do_map_elem_delete_post(info, elem_array[fcnt], cause);
                 fcnt++;
             }
         }
     }
-    if (delete && info->root->tot_elem_cnt == 0) {
-        do_map_node_unlink(info, NULL, 0);
-    }
     if (delete) {
+        if (info->root->tot_elem_cnt == 0) {
+            do_map_node_unlink(info, NULL, 0);
+            space_decreased += slabs_space_size(sizeof(map_hash_node));
+        }
+        if (info->stotal > 0 && space_decreased > 0) { /* apply memory space */
+            do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_MAP, space_decreased);
+        }
         CLOG_ELEM_DELETE_END((coll_meta_info*)info, cause);
     }
     return fcnt;
@@ -963,12 +1000,26 @@ ENGINE_ERROR_CODE map_elem_get(const char *key, const uint32_t nkey,
 uint32_t map_elem_delete_with_count(map_meta_info *info, const uint32_t count)
 {
     uint32_t fcnt = 0;
+    size_t space_decreased = 0;
 
     // cache_lock is held by caller.
     if (info->root != NULL) {
-        fcnt = do_map_elem_delete_by_count(info, info->root, count, ELEM_DELETE_COLL);
+        map_elem_item *deleted_head = NULL;
+        fcnt = do_map_elem_delete_by_count(info, info->root, count, &deleted_head, &space_decreased);
+
+        map_elem_item *deleted = deleted_head;
+        while (deleted != NULL) {
+            map_elem_item *next = deleted->next;
+            do_map_elem_delete_post(info, deleted, ELEM_DELETE_COLL);
+            deleted = next;
+        }
+
         if (info->root->tot_elem_cnt == 0) {
             do_map_node_unlink(info, NULL, 0);
+            space_decreased += slabs_space_size(sizeof(map_hash_node));
+        }
+        if (info->stotal > 0 && space_decreased > 0) { /* apply memory space */
+            do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_MAP, space_decreased);
         }
     }
     return fcnt;
@@ -978,7 +1029,7 @@ void map_elem_get_all(map_meta_info *info, elems_result_t *eresult)
 {
     assert(eresult->elem_arrsz >= info->ccnt && eresult->elem_count == 0);
     eresult->elem_count = do_map_elem_get_all(info, info->root, false,
-                                              (map_elem_item **)eresult->elem_array);
+                                              (map_elem_item **)eresult->elem_array, NULL);
     assert(eresult->elem_count == info->ccnt);
 }
 

--- a/engines/default/coll_set.c
+++ b/engines/default/coll_set.c
@@ -306,11 +306,6 @@ static void do_set_node_unlink(set_meta_info *info,
         par_node->hcnt[par_hidx] = fcnt;
     }
 
-    if (info->stotal > 0) { /* apply memory space */
-        size_t stotal = slabs_space_size(sizeof(set_hash_node));
-        do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_SET, stotal);
-    }
-
     /* free the node */
     do_set_node_free(node);
 }
@@ -416,85 +411,92 @@ static ENGINE_ERROR_CODE do_htree_elem_insert(set_meta_info *info, set_elem_item
 
 static void do_set_elem_unlink(set_meta_info *info,
                                set_hash_node *node, const int hidx,
-                               set_elem_item *prev, set_elem_item *elem,
-                               enum elem_delete_cause cause)
+                               set_elem_item *prev, set_elem_item *elem)
 {
     if (prev != NULL) prev->next = elem->next;
     else              node->htab[hidx] = elem->next;
     elem->linked--;
     node->hcnt[hidx] -= 1;
     node->tot_elem_cnt -= 1;
-    info->ccnt--;
+}
 
+static void do_set_elem_delete_post(set_meta_info *info,
+                                    set_elem_item *elem,
+                                    enum elem_delete_cause cause)
+{
     CLOG_SET_ELEM_DELETE(info, elem, cause);
-
+    info->ccnt--;
     if (info->stotal > 0) { /* apply memory space */
         size_t stotal = slabs_space_size(do_set_elem_ntotal(elem));
         do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_SET, stotal);
     }
-
     assert(elem->linked == 0);
     if (elem->refcount == 0) {
         do_set_elem_free(elem);
     }
 }
 
-static ENGINE_ERROR_CODE do_set_elem_delete_by_value(set_meta_info *info, set_hash_node *node,
-                                                     const int hval, const char *val, const int vlen)
+static set_elem_item *do_set_elem_delete_by_value(set_meta_info *info, set_hash_node *node,
+                                                   const int hval, const char *val, const int vlen,
+                                                   size_t *space_decreased)
 {
-    ENGINE_ERROR_CODE ret;
-
+    set_elem_item *deleted = NULL;
     int hidx = SET_GET_HASHIDX(hval, node->hdepth);
 
     if (node->hcnt[hidx] == -1) {
         set_hash_node *child_node = node->htab[hidx];
-        ret = do_set_elem_delete_by_value(info, child_node, hval, val, vlen);
-        if (ret == ENGINE_SUCCESS) {
+        deleted = do_set_elem_delete_by_value(info, child_node, hval, val, vlen, space_decreased);
+        if (deleted) {
             if (child_node->tot_elem_cnt < (SET_MAX_HASHCHAIN_SIZE/2)) {
                 do_set_node_unlink(info, node, hidx);
+                *space_decreased += slabs_space_size(sizeof(set_hash_node));
             }
             node->tot_elem_cnt -= 1;
         }
     } else {
-        ret = ENGINE_ELEM_ENOENT;
         if (node->hcnt[hidx] > 0) {
             set_elem_item *prev = NULL;
             set_elem_item *elem = node->htab[hidx];
             while (elem != NULL) {
-                if (set_hash_eq(hval, val, vlen, elem->hval, elem->value, elem->nbytes))
+                if (set_hash_eq(hval, val, vlen, elem->hval, elem->value, elem->nbytes)) {
+                    do_set_elem_unlink(info, node, hidx, prev, elem);
+                    deleted = elem;
                     break;
+                }
                 prev = elem;
                 elem = elem->next;
             }
-            if (elem != NULL) {
-                do_set_elem_unlink(info, node, hidx, prev, elem, ELEM_DELETE_NORMAL);
-                ret = ENGINE_SUCCESS;
-            }
         }
     }
-    return ret;
+    return deleted;
 }
 
 static ENGINE_ERROR_CODE do_set_elem_delete(set_meta_info *info,
                                             const char *val, const int vlen)
 {
-    ENGINE_ERROR_CODE ret;
+    ENGINE_ERROR_CODE ret = ENGINE_ELEM_ENOENT;
     if (info->root != NULL) {
         int hval = genhash_string_hash(val, vlen);
-        ret = do_set_elem_delete_by_value(info, info->root, hval, val, vlen);
-        if (ret == ENGINE_SUCCESS) {
+        size_t space_decreased = 0;
+        set_elem_item *deleted = do_set_elem_delete_by_value(info, info->root, hval, val, vlen, &space_decreased);
+        if (deleted != NULL) {
+            do_set_elem_delete_post(info, deleted, ELEM_DELETE_NORMAL);
             if (info->root->tot_elem_cnt == 0) {
                 do_set_node_unlink(info, NULL, 0);
+                space_decreased += slabs_space_size(sizeof(set_hash_node));
             }
+            if (info->stotal > 0 && space_decreased > 0) {
+                do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_SET, space_decreased);
+            }
+            ret = ENGINE_SUCCESS;
         }
-    } else {
-        ret = ENGINE_ELEM_ENOENT;
     }
     return ret;
 }
 
 static int do_set_elem_get_all(set_meta_info *info, set_hash_node *node,
-                               const bool delete, set_elem_item **elem_array)
+                               const bool delete, set_elem_item **elem_array,
+                               size_t *space_decreased)
 {
     assert(elem_array != NULL);
     int hidx;
@@ -503,11 +505,12 @@ static int do_set_elem_get_all(set_meta_info *info, set_hash_node *node,
     for (hidx = 0; hidx < SET_HASHTAB_SIZE; hidx++) {
         if (node->hcnt[hidx] == -1) {
             set_hash_node *child_node = (set_hash_node *)node->htab[hidx];
-            int ecnt = do_set_elem_get_all(info, child_node, delete, &elem_array[fcnt]);
+            int ecnt = do_set_elem_get_all(info, child_node, delete, &elem_array[fcnt], space_decreased);
             fcnt += ecnt;
             if (delete) {
                 if (child_node->tot_elem_cnt < (SET_MAX_HASHCHAIN_SIZE/2)) {
                     do_set_node_unlink(info, node, hidx);
+                    *space_decreased += slabs_space_size(sizeof(set_hash_node));
                 }
                 node->tot_elem_cnt -= ecnt;
             }
@@ -517,7 +520,7 @@ static int do_set_elem_get_all(set_meta_info *info, set_hash_node *node,
                 elem->refcount++;
                 elem_array[fcnt] = elem;
                 fcnt++;
-                if (delete) do_set_elem_unlink(info, node, hidx, NULL, elem, ELEM_DELETE_NORMAL);
+                if (delete) do_set_elem_unlink(info, node, hidx, NULL, elem);
                 elem = (delete ? node->htab[hidx] : elem->next);
             }
         }
@@ -526,7 +529,8 @@ static int do_set_elem_get_all(set_meta_info *info, set_hash_node *node,
 }
 
 static int do_set_elem_delete_by_count(set_meta_info *info, set_hash_node *node,
-                                       const uint32_t count, enum elem_delete_cause cause)
+                                       const uint32_t count, set_elem_item **deleted_head,
+                                       size_t *space_decreased)
 {
     int hidx;
     int fcnt = 0;
@@ -535,17 +539,23 @@ static int do_set_elem_delete_by_count(set_meta_info *info, set_hash_node *node,
         if (node->hcnt[hidx] == -1) {
             set_hash_node *child_node = (set_hash_node *)node->htab[hidx];
             int rcnt = (count > 0 ? (count - fcnt) : 0);
-            int ecnt = do_set_elem_delete_by_count(info, child_node, rcnt, cause);
+            int ecnt = do_set_elem_delete_by_count(info, child_node, rcnt, deleted_head, space_decreased);
             fcnt += ecnt;
             if (child_node->tot_elem_cnt < (SET_MAX_HASHCHAIN_SIZE/2)) {
                 do_set_node_unlink(info, node, hidx);
+                *space_decreased += slabs_space_size(sizeof(set_hash_node));
             }
             node->tot_elem_cnt -= ecnt;
         } else if (node->hcnt[hidx] > 0) {
             set_elem_item *elem = node->htab[hidx];
             while (elem != NULL) {
                 fcnt++;
-                do_set_elem_unlink(info, node, hidx, NULL, elem, cause);
+                do_set_elem_unlink(info, node, hidx, NULL, elem);
+
+                /* link deleted elem into list; returned to caller */
+                elem->next = *deleted_head;
+                *deleted_head = elem;
+
                 if (count > 0 && fcnt >= count) break;
                 elem = node->htab[hidx];
             }
@@ -587,7 +597,8 @@ static int do_set_elem_get_sampling(set_meta_info *info, set_hash_node *node,
 }
 
 static set_elem_item *do_set_elem_get_by_offset(set_meta_info *info, set_hash_node *node,
-                                                uint32_t offset, const bool delete)
+                                                uint32_t offset, const bool delete,
+                                                size_t *space_decreased)
 {
     int hidx;
     for (hidx = 0; hidx < SET_HASHTAB_SIZE; hidx++) {
@@ -597,10 +608,11 @@ static set_elem_item *do_set_elem_get_by_offset(set_meta_info *info, set_hash_no
                 offset -= child_node->tot_elem_cnt;
                 continue;
             }
-            set_elem_item *found = do_set_elem_get_by_offset(info, child_node, offset, delete);
+            set_elem_item *found = do_set_elem_get_by_offset(info, child_node, offset, delete, space_decreased);
             if (delete) {
                 if (child_node->tot_elem_cnt < (SET_MAX_HASHCHAIN_SIZE/2)) {
                     do_set_node_unlink(info, node, hidx);
+                    *space_decreased += slabs_space_size(sizeof(set_hash_node));
                 }
                 node->tot_elem_cnt -= 1;
             }
@@ -618,8 +630,7 @@ static set_elem_item *do_set_elem_get_by_offset(set_meta_info *info, set_hash_no
                 offset -= 1;
             }
             elem->refcount++;
-            if (delete) do_set_elem_unlink(info, node, hidx, prev, elem,
-                                           ELEM_DELETE_NORMAL);
+            if (delete) do_set_elem_unlink(info, node, hidx, prev, elem);
             return elem;
         }
     }
@@ -628,7 +639,8 @@ static set_elem_item *do_set_elem_get_by_offset(set_meta_info *info, set_hash_no
 
 static uint32_t do_set_elem_get_rand(set_meta_info *info,
                                      const uint32_t count, const bool delete,
-                                     set_elem_item **elem_array)
+                                     set_elem_item **elem_array,
+                                     size_t *space_decreased)
 {
     assert(elem_array != NULL);
     uint32_t fcnt = 0;
@@ -637,7 +649,7 @@ static uint32_t do_set_elem_get_rand(set_meta_info *info,
         while (fcnt < count) {
             int rand_offset = (rand() % info->ccnt);
             set_elem_item *found = do_set_elem_get_by_offset(info, info->root,
-                                                             rand_offset, delete);
+                                                             rand_offset, delete, space_decreased);
             assert(found != NULL);
             elem_array[fcnt++] = found;
         }
@@ -649,7 +661,7 @@ static uint32_t do_set_elem_get_rand(set_meta_info *info,
             int rand_offset = (rand() % info->ccnt);
             if (hash_insert(&offset_ht, rand_offset)) {
                 set_elem_item *found = do_set_elem_get_by_offset(info, info->root,
-                                                                 rand_offset, delete);
+                                                                 rand_offset, false, NULL);
                 assert(found != NULL);
                 elem_array[fcnt++] = found;
             }
@@ -678,18 +690,26 @@ static uint32_t do_set_elem_get(set_meta_info *info,
     uint32_t fcnt;
     enum elem_delete_cause cause = ELEM_DELETE_NORMAL;
 
+    size_t space_decreased = 0;
     if (delete) {
         CLOG_ELEM_DELETE_BEGIN((coll_meta_info*)info, count, cause);
     }
     if (count >= info->ccnt || count == 0) { /* Return all */
-        fcnt = do_set_elem_get_all(info, info->root, delete, elem_array);
+        fcnt = do_set_elem_get_all(info, info->root, delete, elem_array, &space_decreased);
     } else { /* Return some */
-        fcnt = do_set_elem_get_rand(info, count, delete, elem_array);
-    }
-    if (delete && info->root->tot_elem_cnt == 0) {
-        do_set_node_unlink(info, NULL, 0);
+        fcnt = do_set_elem_get_rand(info, count, delete, elem_array, &space_decreased);
     }
     if (delete) {
+        for (int ii = 0; ii < fcnt; ii++) {
+            do_set_elem_delete_post(info, elem_array[ii], cause);
+        }
+        if (info->root->tot_elem_cnt == 0) {
+            do_set_node_unlink(info, NULL, 0);
+            space_decreased += slabs_space_size(sizeof(set_hash_node));
+        }
+        if (info->stotal > 0 && space_decreased > 0) {
+            do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_SET, space_decreased);
+        }
         CLOG_ELEM_DELETE_END((coll_meta_info*)info, cause);
     }
     return fcnt;
@@ -955,12 +975,26 @@ ENGINE_ERROR_CODE set_elem_get(const char *key, const uint32_t nkey,
 uint32_t set_elem_delete_with_count(set_meta_info *info, const uint32_t count)
 {
     uint32_t fcnt = 0;
+    size_t space_decreased = 0;
 
     // cache_lock is held by caller
     if (info->root != NULL) {
-        fcnt = do_set_elem_delete_by_count(info, info->root, count, ELEM_DELETE_COLL);
+        set_elem_item *deleted_head = NULL;
+        fcnt = do_set_elem_delete_by_count(info, info->root, count, &deleted_head, &space_decreased);
+
+        set_elem_item *deleted = deleted_head;
+        while (deleted != NULL) {
+            set_elem_item *next = deleted->next;
+            do_set_elem_delete_post(info, deleted, ELEM_DELETE_COLL);
+            deleted = next;
+        }
+
         if (info->root->tot_elem_cnt == 0) {
             do_set_node_unlink(info, NULL, 0);
+            space_decreased += slabs_space_size(sizeof(set_hash_node));
+        }
+        if (info->stotal > 0 && space_decreased > 0) { /* apply memory space */
+            do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_SET, space_decreased);
         }
     }
     return fcnt;
@@ -970,7 +1004,7 @@ void set_elem_get_all(set_meta_info *info, elems_result_t *eresult)
 {
     assert(eresult->elem_arrsz >= info->ccnt && eresult->elem_count == 0);
     eresult->elem_count = do_set_elem_get_all(info, info->root, false,
-                                              (set_elem_item**)(eresult->elem_array));
+                                              (set_elem_item**)(eresult->elem_array), NULL);
     assert(eresult->elem_count == info->ccnt);
 }
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/844#issuecomment-4278095307


### ⌨️ What I did

hash_tree 모듈 추출을 위한 사전 작업으로, map/set의 delete/get 경로에서 hash tree layer와 collection layer를 분리했습니다.

기존 `do_map_elem_unlink`는 chain unlink와 `ccnt--`, `CLOG`, `space accounting`, `free(collection)`를 한 함수에서 모두 처리하고 있었습니다.
이를 htree layer는 unlink만 담당하고, collection layer 후처리는 caller가 맡도록 나눴습니다.

기존 로직을 최대한 건드리지 않는 선에서 레이어 경계를 맞추는 것을 우선으로 했습니다.

---

#### delete 단건 — `do_map_elem_delete_by_field` / `do_set_elem_delete_by_value`

반환 타입을 `bool → {map/set}_elem_item *`으로 변경했습니다. caller가 반환된 elem을 받아 후처리할 수 있도록 했습니다.

---

#### delete bulk — `do_{map/set}_elem_delete_by_count`

unlink된 elem들을 linked list로 묶어 반환합니다. caller에서 리스트를 순회하며 후처리합니다.

---

#### get — `do_map_elem_get_by_field`, `do_{map/set}_elem_get_all`, `do_set_elem_get_rand`

어차피 `elem_array`로 반환하므로 별도 chain 연결은 불필요합니다. caller에서 `elem_array`를 순회하며 `refcount++`와 delete 후처리를 함께 처리하도록 했습니다.

---

#### 공통 — `do_{map/set}_delete_post`

후처리 로직(CLOG, ccnt--, space accounting, free)이 여러 경로에서 반복되어 별도 함수로 추출했습니다.

---

#### 비고
**root node unlink**

```c
if (info->root->tot_elem_cnt == 0) {
    do_map_node_unlink(info, NULL, 0);
    space_decreased += slabs_space_size(sizeof(map_hash_node));
}
```

이 부분은 본래 hash tree layer로 이동해야 합니다. delete/get 함수들이 재귀 구조이므로, 현재는 내부로 이동하지 못 했고
추후 hash_tree 모듈 추출 시 public 함수 안에서 재귀 호출을 마친 뒤 root가 비었으면 unlink하는 형태로 옮길 예정입니다.

**do_map_elem_get_all**
hash tree로 추출 시 `do_map_elem_get_by_count` 형태로 변경할 예정입니다.

