### PR TITLE
INTERNAL: Extract hash tree module from set/map collections

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -171,6 +171,8 @@ default_engine_la_SOURCES= \
                     engines/default/item_clog.h \
                     engines/default/item_base.c \
                     engines/default/item_base.h \
+                    engines/default/hash_tree.c \
+                    engines/default/hash_tree.h \
                     engines/default/coll_list.c \
                     engines/default/coll_list.h \
                     engines/default/coll_set.c \

--- a/engines/default/coll_map.c
+++ b/engines/default/coll_map.c
@@ -61,12 +61,6 @@ static const void *map_get_key(const htree_elem_item *elem, uint16_t *nkey)
 
 static htree_ops map_htree_ops = { map_get_key };
 
-static inline int map_hash_eq(const int h1, const void *v1, size_t vlen1,
-                              const int h2, const void *v2, size_t vlen2)
-{
-    return (h1 == h2 && vlen1 == vlen2 && memcmp(v1, v2, vlen1) == 0);
-}
-
 static inline uint32_t do_map_elem_ntotal(map_elem_item *elem)
 {
     return sizeof(map_elem_item) + elem->nfield + elem->nbytes;
@@ -136,11 +130,6 @@ static hash_item *do_map_item_alloc(const void *key, const uint32_t nkey,
     return it;
 }
 
-static void do_map_node_free(htree_node *node)
-{
-    do_item_mem_free(node, sizeof(htree_node));
-}
-
 static map_elem_item *do_map_elem_alloc(const int nfield,
                                         const uint32_t nbytes)
 {
@@ -177,60 +166,6 @@ static void do_map_elem_release(map_elem_item *elem)
     }
 }
 
-static void do_map_node_unlink(htree_meta *htree,
-                               htree_node *par_node, const int par_hidx)
-{
-    htree_node *node;
-
-    if (par_node == NULL) {
-        node = htree->root;
-        htree->root = NULL;
-        assert(node->tot_elem_cnt == 0);
-    } else {
-        assert(par_node->hcnt[par_hidx] == -1); /* child hash node */
-        map_elem_item *head = NULL;
-        map_elem_item *elem;
-        int hidx, fcnt = 0;
-
-        node = (htree_node *)par_node->htab[par_hidx];
-        assert(node->tot_elem_cnt < (HTREE_MAX_HASHCHAIN_SIZE/2));
-
-        for (hidx = 0; hidx < HTREE_HASHTAB_SIZE; hidx++) {
-            assert(node->hcnt[hidx] >= 0);
-            if (node->hcnt[hidx] > 0) {
-                fcnt += node->hcnt[hidx];
-                while (node->htab[hidx] != NULL) {
-                    elem = node->htab[hidx];
-                    node->htab[hidx] = elem->next;
-                    node->hcnt[hidx] -= 1;
-
-                    elem->next = head;
-                    head = elem;
-                }
-                assert(node->hcnt[hidx] == 0);
-            }
-        }
-        assert(fcnt == node->tot_elem_cnt);
-        node->tot_elem_cnt = 0;
-
-        par_node->htab[par_hidx] = head;
-        par_node->hcnt[par_hidx] = fcnt;
-    }
-
-    /* free the node */
-    do_map_node_free(node);
-}
-
-static void do_map_elem_unlink(htree_node *node, const int hidx,
-                               map_elem_item *prev, map_elem_item *elem)
-{
-    if (prev != NULL) prev->next = elem->next;
-    else              node->htab[hidx] = elem->next;
-    elem->linked--;
-    node->hcnt[hidx] -= 1;
-    node->tot_elem_cnt -= 1;
-}
-
 static void do_map_elem_delete_post(map_meta_info *info,
                                     map_elem_item *elem,
                                     enum elem_delete_cause cause)
@@ -247,151 +182,6 @@ static void do_map_elem_delete_post(map_meta_info *info,
     }
 }
 
-static bool do_map_elem_get_by_field(htree_meta *htree, htree_node *node, const int hval,
-                                     const field_t *field, const bool delete,
-                                     map_elem_item **elem_array, size_t *space_decreased)
-{
-    assert(elem_array != NULL);
-    bool ret;
-    int hidx = HTREE_GET_HASHIDX(hval, node->hdepth);
-
-    if (node->hcnt[hidx] == -1) {
-        htree_node *child_node = node->htab[hidx];
-        ret = do_map_elem_get_by_field(htree, child_node, hval, field, delete, elem_array, space_decreased);
-        if (ret && delete) {
-            if (child_node->tot_elem_cnt < (HTREE_MAX_HASHCHAIN_SIZE/2)) {
-                do_map_node_unlink(htree, node, hidx);
-                *space_decreased += slabs_space_size(sizeof(htree_node));
-            }
-            node->tot_elem_cnt -= 1;
-        }
-    } else {
-        ret = false;
-        if (node->hcnt[hidx] > 0) {
-            map_elem_item *prev = NULL;
-            map_elem_item *elem = node->htab[hidx];
-            while (elem != NULL) {
-                if (map_hash_eq(hval, field->value, field->length, elem->hval, elem->data, elem->nfield)) {
-                    elem->refcount++;
-                    elem_array[0] = elem;
-                    if (delete) {
-                        do_map_elem_unlink(node, hidx, prev, elem);
-                    }
-                    ret = true;
-                    break;
-                }
-                prev = elem;
-                elem = elem->next;
-            }
-        }
-    }
-    return ret;
-}
-
-static map_elem_item *do_map_elem_delete_by_field(htree_meta *htree, htree_node *node, const int hval,
-                                                  const field_t *field, size_t *space_decreased)
-{
-    map_elem_item *deleted = NULL;
-    int hidx = HTREE_GET_HASHIDX(hval, node->hdepth);
-
-    if (node->hcnt[hidx] == -1) {
-        htree_node *child_node = node->htab[hidx];
-        deleted = do_map_elem_delete_by_field(htree, child_node, hval, field, space_decreased);
-        if (deleted) {
-            if (child_node->tot_elem_cnt < (HTREE_MAX_HASHCHAIN_SIZE/2)) {
-                do_map_node_unlink(htree, node, hidx);
-                *space_decreased += slabs_space_size(sizeof(htree_node));
-            }
-            node->tot_elem_cnt -= 1;
-        }
-    } else {
-        if (node->hcnt[hidx] > 0) {
-            map_elem_item *prev = NULL;
-            map_elem_item *elem = node->htab[hidx];
-            while (elem != NULL) {
-                if (map_hash_eq(hval, field->value, field->length, elem->hval, elem->data, elem->nfield)) {
-                    do_map_elem_unlink(node, hidx, prev, elem);
-                    deleted = elem;
-                    break;
-                }
-                prev = elem;
-                elem = elem->next;
-            }
-        }
-    }
-    return deleted;
-}
-
-static int do_map_elem_get_all(htree_meta *htree, htree_node *node,
-                               const bool delete, map_elem_item **elem_array, size_t *space_decreased)
-{
-    assert(elem_array != NULL);
-    int hidx;
-    int fcnt = 0; /* found count */
-
-    for (hidx = 0; hidx < HTREE_HASHTAB_SIZE; hidx++) {
-        if (node->hcnt[hidx] == -1) {
-            htree_node *child_node = (htree_node *)node->htab[hidx];
-            int ecnt = do_map_elem_get_all(htree, child_node, delete, &elem_array[fcnt], space_decreased);
-            fcnt += ecnt;
-            if (delete) {
-                if (child_node->tot_elem_cnt < (HTREE_MAX_HASHCHAIN_SIZE/2)) {
-                    do_map_node_unlink(htree, node, hidx);
-                    *space_decreased += slabs_space_size(sizeof(htree_node));
-                }
-                node->tot_elem_cnt -= ecnt;
-            }
-        } else if (node->hcnt[hidx] > 0) {
-            map_elem_item *elem = node->htab[hidx];
-            while (elem != NULL) {
-                elem->refcount++;
-                elem_array[fcnt] = elem;
-                fcnt++;
-                if (delete) do_map_elem_unlink(node, hidx, NULL, elem);
-                elem = (delete ? node->htab[hidx] : elem->next);
-            }
-        }
-    }
-    return fcnt;
-}
-
-static int do_map_elem_delete_by_count(htree_meta *htree, htree_node *node,
-                                       const uint32_t count, map_elem_item **deleted_head,
-                                       size_t *space_decreased)
-{
-    int hidx;
-    int fcnt = 0;
-
-    for (hidx = 0; hidx < HTREE_HASHTAB_SIZE; hidx++) {
-        if (node->hcnt[hidx] == -1) {
-            htree_node *child_node = (htree_node *)node->htab[hidx];
-            int rcnt = (count > 0 ? (count - fcnt) : 0);
-            int ecnt = do_map_elem_delete_by_count(htree, child_node, rcnt, deleted_head, space_decreased);
-            fcnt += ecnt;
-            if (child_node->tot_elem_cnt < (HTREE_MAX_HASHCHAIN_SIZE/2)) {
-                do_map_node_unlink(htree, node, hidx);
-                *space_decreased += slabs_space_size(sizeof(htree_node));
-            }
-            node->tot_elem_cnt -= ecnt;
-        } else if (node->hcnt[hidx] > 0) {
-            map_elem_item *elem = node->htab[hidx];
-            while (elem != NULL) {
-                fcnt++;
-                do_map_elem_unlink(node, hidx, NULL, elem);
-
-                /* link deleted elem into list; returned to caller */
-                elem->next = *deleted_head;
-                *deleted_head = elem;
-
-                if (count > 0 && fcnt >= count) break;
-                elem = node->htab[hidx];
-            }
-        }
-        if (count > 0 && fcnt >= count) break;
-    }
-    return fcnt;
-}
-
 static uint32_t do_map_elem_delete(map_meta_info *info, const int numfields,
                                    const field_t *flist)
 {
@@ -399,35 +189,32 @@ static uint32_t do_map_elem_delete(map_meta_info *info, const int numfields,
     uint32_t delcnt = 0;
     enum elem_delete_cause cause = ELEM_DELETE_NORMAL;
     size_t space_decreased = 0;
-    map_elem_item *deleted = NULL;
+    htree_elem_item *deleted = NULL;
 
     if (htree->root != NULL) {
         CLOG_ELEM_DELETE_BEGIN((coll_meta_info*)info, numfields, cause);
         if (numfields == 0) {
-            map_elem_item *deleted_head = NULL;
-            delcnt = do_map_elem_delete_by_count(htree, htree->root, 0, &deleted_head, &space_decreased);
+            htree_elem_item *deleted_head = NULL;
+            delcnt = htree_elem_delete_bulk(htree, htree->root, 0 /* all */,
+                                            &deleted_head, &space_decreased);
 
             deleted = deleted_head;
             while (deleted != NULL) {
-                map_elem_item *next = deleted->next;
-                do_map_elem_delete_post(info, deleted, cause);
+                htree_elem_item *next = deleted->next;
+                do_map_elem_delete_post(info, (map_elem_item *)deleted, cause);
                 deleted = next;
             }
         } else {
             for (int ii = 0; ii < numfields; ii++) {
                 int hval = genhash_string_hash(flist[ii].value, flist[ii].length);
 
-                deleted = do_map_elem_delete_by_field(htree, htree->root, hval, &flist[ii], &space_decreased);
+                deleted = htree_elem_delete(htree, htree->root, hval,
+                                            flist[ii].value, flist[ii].length, &space_decreased);
                 if (deleted != NULL) {
-                    do_map_elem_delete_post(info, deleted, cause);
+                    do_map_elem_delete_post(info, (map_elem_item *)deleted, cause);
                     delcnt++;
                 }
             }
-        }
-
-        if (htree->root->tot_elem_cnt == 0) {
-            do_map_node_unlink(htree, NULL, 0);
-            space_decreased += slabs_space_size(sizeof(htree_node));
         }
 
         if (info->stotal > 0 && space_decreased > 0) { /* apply memory space */
@@ -536,7 +323,8 @@ static uint32_t do_map_elem_get(map_meta_info *info,
         CLOG_ELEM_DELETE_BEGIN((coll_meta_info*)info, numfields, cause);
     }
     if (numfields == 0) {
-        fcnt = do_map_elem_get_all(htree, htree->root, delete, elem_array, &space_decreased);
+        fcnt = htree_elem_get_bulk(htree, htree->root, 0 /* all */,
+                                   delete, (htree_elem_item **)elem_array, &space_decreased);
         if (delete) {
             for (int ii = 0; ii < fcnt; ii++) {
                 do_map_elem_delete_post(info, elem_array[ii], cause);
@@ -545,18 +333,15 @@ static uint32_t do_map_elem_get(map_meta_info *info,
     } else {
         for (int ii = 0; ii < numfields; ii++) {
             int hval = genhash_string_hash(flist[ii].value, flist[ii].length);
-            if (do_map_elem_get_by_field(htree, htree->root, hval, &flist[ii],
-                                         delete, &elem_array[fcnt], &space_decreased)) {
+            if (htree_elem_get(htree, htree->root, hval,
+                               flist[ii].value, flist[ii].length,
+                               delete, (htree_elem_item **)&elem_array[fcnt], &space_decreased)) {
                 if (delete) do_map_elem_delete_post(info, elem_array[fcnt], cause);
                 fcnt++;
             }
         }
     }
     if (delete) {
-        if (htree->root->tot_elem_cnt == 0) {
-            do_map_node_unlink(htree, NULL, 0);
-            space_decreased += slabs_space_size(sizeof(htree_node));
-        }
         if (info->stotal > 0 && space_decreased > 0) { /* apply memory space */
             do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_MAP, space_decreased);
         }
@@ -844,20 +629,16 @@ uint32_t map_elem_delete_with_count(map_meta_info *info, const uint32_t count)
 
     // cache_lock is held by caller.
     if (htree->root != NULL) {
-        map_elem_item *deleted_head = NULL;
-        fcnt = do_map_elem_delete_by_count(htree, htree->root, count, &deleted_head, &space_decreased);
+        htree_elem_item *deleted_head = NULL;
+        fcnt = htree_elem_delete_bulk(htree, htree->root, count, &deleted_head, &space_decreased);
 
-        map_elem_item *deleted = deleted_head;
+        htree_elem_item *deleted = deleted_head;
         while (deleted != NULL) {
-            map_elem_item *next = deleted->next;
-            do_map_elem_delete_post(info, deleted, ELEM_DELETE_COLL);
+            htree_elem_item *next = deleted->next;
+            do_map_elem_delete_post(info, (map_elem_item *)deleted, ELEM_DELETE_COLL);
             deleted = next;
         }
 
-        if (htree->root->tot_elem_cnt == 0) {
-            do_map_node_unlink(htree, NULL, 0);
-            space_decreased += slabs_space_size(sizeof(htree_node));
-        }
         if (info->stotal > 0 && space_decreased > 0) { /* apply memory space */
             do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_MAP, space_decreased);
         }
@@ -869,8 +650,8 @@ void map_elem_get_all(map_meta_info *info, elems_result_t *eresult)
 {
     htree_meta *htree = &info->htree;
     assert(eresult->elem_arrsz >= info->ccnt && eresult->elem_count == 0);
-    eresult->elem_count = do_map_elem_get_all(htree, htree->root, false,
-                                              (map_elem_item **)eresult->elem_array, NULL);
+    eresult->elem_count = htree_elem_get_bulk(htree, htree->root, 0 /* all */,
+                                              false, (htree_elem_item**)(eresult->elem_array), NULL);
     assert(eresult->elem_count == info->ccnt);
 }
 

--- a/engines/default/coll_map.c
+++ b/engines/default/coll_map.c
@@ -38,9 +38,6 @@ static struct default_engine *engine=NULL;
 static struct engine_config  *config=NULL; // engine config
 static EXTENSION_LOGGER_DESCRIPTOR *logger;
 
-/* used by set and map collection */
-extern int genhash_string_hash(const void* p, size_t nkey);
-
 /* Cache Lock */
 static inline void LOCK_CACHE(void)
 {
@@ -55,12 +52,14 @@ static inline void UNLOCK_CACHE(void)
 /*
  * MAP collection manangement
  */
-/* map element previous info internally used */
-typedef struct _map_prev_info {
-    htree_node    *node;
-    map_elem_item *prev;
-    uint16_t       hidx;
-} map_prev_info;
+static const void *map_get_key(const htree_elem_item *elem, uint16_t *nkey)
+{
+    map_elem_item *e = (map_elem_item *)elem;
+    *nkey = e->nfield;
+    return e->data;
+}
+
+static htree_ops map_htree_ops = { map_get_key };
 
 static inline int map_hash_eq(const int h1, const void *v1, size_t vlen1,
                               const int h2, const void *v2, size_t vlen2)
@@ -131,28 +130,10 @@ static hash_item *do_map_item_alloc(const void *key, const uint32_t nkey,
         if (attrp->readable == 1)              info->mflags |= COLL_META_FLAG_READABLE;
         info->itdist  = (uint16_t)((size_t*)info-(size_t*)it);
         info->stotal  = 0;
-        info->htree.root = NULL;
+        htree_init(&info->htree, &map_htree_ops);
         assert((hash_item*)COLL_GET_HASH_ITEM(info) == it);
     }
     return it;
-}
-
-static htree_node *do_map_node_alloc(uint8_t hash_depth)
-{
-    size_t ntotal = sizeof(htree_node);
-
-    htree_node *node = do_item_mem_alloc(ntotal, LRU_CLSID_FOR_SMALL);
-    if (node != NULL) {
-        node->slabs_clsid = slabs_clsid(ntotal);
-        assert(node->slabs_clsid > 0);
-
-        node->refcount    = 0;
-        node->hdepth      = hash_depth;
-        node->tot_elem_cnt = 0;
-        memset(node->hcnt, 0, HTREE_HASHTAB_SIZE*sizeof(uint16_t));
-        memset(node->htab, 0, HTREE_HASHTAB_SIZE*sizeof(void*));
-    }
-    return node;
 }
 
 static void do_map_node_free(htree_node *node)
@@ -193,30 +174,6 @@ static void do_map_elem_release(map_elem_item *elem)
     }
     if (elem->refcount == 0 && elem->linked == 0) {
         do_map_elem_free(elem);
-    }
-}
-
-static void do_map_node_link(htree_meta *htree,
-                             htree_node *par_node, const int par_hidx,
-                             htree_node *node)
-{
-    if (par_node == NULL) {
-        htree->root = node;
-    } else {
-        map_elem_item *elem;
-        while (par_node->htab[par_hidx] != NULL) {
-            elem = par_node->htab[par_hidx];
-            par_node->htab[par_hidx] = elem->next;
-
-            int hidx = HTREE_GET_HASHIDX(elem->hval, node->hdepth);
-            elem->next = node->htab[hidx];
-            node->htab[hidx] = elem;
-            node->hcnt[hidx] += 1;
-            node->tot_elem_cnt += 1;
-        }
-        assert(node->tot_elem_cnt == par_node->hcnt[par_hidx]);
-        par_node->htab[par_hidx] = node;
-        par_node->hcnt[par_hidx] = -1; /* child hash node */
     }
 }
 
@@ -262,124 +219,6 @@ static void do_map_node_unlink(htree_meta *htree,
 
     /* free the node */
     do_map_node_free(node);
-}
-
-static map_elem_item *do_map_elem_find(htree_meta *htree,
-                                       const int hval,
-                                       const void *key, uint16_t nkey,
-                                       map_prev_info *pinfo)
-{
-    if (htree->root == NULL) {
-        return NULL;
-    }
-
-    htree_node *node = htree->root;
-    int hidx;
-
-    while (node != NULL) {
-        hidx = HTREE_GET_HASHIDX(hval, node->hdepth);
-        if (node->hcnt[hidx] >= 0) /* map element hash chain */
-            break;
-        node = node->htab[hidx];
-    }
-
-    map_elem_item *prev = NULL;
-    map_elem_item *elem;
-    for (elem = node->htab[hidx]; elem != NULL; elem = elem->next) {
-        if (map_hash_eq(hval, key, nkey, elem->hval, elem->data, elem->nfield)) {
-            break;
-        }
-        prev = elem;
-    }
-
-    if (pinfo != NULL) {
-        pinfo->node = node;
-        pinfo->prev = prev;
-        pinfo->hidx = hidx;
-    }
-    return elem;
-}
-
-static map_elem_item *do_htree_elem_replace(map_meta_info *info,
-                                            map_prev_info *pinfo, map_elem_item *new_elem)
-{
-    map_elem_item *prev = pinfo->prev;
-    map_elem_item *old_elem;
-
-    if (prev != NULL) {
-        old_elem = prev->next;
-    } else {
-        old_elem = (map_elem_item *)pinfo->node->htab[pinfo->hidx];
-    }
-    assert(new_elem->hval == old_elem->hval);
-
-    new_elem->next = old_elem->next;
-    if (prev != NULL) {
-        prev->next = new_elem;
-    } else {
-        pinfo->node->htab[pinfo->hidx] = new_elem;
-    }
-    new_elem->linked++;
-
-    old_elem->linked--;
-    assert(old_elem->linked == 0);
-
-    return old_elem;
-}
-
-static ENGINE_ERROR_CODE do_htree_elem_link(htree_meta *htree,
-                                            htree_node *node, int hidx,
-                                            map_elem_item *elem, size_t *space_increased)
-{
-    if (node->hcnt[hidx] >= HTREE_MAX_HASHCHAIN_SIZE) {
-        htree_node *n_node = do_map_node_alloc(node->hdepth+1);
-        if (n_node == NULL) {
-            return ENGINE_ENOMEM;
-        }
-        do_map_node_link(htree, node, hidx, n_node);
-        *space_increased += slabs_space_size(sizeof(htree_node));
-
-        node = n_node;
-        hidx = HTREE_GET_HASHIDX(elem->hval, node->hdepth);
-    }
-
-    elem->linked++;
-    elem->next = node->htab[hidx];
-    node->htab[hidx] = elem;
-    node->hcnt[hidx] += 1;
-    node->tot_elem_cnt += 1;
-
-    htree_node *par_node = htree->root;
-    while (par_node != node) {
-        par_node->tot_elem_cnt += 1;
-        int par_hidx = HTREE_GET_HASHIDX(elem->hval, par_node->hdepth);
-        assert(par_node->hcnt[par_hidx] == -1);
-        par_node = par_node->htab[par_hidx];
-    }
-    return ENGINE_SUCCESS;
-}
-
-static ENGINE_ERROR_CODE do_htree_elem_add(htree_meta *htree, map_elem_item *elem,
-                                           map_prev_info *pinfo, size_t *space_increased)
-{
-    htree_node *node;
-    int hidx;
-
-    if (htree->root == NULL) {
-        node = do_map_node_alloc(0);
-        if (node == NULL) {
-            return ENGINE_ENOMEM;
-        }
-        do_map_node_link(htree, NULL, 0, node);
-        *space_increased += slabs_space_size(sizeof(htree_node));
-
-        hidx = HTREE_GET_HASHIDX(elem->hval, 0);
-        return do_htree_elem_link(htree, node, hidx, elem, space_increased);
-    }
-
-    node = pinfo->node;
-    hidx = pinfo->hidx;
-    return do_htree_elem_link(htree, node, hidx, elem, space_increased);
 }
 
 static void do_map_elem_unlink(htree_node *node, const int hidx,
@@ -600,11 +439,11 @@ static uint32_t do_map_elem_delete(map_meta_info *info, const int numfields,
     return delcnt;
 }
 
-static ENGINE_ERROR_CODE do_map_elem_replace(map_meta_info *info, map_prev_info *pinfo,
+static ENGINE_ERROR_CODE do_map_elem_replace(map_meta_info *info, htree_elem_pos *pos,
                                              map_elem_item *new_elem)
 {
-    map_elem_item *old_elem = (pinfo->prev != NULL) ? pinfo->prev->next
-                                                    : (map_elem_item *)pinfo->node->htab[pinfo->hidx];
+    map_elem_item *old_elem = (pos->prev != NULL) ? (map_elem_item *)pos->prev->next
+                                                  : (map_elem_item *)pos->node->htab[pos->hidx];
 #ifdef ENABLE_STICKY_ITEM
     /* sticky memory limit check */
     if (IS_STICKY_COLLFLG(info)) {
@@ -614,7 +453,7 @@ static ENGINE_ERROR_CODE do_map_elem_replace(map_meta_info *info, map_prev_info 
         }
     }
 #endif
-    map_elem_item *replaced = do_htree_elem_replace(info, pinfo, new_elem);
+    map_elem_item *replaced = (map_elem_item *)htree_elem_replace(pos, (htree_elem_item *)new_elem);
     assert(replaced == old_elem);
 
     CLOG_MAP_ELEM_INSERT(info, old_elem, new_elem);
@@ -641,7 +480,7 @@ static ENGINE_ERROR_CODE do_map_elem_update(map_meta_info *info,
                                             const uint32_t nbytes)
 {
     htree_meta *htree = &info->htree;
-    map_prev_info  pinfo;
+    htree_elem_pos  pos;
     map_elem_item *elem;
 
     if (htree->root == NULL) {
@@ -649,7 +488,7 @@ static ENGINE_ERROR_CODE do_map_elem_update(map_meta_info *info,
     }
 
     int hval = genhash_string_hash(field->value, field->length);
-    elem = do_map_elem_find(htree, hval, field->value, field->length, &pinfo);
+    elem = (map_elem_item *)htree_elem_find(htree, hval, field->value, field->length, &pos);
 
     if (elem == NULL) {
         return ENGINE_ELEM_ENOENT;
@@ -673,7 +512,7 @@ static ENGINE_ERROR_CODE do_map_elem_update(map_meta_info *info,
         new_elem->hval = elem->hval;
 
         /* replace the element */
-        ENGINE_ERROR_CODE ret = do_map_elem_replace(info, &pinfo, new_elem);
+        ENGINE_ERROR_CODE ret = do_map_elem_replace(info, &pos, new_elem);
         if (ret != ENGINE_SUCCESS) {
             do_map_elem_free(new_elem);
             return ret;
@@ -732,18 +571,18 @@ static ENGINE_ERROR_CODE do_map_elem_insert(hash_item *it, map_elem_item *elem,
     map_meta_info *info = (map_meta_info *)item_get_meta(it);
     htree_meta *htree = &info->htree;
     ENGINE_ERROR_CODE ret;
-    map_prev_info pinfo;
-    map_elem_item *find;
+    htree_elem_pos pos;
+    htree_elem_item *find;
 
     /* map hash value */
     elem->hval = genhash_string_hash(elem->data, elem->nfield);
-    find = do_map_elem_find(htree, elem->hval, elem->data, elem->nfield, &pinfo);
+    find = htree_elem_find(htree, elem->hval, elem->data, elem->nfield, &pos);
 
     if (find != NULL) {
         if (!replace_if_exist) {
             return ENGINE_ELEM_EEXISTS;
         }
-        ENGINE_ERROR_CODE ret = do_map_elem_replace(info, &pinfo, elem);
+        ENGINE_ERROR_CODE ret = do_map_elem_replace(info, &pos, elem);
         if (ret != ENGINE_SUCCESS) {
             return ret;
         }
@@ -766,7 +605,7 @@ static ENGINE_ERROR_CODE do_map_elem_insert(hash_item *it, map_elem_item *elem,
     }
 
     size_t space_increased = 0;
-    ret = do_htree_elem_add(htree, elem, &pinfo, &space_increased);
+    ret = htree_elem_add(htree, (htree_elem_item *)elem, &pos, &space_increased);
     if (ret != ENGINE_SUCCESS) {
         return ret;
     }

--- a/engines/default/coll_map.c
+++ b/engines/default/coll_map.c
@@ -57,13 +57,10 @@ static inline void UNLOCK_CACHE(void)
  */
 /* map element previous info internally used */
 typedef struct _map_prev_info {
-    map_hash_node *node;
+    htree_node    *node;
     map_elem_item *prev;
     uint16_t       hidx;
 } map_prev_info;
-
-#define MAP_GET_HASHIDX(hval, hdepth) \
-        (((hval) & (MAP_HASHIDX_MASK << ((hdepth)*4))) >> ((hdepth)*4))
 
 static inline int map_hash_eq(const int h1, const void *v1, size_t vlen1,
                               const int h2, const void *v2, size_t vlen2)
@@ -134,17 +131,17 @@ static hash_item *do_map_item_alloc(const void *key, const uint32_t nkey,
         if (attrp->readable == 1)              info->mflags |= COLL_META_FLAG_READABLE;
         info->itdist  = (uint16_t)((size_t*)info-(size_t*)it);
         info->stotal  = 0;
-        info->root    = NULL;
+        info->htree.root = NULL;
         assert((hash_item*)COLL_GET_HASH_ITEM(info) == it);
     }
     return it;
 }
 
-static map_hash_node *do_map_node_alloc(uint8_t hash_depth)
+static htree_node *do_map_node_alloc(uint8_t hash_depth)
 {
-    size_t ntotal = sizeof(map_hash_node);
+    size_t ntotal = sizeof(htree_node);
 
-    map_hash_node *node = do_item_mem_alloc(ntotal, LRU_CLSID_FOR_SMALL);
+    htree_node *node = do_item_mem_alloc(ntotal, LRU_CLSID_FOR_SMALL);
     if (node != NULL) {
         node->slabs_clsid = slabs_clsid(ntotal);
         assert(node->slabs_clsid > 0);
@@ -152,15 +149,15 @@ static map_hash_node *do_map_node_alloc(uint8_t hash_depth)
         node->refcount    = 0;
         node->hdepth      = hash_depth;
         node->tot_elem_cnt = 0;
-        memset(node->hcnt, 0, MAP_HASHTAB_SIZE*sizeof(uint16_t));
-        memset(node->htab, 0, MAP_HASHTAB_SIZE*sizeof(void*));
+        memset(node->hcnt, 0, HTREE_HASHTAB_SIZE*sizeof(uint16_t));
+        memset(node->htab, 0, HTREE_HASHTAB_SIZE*sizeof(void*));
     }
     return node;
 }
 
-static void do_map_node_free(map_hash_node *node)
+static void do_map_node_free(htree_node *node)
 {
-    do_item_mem_free(node, sizeof(map_hash_node));
+    do_item_mem_free(node, sizeof(htree_node));
 }
 
 static map_elem_item *do_map_elem_alloc(const int nfield,
@@ -199,19 +196,19 @@ static void do_map_elem_release(map_elem_item *elem)
     }
 }
 
-static void do_map_node_link(map_meta_info *info,
-                             map_hash_node *par_node, const int par_hidx,
-                             map_hash_node *node)
+static void do_map_node_link(htree_meta *htree,
+                             htree_node *par_node, const int par_hidx,
+                             htree_node *node)
 {
     if (par_node == NULL) {
-        info->root = node;
+        htree->root = node;
     } else {
         map_elem_item *elem;
         while (par_node->htab[par_hidx] != NULL) {
             elem = par_node->htab[par_hidx];
             par_node->htab[par_hidx] = elem->next;
 
-            int hidx = MAP_GET_HASHIDX(elem->hval, node->hdepth);
+            int hidx = HTREE_GET_HASHIDX(elem->hval, node->hdepth);
             elem->next = node->htab[hidx];
             node->htab[hidx] = elem;
             node->hcnt[hidx] += 1;
@@ -223,14 +220,14 @@ static void do_map_node_link(map_meta_info *info,
     }
 }
 
-static void do_map_node_unlink(map_meta_info *info,
-                               map_hash_node *par_node, const int par_hidx)
+static void do_map_node_unlink(htree_meta *htree,
+                               htree_node *par_node, const int par_hidx)
 {
-    map_hash_node *node;
+    htree_node *node;
 
     if (par_node == NULL) {
-        node = info->root;
-        info->root = NULL;
+        node = htree->root;
+        htree->root = NULL;
         assert(node->tot_elem_cnt == 0);
     } else {
         assert(par_node->hcnt[par_hidx] == -1); /* child hash node */
@@ -238,10 +235,10 @@ static void do_map_node_unlink(map_meta_info *info,
         map_elem_item *elem;
         int hidx, fcnt = 0;
 
-        node = (map_hash_node *)par_node->htab[par_hidx];
-        assert(node->tot_elem_cnt < (MAP_MAX_HASHCHAIN_SIZE/2));
+        node = (htree_node *)par_node->htab[par_hidx];
+        assert(node->tot_elem_cnt < (HTREE_MAX_HASHCHAIN_SIZE/2));
 
-        for (hidx = 0; hidx < MAP_HASHTAB_SIZE; hidx++) {
+        for (hidx = 0; hidx < HTREE_HASHTAB_SIZE; hidx++) {
             assert(node->hcnt[hidx] >= 0);
             if (node->hcnt[hidx] > 0) {
                 fcnt += node->hcnt[hidx];
@@ -267,20 +264,20 @@ static void do_map_node_unlink(map_meta_info *info,
     do_map_node_free(node);
 }
 
-static map_elem_item *do_map_elem_find(map_meta_info *info,
+static map_elem_item *do_map_elem_find(htree_meta *htree,
                                        const int hval,
                                        const void *key, uint16_t nkey,
                                        map_prev_info *pinfo)
 {
-    if (info->root == NULL) {
+    if (htree->root == NULL) {
         return NULL;
     }
 
-    map_hash_node *node = info->root;
+    htree_node *node = htree->root;
     int hidx;
 
     while (node != NULL) {
-        hidx = MAP_GET_HASHIDX(hval, node->hdepth);
+        hidx = HTREE_GET_HASHIDX(hval, node->hdepth);
         if (node->hcnt[hidx] >= 0) /* map element hash chain */
             break;
         node = node->htab[hidx];
@@ -330,20 +327,20 @@ static map_elem_item *do_htree_elem_replace(map_meta_info *info,
     return old_elem;
 }
 
-static ENGINE_ERROR_CODE do_htree_elem_link(map_meta_info *info,
-                                            map_hash_node *node, int hidx,
+static ENGINE_ERROR_CODE do_htree_elem_link(htree_meta *htree,
+                                            htree_node *node, int hidx,
                                             map_elem_item *elem, size_t *space_increased)
 {
-    if (node->hcnt[hidx] >= MAP_MAX_HASHCHAIN_SIZE) {
-        map_hash_node *n_node = do_map_node_alloc(node->hdepth+1);
+    if (node->hcnt[hidx] >= HTREE_MAX_HASHCHAIN_SIZE) {
+        htree_node *n_node = do_map_node_alloc(node->hdepth+1);
         if (n_node == NULL) {
             return ENGINE_ENOMEM;
         }
-        do_map_node_link(info, node, hidx, n_node);
-        *space_increased += slabs_space_size(sizeof(map_hash_node));
+        do_map_node_link(htree, node, hidx, n_node);
+        *space_increased += slabs_space_size(sizeof(htree_node));
 
         node = n_node;
-        hidx = MAP_GET_HASHIDX(elem->hval, node->hdepth);
+        hidx = HTREE_GET_HASHIDX(elem->hval, node->hdepth);
     }
 
     elem->linked++;
@@ -352,41 +349,40 @@ static ENGINE_ERROR_CODE do_htree_elem_link(map_meta_info *info,
     node->hcnt[hidx] += 1;
     node->tot_elem_cnt += 1;
 
-    map_hash_node *par_node = info->root;
+    htree_node *par_node = htree->root;
     while (par_node != node) {
         par_node->tot_elem_cnt += 1;
-        int par_hidx = MAP_GET_HASHIDX(elem->hval, par_node->hdepth);
+        int par_hidx = HTREE_GET_HASHIDX(elem->hval, par_node->hdepth);
         assert(par_node->hcnt[par_hidx] == -1);
         par_node = par_node->htab[par_hidx];
     }
     return ENGINE_SUCCESS;
 }
 
-static ENGINE_ERROR_CODE do_htree_elem_add(map_meta_info *info, map_elem_item *elem,
+static ENGINE_ERROR_CODE do_htree_elem_add(htree_meta *htree, map_elem_item *elem,
                                            map_prev_info *pinfo, size_t *space_increased)
 {
-    map_hash_node *node;
+    htree_node *node;
     int hidx;
 
-    if (info->root == NULL) {
+    if (htree->root == NULL) {
         node = do_map_node_alloc(0);
         if (node == NULL) {
             return ENGINE_ENOMEM;
         }
-        do_map_node_link(info, NULL, 0, node);
-        *space_increased += slabs_space_size(sizeof(map_hash_node));
+        do_map_node_link(htree, NULL, 0, node);
+        *space_increased += slabs_space_size(sizeof(htree_node));
 
-        hidx = MAP_GET_HASHIDX(elem->hval, 0);
-        return do_htree_elem_link(info, node, hidx, elem, space_increased);
+        hidx = HTREE_GET_HASHIDX(elem->hval, 0);
+        return do_htree_elem_link(htree, node, hidx, elem, space_increased);
     }
 
     node = pinfo->node;
     hidx = pinfo->hidx;
-    return do_htree_elem_link(info, node, hidx, elem, space_increased);
+    return do_htree_elem_link(htree, node, hidx, elem, space_increased);
 }
 
-static void do_map_elem_unlink(map_meta_info *info,
-                               map_hash_node *node, const int hidx,
+static void do_map_elem_unlink(htree_node *node, const int hidx,
                                map_elem_item *prev, map_elem_item *elem)
 {
     if (prev != NULL) prev->next = elem->next;
@@ -412,21 +408,21 @@ static void do_map_elem_delete_post(map_meta_info *info,
     }
 }
 
-static bool do_map_elem_get_by_field(map_meta_info *info, map_hash_node *node, const int hval,
+static bool do_map_elem_get_by_field(htree_meta *htree, htree_node *node, const int hval,
                                      const field_t *field, const bool delete,
                                      map_elem_item **elem_array, size_t *space_decreased)
 {
     assert(elem_array != NULL);
     bool ret;
-    int hidx = MAP_GET_HASHIDX(hval, node->hdepth);
+    int hidx = HTREE_GET_HASHIDX(hval, node->hdepth);
 
     if (node->hcnt[hidx] == -1) {
-        map_hash_node *child_node = node->htab[hidx];
-        ret = do_map_elem_get_by_field(info, child_node, hval, field, delete, elem_array, space_decreased);
+        htree_node *child_node = node->htab[hidx];
+        ret = do_map_elem_get_by_field(htree, child_node, hval, field, delete, elem_array, space_decreased);
         if (ret && delete) {
-            if (child_node->tot_elem_cnt < (MAP_MAX_HASHCHAIN_SIZE/2)) {
-                do_map_node_unlink(info, node, hidx);
-                *space_decreased += slabs_space_size(sizeof(map_hash_node));
+            if (child_node->tot_elem_cnt < (HTREE_MAX_HASHCHAIN_SIZE/2)) {
+                do_map_node_unlink(htree, node, hidx);
+                *space_decreased += slabs_space_size(sizeof(htree_node));
             }
             node->tot_elem_cnt -= 1;
         }
@@ -440,7 +436,7 @@ static bool do_map_elem_get_by_field(map_meta_info *info, map_hash_node *node, c
                     elem->refcount++;
                     elem_array[0] = elem;
                     if (delete) {
-                        do_map_elem_unlink(info, node, hidx, prev, elem);
+                        do_map_elem_unlink(node, hidx, prev, elem);
                     }
                     ret = true;
                     break;
@@ -453,19 +449,19 @@ static bool do_map_elem_get_by_field(map_meta_info *info, map_hash_node *node, c
     return ret;
 }
 
-static map_elem_item *do_map_elem_delete_by_field(map_meta_info *info, map_hash_node *node, const int hval,
+static map_elem_item *do_map_elem_delete_by_field(htree_meta *htree, htree_node *node, const int hval,
                                                   const field_t *field, size_t *space_decreased)
 {
     map_elem_item *deleted = NULL;
-    int hidx = MAP_GET_HASHIDX(hval, node->hdepth);
+    int hidx = HTREE_GET_HASHIDX(hval, node->hdepth);
 
     if (node->hcnt[hidx] == -1) {
-        map_hash_node *child_node = node->htab[hidx];
-        deleted = do_map_elem_delete_by_field(info, child_node, hval, field, space_decreased);
+        htree_node *child_node = node->htab[hidx];
+        deleted = do_map_elem_delete_by_field(htree, child_node, hval, field, space_decreased);
         if (deleted) {
-            if (child_node->tot_elem_cnt < (MAP_MAX_HASHCHAIN_SIZE/2)) {
-                do_map_node_unlink(info, node, hidx);
-                *space_decreased += slabs_space_size(sizeof(map_hash_node));
+            if (child_node->tot_elem_cnt < (HTREE_MAX_HASHCHAIN_SIZE/2)) {
+                do_map_node_unlink(htree, node, hidx);
+                *space_decreased += slabs_space_size(sizeof(htree_node));
             }
             node->tot_elem_cnt -= 1;
         }
@@ -475,7 +471,7 @@ static map_elem_item *do_map_elem_delete_by_field(map_meta_info *info, map_hash_
             map_elem_item *elem = node->htab[hidx];
             while (elem != NULL) {
                 if (map_hash_eq(hval, field->value, field->length, elem->hval, elem->data, elem->nfield)) {
-                    do_map_elem_unlink(info, node, hidx, prev, elem);
+                    do_map_elem_unlink(node, hidx, prev, elem);
                     deleted = elem;
                     break;
                 }
@@ -487,22 +483,22 @@ static map_elem_item *do_map_elem_delete_by_field(map_meta_info *info, map_hash_
     return deleted;
 }
 
-static int do_map_elem_get_all(map_meta_info *info, map_hash_node *node,
+static int do_map_elem_get_all(htree_meta *htree, htree_node *node,
                                const bool delete, map_elem_item **elem_array, size_t *space_decreased)
 {
     assert(elem_array != NULL);
     int hidx;
     int fcnt = 0; /* found count */
 
-    for (hidx = 0; hidx < MAP_HASHTAB_SIZE; hidx++) {
+    for (hidx = 0; hidx < HTREE_HASHTAB_SIZE; hidx++) {
         if (node->hcnt[hidx] == -1) {
-            map_hash_node *child_node = (map_hash_node *)node->htab[hidx];
-            int ecnt = do_map_elem_get_all(info, child_node, delete, &elem_array[fcnt], space_decreased);
+            htree_node *child_node = (htree_node *)node->htab[hidx];
+            int ecnt = do_map_elem_get_all(htree, child_node, delete, &elem_array[fcnt], space_decreased);
             fcnt += ecnt;
             if (delete) {
-                if (child_node->tot_elem_cnt < (MAP_MAX_HASHCHAIN_SIZE/2)) {
-                    do_map_node_unlink(info, node, hidx);
-                    *space_decreased += slabs_space_size(sizeof(map_hash_node));
+                if (child_node->tot_elem_cnt < (HTREE_MAX_HASHCHAIN_SIZE/2)) {
+                    do_map_node_unlink(htree, node, hidx);
+                    *space_decreased += slabs_space_size(sizeof(htree_node));
                 }
                 node->tot_elem_cnt -= ecnt;
             }
@@ -512,7 +508,7 @@ static int do_map_elem_get_all(map_meta_info *info, map_hash_node *node,
                 elem->refcount++;
                 elem_array[fcnt] = elem;
                 fcnt++;
-                if (delete) do_map_elem_unlink(info, node, hidx, NULL, elem);
+                if (delete) do_map_elem_unlink(node, hidx, NULL, elem);
                 elem = (delete ? node->htab[hidx] : elem->next);
             }
         }
@@ -520,29 +516,29 @@ static int do_map_elem_get_all(map_meta_info *info, map_hash_node *node,
     return fcnt;
 }
 
-static int do_map_elem_delete_by_count(map_meta_info *info, map_hash_node *node,
+static int do_map_elem_delete_by_count(htree_meta *htree, htree_node *node,
                                        const uint32_t count, map_elem_item **deleted_head,
                                        size_t *space_decreased)
 {
     int hidx;
     int fcnt = 0;
 
-    for (hidx = 0; hidx < MAP_HASHTAB_SIZE; hidx++) {
+    for (hidx = 0; hidx < HTREE_HASHTAB_SIZE; hidx++) {
         if (node->hcnt[hidx] == -1) {
-            map_hash_node *child_node = (map_hash_node *)node->htab[hidx];
+            htree_node *child_node = (htree_node *)node->htab[hidx];
             int rcnt = (count > 0 ? (count - fcnt) : 0);
-            int ecnt = do_map_elem_delete_by_count(info, child_node, rcnt, deleted_head, space_decreased);
+            int ecnt = do_map_elem_delete_by_count(htree, child_node, rcnt, deleted_head, space_decreased);
             fcnt += ecnt;
-            if (child_node->tot_elem_cnt < (MAP_MAX_HASHCHAIN_SIZE/2)) {
-                do_map_node_unlink(info, node, hidx);
-                *space_decreased += slabs_space_size(sizeof(map_hash_node));
+            if (child_node->tot_elem_cnt < (HTREE_MAX_HASHCHAIN_SIZE/2)) {
+                do_map_node_unlink(htree, node, hidx);
+                *space_decreased += slabs_space_size(sizeof(htree_node));
             }
             node->tot_elem_cnt -= ecnt;
         } else if (node->hcnt[hidx] > 0) {
             map_elem_item *elem = node->htab[hidx];
             while (elem != NULL) {
                 fcnt++;
-                do_map_elem_unlink(info, node, hidx, NULL, elem);
+                do_map_elem_unlink(node, hidx, NULL, elem);
 
                 /* link deleted elem into list; returned to caller */
                 elem->next = *deleted_head;
@@ -560,16 +556,17 @@ static int do_map_elem_delete_by_count(map_meta_info *info, map_hash_node *node,
 static uint32_t do_map_elem_delete(map_meta_info *info, const int numfields,
                                    const field_t *flist)
 {
+    htree_meta *htree = &info->htree;
     uint32_t delcnt = 0;
     enum elem_delete_cause cause = ELEM_DELETE_NORMAL;
     size_t space_decreased = 0;
     map_elem_item *deleted = NULL;
 
-    if (info->root != NULL) {
+    if (htree->root != NULL) {
         CLOG_ELEM_DELETE_BEGIN((coll_meta_info*)info, numfields, cause);
         if (numfields == 0) {
             map_elem_item *deleted_head = NULL;
-            delcnt = do_map_elem_delete_by_count(info, info->root, 0, &deleted_head, &space_decreased);
+            delcnt = do_map_elem_delete_by_count(htree, htree->root, 0, &deleted_head, &space_decreased);
 
             deleted = deleted_head;
             while (deleted != NULL) {
@@ -581,7 +578,7 @@ static uint32_t do_map_elem_delete(map_meta_info *info, const int numfields,
             for (int ii = 0; ii < numfields; ii++) {
                 int hval = genhash_string_hash(flist[ii].value, flist[ii].length);
 
-                deleted = do_map_elem_delete_by_field(info, info->root, hval, &flist[ii], &space_decreased);
+                deleted = do_map_elem_delete_by_field(htree, htree->root, hval, &flist[ii], &space_decreased);
                 if (deleted != NULL) {
                     do_map_elem_delete_post(info, deleted, cause);
                     delcnt++;
@@ -589,9 +586,9 @@ static uint32_t do_map_elem_delete(map_meta_info *info, const int numfields,
             }
         }
 
-        if (info->root->tot_elem_cnt == 0) {
-            do_map_node_unlink(info, NULL, 0);
-            space_decreased += slabs_space_size(sizeof(map_hash_node));
+        if (htree->root->tot_elem_cnt == 0) {
+            do_map_node_unlink(htree, NULL, 0);
+            space_decreased += slabs_space_size(sizeof(htree_node));
         }
 
         if (info->stotal > 0 && space_decreased > 0) { /* apply memory space */
@@ -643,15 +640,16 @@ static ENGINE_ERROR_CODE do_map_elem_update(map_meta_info *info,
                                             const field_t *field, const char *value,
                                             const uint32_t nbytes)
 {
+    htree_meta *htree = &info->htree;
     map_prev_info  pinfo;
     map_elem_item *elem;
 
-    if (info->root == NULL) {
+    if (htree->root == NULL) {
         return ENGINE_ELEM_ENOENT;
     }
 
     int hval = genhash_string_hash(field->value, field->length);
-    elem = do_map_elem_find(info, hval, field->value, field->length, &pinfo);
+    elem = do_map_elem_find(htree, hval, field->value, field->length, &pinfo);
 
     if (elem == NULL) {
         return ENGINE_ELEM_ENOENT;
@@ -689,7 +687,8 @@ static uint32_t do_map_elem_get(map_meta_info *info,
                                 const int numfields, const field_t *flist,
                                 const bool delete, map_elem_item **elem_array)
 {
-    assert(info->root);
+    htree_meta *htree = &info->htree;
+    assert(htree->root);
     uint32_t fcnt = 0;
     enum elem_delete_cause cause = ELEM_DELETE_NORMAL;
     size_t space_decreased = 0;
@@ -698,7 +697,7 @@ static uint32_t do_map_elem_get(map_meta_info *info,
         CLOG_ELEM_DELETE_BEGIN((coll_meta_info*)info, numfields, cause);
     }
     if (numfields == 0) {
-        fcnt = do_map_elem_get_all(info, info->root, delete, elem_array, &space_decreased);
+        fcnt = do_map_elem_get_all(htree, htree->root, delete, elem_array, &space_decreased);
         if (delete) {
             for (int ii = 0; ii < fcnt; ii++) {
                 do_map_elem_delete_post(info, elem_array[ii], cause);
@@ -707,7 +706,7 @@ static uint32_t do_map_elem_get(map_meta_info *info,
     } else {
         for (int ii = 0; ii < numfields; ii++) {
             int hval = genhash_string_hash(flist[ii].value, flist[ii].length);
-            if (do_map_elem_get_by_field(info, info->root, hval, &flist[ii],
+            if (do_map_elem_get_by_field(htree, htree->root, hval, &flist[ii],
                                          delete, &elem_array[fcnt], &space_decreased)) {
                 if (delete) do_map_elem_delete_post(info, elem_array[fcnt], cause);
                 fcnt++;
@@ -715,9 +714,9 @@ static uint32_t do_map_elem_get(map_meta_info *info,
         }
     }
     if (delete) {
-        if (info->root->tot_elem_cnt == 0) {
-            do_map_node_unlink(info, NULL, 0);
-            space_decreased += slabs_space_size(sizeof(map_hash_node));
+        if (htree->root->tot_elem_cnt == 0) {
+            do_map_node_unlink(htree, NULL, 0);
+            space_decreased += slabs_space_size(sizeof(htree_node));
         }
         if (info->stotal > 0 && space_decreased > 0) { /* apply memory space */
             do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_MAP, space_decreased);
@@ -731,13 +730,14 @@ static ENGINE_ERROR_CODE do_map_elem_insert(hash_item *it, map_elem_item *elem,
                                             const bool replace_if_exist, bool *replaced)
 {
     map_meta_info *info = (map_meta_info *)item_get_meta(it);
+    htree_meta *htree = &info->htree;
     ENGINE_ERROR_CODE ret;
     map_prev_info pinfo;
     map_elem_item *find;
 
     /* map hash value */
     elem->hval = genhash_string_hash(elem->data, elem->nfield);
-    find = do_map_elem_find(info, elem->hval, elem->data, elem->nfield, &pinfo);
+    find = do_map_elem_find(htree, elem->hval, elem->data, elem->nfield, &pinfo);
 
     if (find != NULL) {
         if (!replace_if_exist) {
@@ -766,7 +766,7 @@ static ENGINE_ERROR_CODE do_map_elem_insert(hash_item *it, map_elem_item *elem,
     }
 
     size_t space_increased = 0;
-    ret = do_htree_elem_add(info, elem, &pinfo, &space_increased);
+    ret = do_htree_elem_add(htree, elem, &pinfo, &space_increased);
     if (ret != ENGINE_SUCCESS) {
         return ret;
     }
@@ -923,7 +923,7 @@ ENGINE_ERROR_CODE map_elem_delete(const char *key, const uint32_t nkey,
         *del_count = do_map_elem_delete(info, numfields, flist);
         if (*del_count > 0) {
             if (info->ccnt == 0 && drop_if_empty) {
-                assert(info->root == NULL);
+                assert(info->htree.root == NULL);
                 do_item_unlink(it, ITEM_UNLINK_NORMAL);
                 *dropped = true;
             }
@@ -999,13 +999,14 @@ ENGINE_ERROR_CODE map_elem_get(const char *key, const uint32_t nkey,
 
 uint32_t map_elem_delete_with_count(map_meta_info *info, const uint32_t count)
 {
+    htree_meta *htree = &info->htree;
     uint32_t fcnt = 0;
     size_t space_decreased = 0;
 
     // cache_lock is held by caller.
-    if (info->root != NULL) {
+    if (htree->root != NULL) {
         map_elem_item *deleted_head = NULL;
-        fcnt = do_map_elem_delete_by_count(info, info->root, count, &deleted_head, &space_decreased);
+        fcnt = do_map_elem_delete_by_count(htree, htree->root, count, &deleted_head, &space_decreased);
 
         map_elem_item *deleted = deleted_head;
         while (deleted != NULL) {
@@ -1014,9 +1015,9 @@ uint32_t map_elem_delete_with_count(map_meta_info *info, const uint32_t count)
             deleted = next;
         }
 
-        if (info->root->tot_elem_cnt == 0) {
-            do_map_node_unlink(info, NULL, 0);
-            space_decreased += slabs_space_size(sizeof(map_hash_node));
+        if (htree->root->tot_elem_cnt == 0) {
+            do_map_node_unlink(htree, NULL, 0);
+            space_decreased += slabs_space_size(sizeof(htree_node));
         }
         if (info->stotal > 0 && space_decreased > 0) { /* apply memory space */
             do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_MAP, space_decreased);
@@ -1027,8 +1028,9 @@ uint32_t map_elem_delete_with_count(map_meta_info *info, const uint32_t count)
 
 void map_elem_get_all(map_meta_info *info, elems_result_t *eresult)
 {
+    htree_meta *htree = &info->htree;
     assert(eresult->elem_arrsz >= info->ccnt && eresult->elem_count == 0);
-    eresult->elem_count = do_map_elem_get_all(info, info->root, false,
+    eresult->elem_count = do_map_elem_get_all(htree, htree->root, false,
                                               (map_elem_item **)eresult->elem_array, NULL);
     assert(eresult->elem_count == info->ccnt);
 }

--- a/engines/default/coll_set.c
+++ b/engines/default/coll_set.c
@@ -102,13 +102,10 @@ static bool hash_insert(hash_table *ht, int key)
  * SET collection manangement
  */
 typedef struct _set_prev_info {
-    set_hash_node *node;
+    htree_node *node;
     set_elem_item *prev;
     uint16_t       hidx;
 } set_prev_info;
-
-#define SET_GET_HASHIDX(hval, hdepth) \
-        (((hval) & (SET_HASHIDX_MASK << ((hdepth)*4))) >> ((hdepth)*4))
 
 static inline int set_hash_eq(const int h1, const void *v1, size_t vlen1,
                               const int h2, const void *v2, size_t vlen2)
@@ -179,17 +176,17 @@ static hash_item *do_set_item_alloc(const void *key, const uint32_t nkey,
         if (attrp->readable == 1)              info->mflags |= COLL_META_FLAG_READABLE;
         info->itdist  = (uint16_t)((size_t*)info-(size_t*)it);
         info->stotal  = 0;
-        info->root    = NULL;
+        info->htree.root    = NULL;
         assert((hash_item*)COLL_GET_HASH_ITEM(info) == it);
     }
     return it;
 }
 
-static set_hash_node *do_set_node_alloc(uint8_t hash_depth)
+static htree_node *do_set_node_alloc(uint8_t hash_depth)
 {
-    size_t ntotal = sizeof(set_hash_node);
+    size_t ntotal = sizeof(htree_node);
 
-    set_hash_node *node = do_item_mem_alloc(ntotal, LRU_CLSID_FOR_SMALL);
+    htree_node *node = do_item_mem_alloc(ntotal, LRU_CLSID_FOR_SMALL);
     if (node != NULL) {
         node->slabs_clsid = slabs_clsid(ntotal);
         assert(node->slabs_clsid > 0);
@@ -197,15 +194,15 @@ static set_hash_node *do_set_node_alloc(uint8_t hash_depth)
         node->refcount    = 0;
         node->hdepth      = hash_depth;
         node->tot_elem_cnt = 0;
-        memset(node->hcnt, 0, SET_HASHTAB_SIZE*sizeof(uint16_t));
-        memset(node->htab, 0, SET_HASHTAB_SIZE*sizeof(void*));
+        memset(node->hcnt, 0, HTREE_HASHTAB_SIZE*sizeof(uint16_t));
+        memset(node->htab, 0, HTREE_HASHTAB_SIZE*sizeof(void*));
     }
     return node;
 }
 
-static void do_set_node_free(set_hash_node *node)
+static void do_set_node_free(htree_node *node)
 {
-    do_item_mem_free(node, sizeof(set_hash_node));
+    do_item_mem_free(node, sizeof(htree_node));
 }
 
 static set_elem_item *do_set_elem_alloc(const uint32_t nbytes)
@@ -242,19 +239,19 @@ static void do_set_elem_release(set_elem_item *elem)
     }
 }
 
-static void do_set_node_link(set_meta_info *info,
-                             set_hash_node *par_node, const int par_hidx,
-                             set_hash_node *node)
+static void do_set_node_link(htree_meta *htree,
+                             htree_node *par_node, const int par_hidx,
+                             htree_node *node)
 {
     if (par_node == NULL) {
-        info->root = node;
+        htree->root = node;
     } else {
         set_elem_item *elem;
         while (par_node->htab[par_hidx] != NULL) {
             elem = par_node->htab[par_hidx];
             par_node->htab[par_hidx] = elem->next;
 
-            int hidx = SET_GET_HASHIDX(elem->hval, node->hdepth);
+            int hidx = HTREE_GET_HASHIDX(elem->hval, node->hdepth);
             elem->next = node->htab[hidx];
             node->htab[hidx] = elem;
             node->hcnt[hidx] += 1;
@@ -266,14 +263,14 @@ static void do_set_node_link(set_meta_info *info,
     }
 }
 
-static void do_set_node_unlink(set_meta_info *info,
-                               set_hash_node *par_node, const int par_hidx)
+static void do_set_node_unlink(htree_meta *htree,
+                               htree_node *par_node, const int par_hidx)
 {
-    set_hash_node *node;
+    htree_node *node;
 
     if (par_node == NULL) {
-        node = info->root;
-        info->root = NULL;
+        node = htree->root;
+        htree->root = NULL;
         assert(node->tot_elem_cnt == 0);
     } else {
         assert(par_node->hcnt[par_hidx] == -1); /* child hash node */
@@ -281,10 +278,10 @@ static void do_set_node_unlink(set_meta_info *info,
         set_elem_item *elem;
         int hidx, fcnt = 0;
 
-        node = (set_hash_node *)par_node->htab[par_hidx];
-        assert(node->tot_elem_cnt < (SET_MAX_HASHCHAIN_SIZE/2));
+        node = (htree_node *)par_node->htab[par_hidx];
+        assert(node->tot_elem_cnt < (HTREE_MAX_HASHCHAIN_SIZE/2));
 
-        for (hidx = 0; hidx < SET_HASHTAB_SIZE; hidx++) {
+        for (hidx = 0; hidx < HTREE_HASHTAB_SIZE; hidx++) {
             assert(node->hcnt[hidx] >= 0);
             if (node->hcnt[hidx] > 0) {
                 fcnt += node->hcnt[hidx];
@@ -310,20 +307,20 @@ static void do_set_node_unlink(set_meta_info *info,
     do_set_node_free(node);
 }
 
-static set_elem_item *do_set_elem_find(set_meta_info *info,
+static set_elem_item *do_set_elem_find(htree_meta *htree,
                                        const int hval,
                                        const void *key, uint16_t nkey,
                                        set_prev_info *pinfo)
 {
-    if (info->root == NULL) {
+    if (htree->root == NULL) {
         return NULL;
     }
 
-    set_hash_node *node = info->root;
+    htree_node *node = htree->root;
     int hidx;
 
     while (node != NULL) {
-        hidx = SET_GET_HASHIDX(hval, node->hdepth);
+        hidx = HTREE_GET_HASHIDX(hval, node->hdepth);
         if (node->hcnt[hidx] >= 0)
             break;
         node = node->htab[hidx];
@@ -346,20 +343,20 @@ static set_elem_item *do_set_elem_find(set_meta_info *info,
     return elem;
 }
 
-static ENGINE_ERROR_CODE do_htree_elem_link(set_meta_info *info,
-                                            set_hash_node *node, int hidx,
+static ENGINE_ERROR_CODE do_htree_elem_link(htree_meta *htree,
+                                            htree_node *node, int hidx,
                                             set_elem_item *elem, size_t *space_increased)
 {
-    if (node->hcnt[hidx] >= SET_MAX_HASHCHAIN_SIZE) {
-        set_hash_node *n_node = do_set_node_alloc(node->hdepth+1);
+    if (node->hcnt[hidx] >= HTREE_MAX_HASHCHAIN_SIZE) {
+        htree_node *n_node = do_set_node_alloc(node->hdepth+1);
         if (n_node == NULL) {
             return ENGINE_ENOMEM;
         }
-        do_set_node_link(info, node, hidx, n_node);
-        *space_increased += slabs_space_size(sizeof(set_hash_node));
+        do_set_node_link(htree, node, hidx, n_node);
+        *space_increased += slabs_space_size(sizeof(htree_node));
 
         node = n_node;
-        hidx = SET_GET_HASHIDX(elem->hval, node->hdepth);
+        hidx = HTREE_GET_HASHIDX(elem->hval, node->hdepth);
     }
 
     elem->linked++;
@@ -368,49 +365,48 @@ static ENGINE_ERROR_CODE do_htree_elem_link(set_meta_info *info,
     node->hcnt[hidx] += 1;
     node->tot_elem_cnt += 1;
 
-    set_hash_node *par_node = info->root;
+    htree_node *par_node = htree->root;
     while (par_node != node) {
         par_node->tot_elem_cnt += 1;
-        int par_hidx = SET_GET_HASHIDX(elem->hval, par_node->hdepth);
+        int par_hidx = HTREE_GET_HASHIDX(elem->hval, par_node->hdepth);
         assert(par_node->hcnt[par_hidx] == -1);
         par_node = par_node->htab[par_hidx];
     }
     return ENGINE_SUCCESS;
 }
 
-static ENGINE_ERROR_CODE do_htree_elem_insert(set_meta_info *info, set_elem_item *elem,
+static ENGINE_ERROR_CODE do_htree_elem_insert(htree_meta *htree, set_elem_item *elem,
                                               size_t *space_increased)
 {
-    set_hash_node *node;
+    htree_node *node;
     int hidx;
     /* create the root hash node if it does not exist */
-    if (info->root == NULL) {
+    if (htree->root == NULL) {
         node = do_set_node_alloc(0);
         if (node == NULL) {
             return ENGINE_ENOMEM;
         }
-        do_set_node_link(info, NULL, 0, node);
-        *space_increased += slabs_space_size(sizeof(set_hash_node));
+        do_set_node_link(htree, NULL, 0, node);
+        *space_increased += slabs_space_size(sizeof(htree_node));
 
-        hidx = SET_GET_HASHIDX(elem->hval, 0);
-        return do_htree_elem_link(info, node, hidx, elem, space_increased);
+        hidx = HTREE_GET_HASHIDX(elem->hval, 0);
+        return do_htree_elem_link(htree, node, hidx, elem, space_increased);
     }
 
     set_elem_item *find;
     set_prev_info pinfo;
 
-    find = do_set_elem_find(info, elem->hval, elem->value, elem->nbytes, &pinfo);
+    find = do_set_elem_find(htree, elem->hval, elem->value, elem->nbytes, &pinfo);
     if (find != NULL) {
         return ENGINE_ELEM_EEXISTS;
     }
 
     node = pinfo.node;
     hidx = pinfo.hidx;
-    return do_htree_elem_link(info, node, hidx, elem, space_increased);
+    return do_htree_elem_link(htree, node, hidx, elem, space_increased);
 }
 
-static void do_set_elem_unlink(set_meta_info *info,
-                               set_hash_node *node, const int hidx,
+static void do_set_elem_unlink(htree_node *node, const int hidx,
                                set_elem_item *prev, set_elem_item *elem)
 {
     if (prev != NULL) prev->next = elem->next;
@@ -436,20 +432,20 @@ static void do_set_elem_delete_post(set_meta_info *info,
     }
 }
 
-static set_elem_item *do_set_elem_delete_by_value(set_meta_info *info, set_hash_node *node,
+static set_elem_item *do_set_elem_delete_by_value(htree_meta *htree, htree_node *node,
                                                    const int hval, const char *val, const int vlen,
                                                    size_t *space_decreased)
 {
     set_elem_item *deleted = NULL;
-    int hidx = SET_GET_HASHIDX(hval, node->hdepth);
+    int hidx = HTREE_GET_HASHIDX(hval, node->hdepth);
 
     if (node->hcnt[hidx] == -1) {
-        set_hash_node *child_node = node->htab[hidx];
-        deleted = do_set_elem_delete_by_value(info, child_node, hval, val, vlen, space_decreased);
+        htree_node *child_node = node->htab[hidx];
+        deleted = do_set_elem_delete_by_value(htree, child_node, hval, val, vlen, space_decreased);
         if (deleted) {
-            if (child_node->tot_elem_cnt < (SET_MAX_HASHCHAIN_SIZE/2)) {
-                do_set_node_unlink(info, node, hidx);
-                *space_decreased += slabs_space_size(sizeof(set_hash_node));
+            if (child_node->tot_elem_cnt < (HTREE_MAX_HASHCHAIN_SIZE/2)) {
+                do_set_node_unlink(htree, node, hidx);
+                *space_decreased += slabs_space_size(sizeof(htree_node));
             }
             node->tot_elem_cnt -= 1;
         }
@@ -459,7 +455,7 @@ static set_elem_item *do_set_elem_delete_by_value(set_meta_info *info, set_hash_
             set_elem_item *elem = node->htab[hidx];
             while (elem != NULL) {
                 if (set_hash_eq(hval, val, vlen, elem->hval, elem->value, elem->nbytes)) {
-                    do_set_elem_unlink(info, node, hidx, prev, elem);
+                    do_set_elem_unlink(node, hidx, prev, elem);
                     deleted = elem;
                     break;
                 }
@@ -474,16 +470,17 @@ static set_elem_item *do_set_elem_delete_by_value(set_meta_info *info, set_hash_
 static ENGINE_ERROR_CODE do_set_elem_delete(set_meta_info *info,
                                             const char *val, const int vlen)
 {
+    htree_meta *htree = &info->htree;
     ENGINE_ERROR_CODE ret = ENGINE_ELEM_ENOENT;
-    if (info->root != NULL) {
+    if (htree->root != NULL) {
         int hval = genhash_string_hash(val, vlen);
         size_t space_decreased = 0;
-        set_elem_item *deleted = do_set_elem_delete_by_value(info, info->root, hval, val, vlen, &space_decreased);
+        set_elem_item *deleted = do_set_elem_delete_by_value(htree, htree->root, hval, val, vlen, &space_decreased);
         if (deleted != NULL) {
             do_set_elem_delete_post(info, deleted, ELEM_DELETE_NORMAL);
-            if (info->root->tot_elem_cnt == 0) {
-                do_set_node_unlink(info, NULL, 0);
-                space_decreased += slabs_space_size(sizeof(set_hash_node));
+            if (htree->root->tot_elem_cnt == 0) {
+                do_set_node_unlink(htree, NULL, 0);
+                space_decreased += slabs_space_size(sizeof(htree_node));
             }
             if (info->stotal > 0 && space_decreased > 0) {
                 do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_SET, space_decreased);
@@ -494,7 +491,7 @@ static ENGINE_ERROR_CODE do_set_elem_delete(set_meta_info *info,
     return ret;
 }
 
-static int do_set_elem_get_all(set_meta_info *info, set_hash_node *node,
+static int do_set_elem_get_all(htree_meta *htree, htree_node *node,
                                const bool delete, set_elem_item **elem_array,
                                size_t *space_decreased)
 {
@@ -502,15 +499,15 @@ static int do_set_elem_get_all(set_meta_info *info, set_hash_node *node,
     int hidx;
     int fcnt = 0; /* found count */
 
-    for (hidx = 0; hidx < SET_HASHTAB_SIZE; hidx++) {
+    for (hidx = 0; hidx < HTREE_HASHTAB_SIZE; hidx++) {
         if (node->hcnt[hidx] == -1) {
-            set_hash_node *child_node = (set_hash_node *)node->htab[hidx];
-            int ecnt = do_set_elem_get_all(info, child_node, delete, &elem_array[fcnt], space_decreased);
+            htree_node *child_node = (htree_node *)node->htab[hidx];
+            int ecnt = do_set_elem_get_all(htree, child_node, delete, &elem_array[fcnt], space_decreased);
             fcnt += ecnt;
             if (delete) {
-                if (child_node->tot_elem_cnt < (SET_MAX_HASHCHAIN_SIZE/2)) {
-                    do_set_node_unlink(info, node, hidx);
-                    *space_decreased += slabs_space_size(sizeof(set_hash_node));
+                if (child_node->tot_elem_cnt < (HTREE_MAX_HASHCHAIN_SIZE/2)) {
+                    do_set_node_unlink(htree, node, hidx);
+                    *space_decreased += slabs_space_size(sizeof(htree_node));
                 }
                 node->tot_elem_cnt -= ecnt;
             }
@@ -520,7 +517,7 @@ static int do_set_elem_get_all(set_meta_info *info, set_hash_node *node,
                 elem->refcount++;
                 elem_array[fcnt] = elem;
                 fcnt++;
-                if (delete) do_set_elem_unlink(info, node, hidx, NULL, elem);
+                if (delete) do_set_elem_unlink(node, hidx, NULL, elem);
                 elem = (delete ? node->htab[hidx] : elem->next);
             }
         }
@@ -528,29 +525,29 @@ static int do_set_elem_get_all(set_meta_info *info, set_hash_node *node,
     return fcnt;
 }
 
-static int do_set_elem_delete_by_count(set_meta_info *info, set_hash_node *node,
+static int do_set_elem_delete_by_count(htree_meta *htree, htree_node *node,
                                        const uint32_t count, set_elem_item **deleted_head,
                                        size_t *space_decreased)
 {
     int hidx;
     int fcnt = 0;
 
-    for (hidx = 0; hidx < SET_HASHTAB_SIZE; hidx++) {
+    for (hidx = 0; hidx < HTREE_HASHTAB_SIZE; hidx++) {
         if (node->hcnt[hidx] == -1) {
-            set_hash_node *child_node = (set_hash_node *)node->htab[hidx];
+            htree_node *child_node = (htree_node *)node->htab[hidx];
             int rcnt = (count > 0 ? (count - fcnt) : 0);
-            int ecnt = do_set_elem_delete_by_count(info, child_node, rcnt, deleted_head, space_decreased);
+            int ecnt = do_set_elem_delete_by_count(htree, child_node, rcnt, deleted_head, space_decreased);
             fcnt += ecnt;
-            if (child_node->tot_elem_cnt < (SET_MAX_HASHCHAIN_SIZE/2)) {
-                do_set_node_unlink(info, node, hidx);
-                *space_decreased += slabs_space_size(sizeof(set_hash_node));
+            if (child_node->tot_elem_cnt < (HTREE_MAX_HASHCHAIN_SIZE/2)) {
+                do_set_node_unlink(htree, node, hidx);
+                *space_decreased += slabs_space_size(sizeof(htree_node));
             }
             node->tot_elem_cnt -= ecnt;
         } else if (node->hcnt[hidx] > 0) {
             set_elem_item *elem = node->htab[hidx];
             while (elem != NULL) {
                 fcnt++;
-                do_set_elem_unlink(info, node, hidx, NULL, elem);
+                do_set_elem_unlink(node, hidx, NULL, elem);
 
                 /* link deleted elem into list; returned to caller */
                 elem->next = *deleted_head;
@@ -565,17 +562,17 @@ static int do_set_elem_delete_by_count(set_meta_info *info, set_hash_node *node,
     return fcnt;
 }
 
-static int do_set_elem_get_sampling(set_meta_info *info, set_hash_node *node,
+static int do_set_elem_get_sampling(htree_meta *htree, htree_node *node,
                                     uint32_t remain, const uint32_t count,
                                     set_elem_item **elem_array)
 {
     int hidx;
     int fcnt = 0; /* found count */
 
-    for (hidx = 0; hidx < SET_HASHTAB_SIZE; hidx++) {
+    for (hidx = 0; hidx < HTREE_HASHTAB_SIZE; hidx++) {
         if (node->hcnt[hidx] == -1) {
-            set_hash_node *child_node = (set_hash_node *)node->htab[hidx];
-            fcnt += do_set_elem_get_sampling(info, child_node, remain,
+            htree_node *child_node = (htree_node *)node->htab[hidx];
+            fcnt += do_set_elem_get_sampling(htree, child_node, remain,
                                              count - fcnt, &elem_array[fcnt]);
             remain -= child_node->tot_elem_cnt;
         } else if (node->hcnt[hidx] > 0) {
@@ -596,23 +593,23 @@ static int do_set_elem_get_sampling(set_meta_info *info, set_hash_node *node,
     return fcnt;
 }
 
-static set_elem_item *do_set_elem_get_by_offset(set_meta_info *info, set_hash_node *node,
+static set_elem_item *do_set_elem_get_by_offset(htree_meta *htree, htree_node *node,
                                                 uint32_t offset, const bool delete,
                                                 size_t *space_decreased)
 {
     int hidx;
-    for (hidx = 0; hidx < SET_HASHTAB_SIZE; hidx++) {
+    for (hidx = 0; hidx < HTREE_HASHTAB_SIZE; hidx++) {
         if (node->hcnt[hidx] == -1) {
-            set_hash_node *child_node = (set_hash_node *)node->htab[hidx];
+            htree_node *child_node = (htree_node *)node->htab[hidx];
             if (offset >= child_node->tot_elem_cnt) {
                 offset -= child_node->tot_elem_cnt;
                 continue;
             }
-            set_elem_item *found = do_set_elem_get_by_offset(info, child_node, offset, delete, space_decreased);
+            set_elem_item *found = do_set_elem_get_by_offset(htree, child_node, offset, delete, space_decreased);
             if (delete) {
-                if (child_node->tot_elem_cnt < (SET_MAX_HASHCHAIN_SIZE/2)) {
-                    do_set_node_unlink(info, node, hidx);
-                    *space_decreased += slabs_space_size(sizeof(set_hash_node));
+                if (child_node->tot_elem_cnt < (HTREE_MAX_HASHCHAIN_SIZE/2)) {
+                    do_set_node_unlink(htree, node, hidx);
+                    *space_decreased += slabs_space_size(sizeof(htree_node));
                 }
                 node->tot_elem_cnt -= 1;
             }
@@ -630,14 +627,15 @@ static set_elem_item *do_set_elem_get_by_offset(set_meta_info *info, set_hash_no
                 offset -= 1;
             }
             elem->refcount++;
-            if (delete) do_set_elem_unlink(info, node, hidx, prev, elem);
+            if (delete) do_set_elem_unlink(node, hidx, prev, elem);
             return elem;
         }
     }
     return NULL;
 }
 
-static uint32_t do_set_elem_get_rand(set_meta_info *info,
+static uint32_t do_set_elem_get_rand(htree_meta *htree,
+                                     const uint32_t ccnt,
                                      const uint32_t count, const bool delete,
                                      set_elem_item **elem_array,
                                      size_t *space_decreased)
@@ -647,20 +645,20 @@ static uint32_t do_set_elem_get_rand(set_meta_info *info,
 
     if (delete) { /* Deleting partial elements */
         while (fcnt < count) {
-            int rand_offset = (rand() % info->ccnt);
-            set_elem_item *found = do_set_elem_get_by_offset(info, info->root,
+            int rand_offset = (rand() % ccnt);
+            set_elem_item *found = do_set_elem_get_by_offset(htree, htree->root,
                                                              rand_offset, delete, space_decreased);
             assert(found != NULL);
             elem_array[fcnt++] = found;
         }
-    } else if (count <= info->ccnt / 10) { /* Use hash table */
+    } else if (count <= ccnt / 10) { /* Use hash table */
         hash_table offset_ht;
         if (!hash_init(&offset_ht, count))
             return 0;
         while (fcnt < count) {
-            int rand_offset = (rand() % info->ccnt);
+            int rand_offset = (rand() % ccnt);
             if (hash_insert(&offset_ht, rand_offset)) {
-                set_elem_item *found = do_set_elem_get_by_offset(info, info->root,
+                set_elem_item *found = do_set_elem_get_by_offset(htree, htree->root,
                                                                  rand_offset, false, NULL);
                 assert(found != NULL);
                 elem_array[fcnt++] = found;
@@ -668,7 +666,7 @@ static uint32_t do_set_elem_get_rand(set_meta_info *info,
         }
         hash_free(&offset_ht);
     } else { /* Use sampling */
-        fcnt = do_set_elem_get_sampling(info, info->root, info->ccnt, count,
+        fcnt = do_set_elem_get_sampling(htree, htree->root, ccnt, count,
                                         elem_array);
         for (int i = fcnt - 1; i > 0; i--) {
             int rand_idx = rand() % (i + 1);
@@ -686,7 +684,8 @@ static uint32_t do_set_elem_get(set_meta_info *info,
                                 const uint32_t count, const bool delete,
                                 set_elem_item **elem_array)
 {
-    assert(info->root);
+    htree_meta *htree = &info->htree;
+    assert(htree->root);
     uint32_t fcnt;
     enum elem_delete_cause cause = ELEM_DELETE_NORMAL;
 
@@ -695,17 +694,17 @@ static uint32_t do_set_elem_get(set_meta_info *info,
         CLOG_ELEM_DELETE_BEGIN((coll_meta_info*)info, count, cause);
     }
     if (count >= info->ccnt || count == 0) { /* Return all */
-        fcnt = do_set_elem_get_all(info, info->root, delete, elem_array, &space_decreased);
+        fcnt = do_set_elem_get_all(htree, htree->root, delete, elem_array, &space_decreased);
     } else { /* Return some */
-        fcnt = do_set_elem_get_rand(info, count, delete, elem_array, &space_decreased);
+        fcnt = do_set_elem_get_rand(htree, info->ccnt, count, delete, elem_array, &space_decreased);
     }
     if (delete) {
         for (int ii = 0; ii < fcnt; ii++) {
             do_set_elem_delete_post(info, elem_array[ii], cause);
         }
-        if (info->root->tot_elem_cnt == 0) {
-            do_set_node_unlink(info, NULL, 0);
-            space_decreased += slabs_space_size(sizeof(set_hash_node));
+        if (htree->root->tot_elem_cnt == 0) {
+            do_set_node_unlink(htree, NULL, 0);
+            space_decreased += slabs_space_size(sizeof(htree_node));
         }
         if (info->stotal > 0 && space_decreased > 0) {
             do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_SET, space_decreased);
@@ -739,7 +738,7 @@ static ENGINE_ERROR_CODE do_set_elem_insert(hash_item *it, set_elem_item *elem)
     }
 
     size_t space_increased = 0;
-    ret = do_htree_elem_insert(info, elem, &space_increased);
+    ret = do_htree_elem_insert(&info->htree, elem, &space_increased);
     if (ret != ENGINE_SUCCESS) {
         return ret;
     }
@@ -901,7 +900,7 @@ ENGINE_ERROR_CODE set_elem_exist(const char *key, const uint32_t nkey,
                 ret = ENGINE_UNREADABLE; break;
             }
             int hval = genhash_string_hash(value, nbytes);
-            if (do_set_elem_find(info, hval, value, nbytes, NULL) != NULL)
+            if (do_set_elem_find(&info->htree, hval, value, nbytes, NULL) != NULL)
                 *exist = true;
             else
                 *exist = false;
@@ -974,13 +973,14 @@ ENGINE_ERROR_CODE set_elem_get(const char *key, const uint32_t nkey,
 
 uint32_t set_elem_delete_with_count(set_meta_info *info, const uint32_t count)
 {
+    htree_meta *htree = &info->htree;
     uint32_t fcnt = 0;
     size_t space_decreased = 0;
 
     // cache_lock is held by caller
-    if (info->root != NULL) {
+    if (htree->root != NULL) {
         set_elem_item *deleted_head = NULL;
-        fcnt = do_set_elem_delete_by_count(info, info->root, count, &deleted_head, &space_decreased);
+        fcnt = do_set_elem_delete_by_count(htree, htree->root, count, &deleted_head, &space_decreased);
 
         set_elem_item *deleted = deleted_head;
         while (deleted != NULL) {
@@ -989,9 +989,9 @@ uint32_t set_elem_delete_with_count(set_meta_info *info, const uint32_t count)
             deleted = next;
         }
 
-        if (info->root->tot_elem_cnt == 0) {
-            do_set_node_unlink(info, NULL, 0);
-            space_decreased += slabs_space_size(sizeof(set_hash_node));
+        if (htree->root->tot_elem_cnt == 0) {
+            do_set_node_unlink(htree, NULL, 0);
+            space_decreased += slabs_space_size(sizeof(htree_node));
         }
         if (info->stotal > 0 && space_decreased > 0) { /* apply memory space */
             do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_SET, space_decreased);
@@ -1002,8 +1002,9 @@ uint32_t set_elem_delete_with_count(set_meta_info *info, const uint32_t count)
 
 void set_elem_get_all(set_meta_info *info, elems_result_t *eresult)
 {
+    htree_meta *htree = &info->htree;
     assert(eresult->elem_arrsz >= info->ccnt && eresult->elem_count == 0);
-    eresult->elem_count = do_set_elem_get_all(info, info->root, false,
+    eresult->elem_count = do_set_elem_get_all(htree, htree->root, false,
                                               (set_elem_item**)(eresult->elem_array), NULL);
     assert(eresult->elem_count == info->ccnt);
 }

--- a/engines/default/coll_set.c
+++ b/engines/default/coll_set.c
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 #include "config.h"
+#include "hash_tree.h"
 #include <fcntl.h>
 #include <errno.h>
 #include <stdlib.h>
@@ -37,9 +38,6 @@
 static struct default_engine *engine=NULL;
 static struct engine_config  *config=NULL; // engine config
 static EXTENSION_LOGGER_DESCRIPTOR *logger;
-
-/* used by set and map collection */
-extern int genhash_string_hash(const void* p, size_t nkey);
 
 /* Cache Lock */
 static inline void LOCK_CACHE(void)
@@ -101,6 +99,15 @@ static bool hash_insert(hash_table *ht, int key)
 /*
  * SET collection manangement
  */
+static const void *set_get_key(const htree_elem_item *elem, uint16_t *nkey)
+{
+    set_elem_item *e = (set_elem_item *)elem;
+    *nkey = e->nbytes;
+    return e->value;
+}
+
+static htree_ops set_htree_ops = { set_get_key };
+
 typedef struct _set_prev_info {
     htree_node *node;
     set_elem_item *prev;
@@ -176,28 +183,10 @@ static hash_item *do_set_item_alloc(const void *key, const uint32_t nkey,
         if (attrp->readable == 1)              info->mflags |= COLL_META_FLAG_READABLE;
         info->itdist  = (uint16_t)((size_t*)info-(size_t*)it);
         info->stotal  = 0;
-        info->htree.root    = NULL;
+        htree_init(&info->htree, &set_htree_ops);
         assert((hash_item*)COLL_GET_HASH_ITEM(info) == it);
     }
     return it;
-}
-
-static htree_node *do_set_node_alloc(uint8_t hash_depth)
-{
-    size_t ntotal = sizeof(htree_node);
-
-    htree_node *node = do_item_mem_alloc(ntotal, LRU_CLSID_FOR_SMALL);
-    if (node != NULL) {
-        node->slabs_clsid = slabs_clsid(ntotal);
-        assert(node->slabs_clsid > 0);
-
-        node->refcount    = 0;
-        node->hdepth      = hash_depth;
-        node->tot_elem_cnt = 0;
-        memset(node->hcnt, 0, HTREE_HASHTAB_SIZE*sizeof(uint16_t));
-        memset(node->htab, 0, HTREE_HASHTAB_SIZE*sizeof(void*));
-    }
-    return node;
 }
 
 static void do_set_node_free(htree_node *node)
@@ -236,30 +225,6 @@ static void do_set_elem_release(set_elem_item *elem)
     }
     if (elem->refcount == 0 && elem->linked == 0) {
         do_set_elem_free(elem);
-    }
-}
-
-static void do_set_node_link(htree_meta *htree,
-                             htree_node *par_node, const int par_hidx,
-                             htree_node *node)
-{
-    if (par_node == NULL) {
-        htree->root = node;
-    } else {
-        set_elem_item *elem;
-        while (par_node->htab[par_hidx] != NULL) {
-            elem = par_node->htab[par_hidx];
-            par_node->htab[par_hidx] = elem->next;
-
-            int hidx = HTREE_GET_HASHIDX(elem->hval, node->hdepth);
-            elem->next = node->htab[hidx];
-            node->htab[hidx] = elem;
-            node->hcnt[hidx] += 1;
-            node->tot_elem_cnt += 1;
-        }
-        assert(node->tot_elem_cnt == par_node->hcnt[par_hidx]);
-        par_node->htab[par_hidx] = node;
-        par_node->hcnt[par_hidx] = -1; /* child hash node */
     }
 }
 
@@ -305,105 +270,6 @@ static void do_set_node_unlink(htree_meta *htree,
 
     /* free the node */
     do_set_node_free(node);
-}
-
-static set_elem_item *do_set_elem_find(htree_meta *htree,
-                                       const int hval,
-                                       const void *key, uint16_t nkey,
-                                       set_prev_info *pinfo)
-{
-    if (htree->root == NULL) {
-        return NULL;
-    }
-
-    htree_node *node = htree->root;
-    int hidx;
-
-    while (node != NULL) {
-        hidx = HTREE_GET_HASHIDX(hval, node->hdepth);
-        if (node->hcnt[hidx] >= 0)
-            break;
-        node = node->htab[hidx];
-    }
-
-    set_elem_item *prev = NULL;
-    set_elem_item *elem;
-    for (elem = node->htab[hidx]; elem != NULL; elem = elem->next) {
-        if (set_hash_eq(hval, key, nkey, elem->hval, elem->value, elem->nbytes))
-            break;
-        prev = elem;
-    }
-
-    if (pinfo != NULL) {
-        pinfo->node = node;
-        pinfo->prev = prev;
-        pinfo->hidx = hidx;
-    }
-
-    return elem;
-}
-
-static ENGINE_ERROR_CODE do_htree_elem_link(htree_meta *htree,
-                                            htree_node *node, int hidx,
-                                            set_elem_item *elem, size_t *space_increased)
-{
-    if (node->hcnt[hidx] >= HTREE_MAX_HASHCHAIN_SIZE) {
-        htree_node *n_node = do_set_node_alloc(node->hdepth+1);
-        if (n_node == NULL) {
-            return ENGINE_ENOMEM;
-        }
-        do_set_node_link(htree, node, hidx, n_node);
-        *space_increased += slabs_space_size(sizeof(htree_node));
-
-        node = n_node;
-        hidx = HTREE_GET_HASHIDX(elem->hval, node->hdepth);
-    }
-
-    elem->linked++;
-    elem->next = node->htab[hidx];
-    node->htab[hidx] = elem;
-    node->hcnt[hidx] += 1;
-    node->tot_elem_cnt += 1;
-
-    htree_node *par_node = htree->root;
-    while (par_node != node) {
-        par_node->tot_elem_cnt += 1;
-        int par_hidx = HTREE_GET_HASHIDX(elem->hval, par_node->hdepth);
-        assert(par_node->hcnt[par_hidx] == -1);
-        par_node = par_node->htab[par_hidx];
-    }
-    return ENGINE_SUCCESS;
-}
-
-static ENGINE_ERROR_CODE do_htree_elem_insert(htree_meta *htree, set_elem_item *elem,
-                                              size_t *space_increased)
-{
-    htree_node *node;
-    int hidx;
-    /* create the root hash node if it does not exist */
-    if (htree->root == NULL) {
-        node = do_set_node_alloc(0);
-        if (node == NULL) {
-            return ENGINE_ENOMEM;
-        }
-        do_set_node_link(htree, NULL, 0, node);
-        *space_increased += slabs_space_size(sizeof(htree_node));
-
-        hidx = HTREE_GET_HASHIDX(elem->hval, 0);
-        return do_htree_elem_link(htree, node, hidx, elem, space_increased);
-    }
-
-    set_elem_item *find;
-    set_prev_info pinfo;
-
-    find = do_set_elem_find(htree, elem->hval, elem->value, elem->nbytes, &pinfo);
-    if (find != NULL) {
-        return ENGINE_ELEM_EEXISTS;
-    }
-
-    node = pinfo.node;
-    hidx = pinfo.hidx;
-    return do_htree_elem_link(htree, node, hidx, elem, space_increased);
 }
 
 static void do_set_elem_unlink(htree_node *node, const int hidx,
@@ -738,7 +604,7 @@ static ENGINE_ERROR_CODE do_set_elem_insert(hash_item *it, set_elem_item *elem)
     }
 
     size_t space_increased = 0;
-    ret = do_htree_elem_insert(&info->htree, elem, &space_increased);
+    ret = htree_elem_insert(&info->htree, (htree_elem_item *)elem, &space_increased);
     if (ret != ENGINE_SUCCESS) {
         return ret;
     }
@@ -900,7 +766,7 @@ ENGINE_ERROR_CODE set_elem_exist(const char *key, const uint32_t nkey,
                 ret = ENGINE_UNREADABLE; break;
             }
             int hval = genhash_string_hash(value, nbytes);
-            if (do_set_elem_find(&info->htree, hval, value, nbytes, NULL) != NULL)
+            if (htree_elem_find(&info->htree, hval, value, nbytes, NULL) != NULL)
                 *exist = true;
             else
                 *exist = false;

--- a/engines/default/coll_set.c
+++ b/engines/default/coll_set.c
@@ -51,52 +51,6 @@ static inline void UNLOCK_CACHE(void)
 }
 
 /*
- * Hash table management
- */
-typedef struct hash_node {
-    int cnt;
-    int keys[3];
-} hash_node;
-
-typedef struct hash_table {
-    hash_node *buckets;
-    int capacity;
-} hash_table;
-
-static bool hash_init(hash_table *ht, int count)
-{
-    ht->capacity = (int)(1.3 * (double)count);
-    ht->buckets = (hash_node*)calloc(ht->capacity, sizeof(hash_node));
-    if (ht->buckets == NULL)
-        return false;
-    return true;
-}
-
-static void hash_free(hash_table *ht)
-{
-    if (ht->buckets) {
-        free(ht->buckets);
-        ht->buckets = NULL;
-        ht->capacity = 0;
-    }
-}
-
-static bool hash_insert(hash_table *ht, int key)
-{
-    size_t idx = key % ht->capacity;
-    hash_node *bucket = &ht->buckets[idx];
-    if (bucket->cnt == 3)
-        return false;
-    for (int i = 0; i < bucket->cnt; i++) {
-        if (bucket->keys[i] == key)
-            return false;
-    }
-    bucket->keys[bucket->cnt] = key;
-    bucket->cnt++;
-    return true;
-}
-
-/*
  * SET collection manangement
  */
 static const void *set_get_key(const htree_elem_item *elem, uint16_t *nkey)
@@ -107,18 +61,6 @@ static const void *set_get_key(const htree_elem_item *elem, uint16_t *nkey)
 }
 
 static htree_ops set_htree_ops = { set_get_key };
-
-typedef struct _set_prev_info {
-    htree_node *node;
-    set_elem_item *prev;
-    uint16_t       hidx;
-} set_prev_info;
-
-static inline int set_hash_eq(const int h1, const void *v1, size_t vlen1,
-                              const int h2, const void *v2, size_t vlen2)
-{
-    return (h1 == h2 && vlen1 == vlen2 && memcmp(v1, v2, vlen1) == 0);
-}
 
 static inline uint32_t do_set_elem_ntotal(set_elem_item *elem)
 {
@@ -189,11 +131,6 @@ static hash_item *do_set_item_alloc(const void *key, const uint32_t nkey,
     return it;
 }
 
-static void do_set_node_free(htree_node *node)
-{
-    do_item_mem_free(node, sizeof(htree_node));
-}
-
 static set_elem_item *do_set_elem_alloc(const uint32_t nbytes)
 {
     size_t ntotal = sizeof(set_elem_item) + nbytes;
@@ -228,60 +165,6 @@ static void do_set_elem_release(set_elem_item *elem)
     }
 }
 
-static void do_set_node_unlink(htree_meta *htree,
-                               htree_node *par_node, const int par_hidx)
-{
-    htree_node *node;
-
-    if (par_node == NULL) {
-        node = htree->root;
-        htree->root = NULL;
-        assert(node->tot_elem_cnt == 0);
-    } else {
-        assert(par_node->hcnt[par_hidx] == -1); /* child hash node */
-        set_elem_item *head = NULL;
-        set_elem_item *elem;
-        int hidx, fcnt = 0;
-
-        node = (htree_node *)par_node->htab[par_hidx];
-        assert(node->tot_elem_cnt < (HTREE_MAX_HASHCHAIN_SIZE/2));
-
-        for (hidx = 0; hidx < HTREE_HASHTAB_SIZE; hidx++) {
-            assert(node->hcnt[hidx] >= 0);
-            if (node->hcnt[hidx] > 0) {
-                fcnt += node->hcnt[hidx];
-                while (node->htab[hidx] != NULL) {
-                    elem = node->htab[hidx];
-                    node->htab[hidx] = elem->next;
-                    node->hcnt[hidx] -= 1;
-
-                    elem->next = head;
-                    head = elem;
-                }
-                assert(node->hcnt[hidx] == 0);
-            }
-        }
-        assert(fcnt == node->tot_elem_cnt);
-        node->tot_elem_cnt = 0;
-
-        par_node->htab[par_hidx] = head;
-        par_node->hcnt[par_hidx] = fcnt;
-    }
-
-    /* free the node */
-    do_set_node_free(node);
-}
-
-static void do_set_elem_unlink(htree_node *node, const int hidx,
-                               set_elem_item *prev, set_elem_item *elem)
-{
-    if (prev != NULL) prev->next = elem->next;
-    else              node->htab[hidx] = elem->next;
-    elem->linked--;
-    node->hcnt[hidx] -= 1;
-    node->tot_elem_cnt -= 1;
-}
-
 static void do_set_elem_delete_post(set_meta_info *info,
                                     set_elem_item *elem,
                                     enum elem_delete_cause cause)
@@ -298,41 +181,6 @@ static void do_set_elem_delete_post(set_meta_info *info,
     }
 }
 
-static set_elem_item *do_set_elem_delete_by_value(htree_meta *htree, htree_node *node,
-                                                   const int hval, const char *val, const int vlen,
-                                                   size_t *space_decreased)
-{
-    set_elem_item *deleted = NULL;
-    int hidx = HTREE_GET_HASHIDX(hval, node->hdepth);
-
-    if (node->hcnt[hidx] == -1) {
-        htree_node *child_node = node->htab[hidx];
-        deleted = do_set_elem_delete_by_value(htree, child_node, hval, val, vlen, space_decreased);
-        if (deleted) {
-            if (child_node->tot_elem_cnt < (HTREE_MAX_HASHCHAIN_SIZE/2)) {
-                do_set_node_unlink(htree, node, hidx);
-                *space_decreased += slabs_space_size(sizeof(htree_node));
-            }
-            node->tot_elem_cnt -= 1;
-        }
-    } else {
-        if (node->hcnt[hidx] > 0) {
-            set_elem_item *prev = NULL;
-            set_elem_item *elem = node->htab[hidx];
-            while (elem != NULL) {
-                if (set_hash_eq(hval, val, vlen, elem->hval, elem->value, elem->nbytes)) {
-                    do_set_elem_unlink(node, hidx, prev, elem);
-                    deleted = elem;
-                    break;
-                }
-                prev = elem;
-                elem = elem->next;
-            }
-        }
-    }
-    return deleted;
-}
-
 static ENGINE_ERROR_CODE do_set_elem_delete(set_meta_info *info,
                                             const char *val, const int vlen)
 {
@@ -341,13 +189,9 @@ static ENGINE_ERROR_CODE do_set_elem_delete(set_meta_info *info,
     if (htree->root != NULL) {
         int hval = genhash_string_hash(val, vlen);
         size_t space_decreased = 0;
-        set_elem_item *deleted = do_set_elem_delete_by_value(htree, htree->root, hval, val, vlen, &space_decreased);
+        htree_elem_item *deleted = htree_elem_delete(htree, htree->root, hval, val, vlen, &space_decreased);
         if (deleted != NULL) {
-            do_set_elem_delete_post(info, deleted, ELEM_DELETE_NORMAL);
-            if (htree->root->tot_elem_cnt == 0) {
-                do_set_node_unlink(htree, NULL, 0);
-                space_decreased += slabs_space_size(sizeof(htree_node));
-            }
+            do_set_elem_delete_post(info, (set_elem_item *)deleted, ELEM_DELETE_NORMAL);
             if (info->stotal > 0 && space_decreased > 0) {
                 do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_SET, space_decreased);
             }
@@ -355,195 +199,6 @@ static ENGINE_ERROR_CODE do_set_elem_delete(set_meta_info *info,
         }
     }
     return ret;
-}
-
-static int do_set_elem_get_all(htree_meta *htree, htree_node *node,
-                               const bool delete, set_elem_item **elem_array,
-                               size_t *space_decreased)
-{
-    assert(elem_array != NULL);
-    int hidx;
-    int fcnt = 0; /* found count */
-
-    for (hidx = 0; hidx < HTREE_HASHTAB_SIZE; hidx++) {
-        if (node->hcnt[hidx] == -1) {
-            htree_node *child_node = (htree_node *)node->htab[hidx];
-            int ecnt = do_set_elem_get_all(htree, child_node, delete, &elem_array[fcnt], space_decreased);
-            fcnt += ecnt;
-            if (delete) {
-                if (child_node->tot_elem_cnt < (HTREE_MAX_HASHCHAIN_SIZE/2)) {
-                    do_set_node_unlink(htree, node, hidx);
-                    *space_decreased += slabs_space_size(sizeof(htree_node));
-                }
-                node->tot_elem_cnt -= ecnt;
-            }
-        } else if (node->hcnt[hidx] > 0) {
-            set_elem_item *elem = node->htab[hidx];
-            while (elem != NULL) {
-                elem->refcount++;
-                elem_array[fcnt] = elem;
-                fcnt++;
-                if (delete) do_set_elem_unlink(node, hidx, NULL, elem);
-                elem = (delete ? node->htab[hidx] : elem->next);
-            }
-        }
-    }
-    return fcnt;
-}
-
-static int do_set_elem_delete_by_count(htree_meta *htree, htree_node *node,
-                                       const uint32_t count, set_elem_item **deleted_head,
-                                       size_t *space_decreased)
-{
-    int hidx;
-    int fcnt = 0;
-
-    for (hidx = 0; hidx < HTREE_HASHTAB_SIZE; hidx++) {
-        if (node->hcnt[hidx] == -1) {
-            htree_node *child_node = (htree_node *)node->htab[hidx];
-            int rcnt = (count > 0 ? (count - fcnt) : 0);
-            int ecnt = do_set_elem_delete_by_count(htree, child_node, rcnt, deleted_head, space_decreased);
-            fcnt += ecnt;
-            if (child_node->tot_elem_cnt < (HTREE_MAX_HASHCHAIN_SIZE/2)) {
-                do_set_node_unlink(htree, node, hidx);
-                *space_decreased += slabs_space_size(sizeof(htree_node));
-            }
-            node->tot_elem_cnt -= ecnt;
-        } else if (node->hcnt[hidx] > 0) {
-            set_elem_item *elem = node->htab[hidx];
-            while (elem != NULL) {
-                fcnt++;
-                do_set_elem_unlink(node, hidx, NULL, elem);
-
-                /* link deleted elem into list; returned to caller */
-                elem->next = *deleted_head;
-                *deleted_head = elem;
-
-                if (count > 0 && fcnt >= count) break;
-                elem = node->htab[hidx];
-            }
-        }
-        if (count > 0 && fcnt >= count) break;
-    }
-    return fcnt;
-}
-
-static int do_set_elem_get_sampling(htree_meta *htree, htree_node *node,
-                                    uint32_t remain, const uint32_t count,
-                                    set_elem_item **elem_array)
-{
-    int hidx;
-    int fcnt = 0; /* found count */
-
-    for (hidx = 0; hidx < HTREE_HASHTAB_SIZE; hidx++) {
-        if (node->hcnt[hidx] == -1) {
-            htree_node *child_node = (htree_node *)node->htab[hidx];
-            fcnt += do_set_elem_get_sampling(htree, child_node, remain,
-                                             count - fcnt, &elem_array[fcnt]);
-            remain -= child_node->tot_elem_cnt;
-        } else if (node->hcnt[hidx] > 0) {
-            set_elem_item *elem = node->htab[hidx];
-            while (elem != NULL) {
-                if ((rand() % remain) < (count - fcnt)) {
-                    elem->refcount++;
-                    elem_array[fcnt] = elem;
-                    fcnt++;
-                    if (fcnt >= count) break;
-                }
-                remain -= 1;
-                elem = elem->next;
-            }
-        }
-        if (fcnt >= count) break;
-    }
-    return fcnt;
-}
-
-static set_elem_item *do_set_elem_get_by_offset(htree_meta *htree, htree_node *node,
-                                                uint32_t offset, const bool delete,
-                                                size_t *space_decreased)
-{
-    int hidx;
-    for (hidx = 0; hidx < HTREE_HASHTAB_SIZE; hidx++) {
-        if (node->hcnt[hidx] == -1) {
-            htree_node *child_node = (htree_node *)node->htab[hidx];
-            if (offset >= child_node->tot_elem_cnt) {
-                offset -= child_node->tot_elem_cnt;
-                continue;
-            }
-            set_elem_item *found = do_set_elem_get_by_offset(htree, child_node, offset, delete, space_decreased);
-            if (delete) {
-                if (child_node->tot_elem_cnt < (HTREE_MAX_HASHCHAIN_SIZE/2)) {
-                    do_set_node_unlink(htree, node, hidx);
-                    *space_decreased += slabs_space_size(sizeof(htree_node));
-                }
-                node->tot_elem_cnt -= 1;
-            }
-            return found;
-        } else if (node->hcnt[hidx] > 0) {
-            if (offset >= node->hcnt[hidx]) {
-                offset -= node->hcnt[hidx];
-                continue;
-            }
-            set_elem_item *prev = NULL;
-            set_elem_item *elem = node->htab[hidx];
-            while (offset > 0) {
-                prev = elem;
-                elem = elem->next;
-                offset -= 1;
-            }
-            elem->refcount++;
-            if (delete) do_set_elem_unlink(node, hidx, prev, elem);
-            return elem;
-        }
-    }
-    return NULL;
-}
-
-static uint32_t do_set_elem_get_rand(htree_meta *htree,
-                                     const uint32_t ccnt,
-                                     const uint32_t count, const bool delete,
-                                     set_elem_item **elem_array,
-                                     size_t *space_decreased)
-{
-    assert(elem_array != NULL);
-    uint32_t fcnt = 0;
-
-    if (delete) { /* Deleting partial elements */
-        while (fcnt < count) {
-            int rand_offset = (rand() % ccnt);
-            set_elem_item *found = do_set_elem_get_by_offset(htree, htree->root,
-                                                             rand_offset, delete, space_decreased);
-            assert(found != NULL);
-            elem_array[fcnt++] = found;
-        }
-    } else if (count <= ccnt / 10) { /* Use hash table */
-        hash_table offset_ht;
-        if (!hash_init(&offset_ht, count))
-            return 0;
-        while (fcnt < count) {
-            int rand_offset = (rand() % ccnt);
-            if (hash_insert(&offset_ht, rand_offset)) {
-                set_elem_item *found = do_set_elem_get_by_offset(htree, htree->root,
-                                                                 rand_offset, false, NULL);
-                assert(found != NULL);
-                elem_array[fcnt++] = found;
-            }
-        }
-        hash_free(&offset_ht);
-    } else { /* Use sampling */
-        fcnt = do_set_elem_get_sampling(htree, htree->root, ccnt, count,
-                                        elem_array);
-        for (int i = fcnt - 1; i > 0; i--) {
-            int rand_idx = rand() % (i + 1);
-            if (rand_idx != i) {
-                set_elem_item *temp = elem_array[i];
-                elem_array[i] = elem_array[rand_idx];
-                elem_array[rand_idx] = temp;
-            }
-        }
-    }
-    return fcnt;
 }
 
 static uint32_t do_set_elem_get(set_meta_info *info,
@@ -560,17 +215,15 @@ static uint32_t do_set_elem_get(set_meta_info *info,
         CLOG_ELEM_DELETE_BEGIN((coll_meta_info*)info, count, cause);
     }
     if (count >= info->ccnt || count == 0) { /* Return all */
-        fcnt = do_set_elem_get_all(htree, htree->root, delete, elem_array, &space_decreased);
+        fcnt = htree_elem_get_bulk(htree, htree->root, 0 /* all */,
+                                   delete, (htree_elem_item **)elem_array, &space_decreased);
     } else { /* Return some */
-        fcnt = do_set_elem_get_rand(htree, info->ccnt, count, delete, elem_array, &space_decreased);
+        fcnt = htree_elem_get_rand(htree, info->ccnt, count,
+                                   delete, (htree_elem_item **)elem_array, &space_decreased);
     }
     if (delete) {
         for (int ii = 0; ii < fcnt; ii++) {
             do_set_elem_delete_post(info, elem_array[ii], cause);
-        }
-        if (htree->root->tot_elem_cnt == 0) {
-            do_set_node_unlink(htree, NULL, 0);
-            space_decreased += slabs_space_size(sizeof(htree_node));
         }
         if (info->stotal > 0 && space_decreased > 0) {
             do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_SET, space_decreased);
@@ -845,20 +498,16 @@ uint32_t set_elem_delete_with_count(set_meta_info *info, const uint32_t count)
 
     // cache_lock is held by caller
     if (htree->root != NULL) {
-        set_elem_item *deleted_head = NULL;
-        fcnt = do_set_elem_delete_by_count(htree, htree->root, count, &deleted_head, &space_decreased);
+        htree_elem_item *deleted_head = NULL;
+        fcnt = htree_elem_delete_bulk(htree, htree->root, count, &deleted_head, &space_decreased);
 
-        set_elem_item *deleted = deleted_head;
+        htree_elem_item *deleted = deleted_head;
         while (deleted != NULL) {
-            set_elem_item *next = deleted->next;
-            do_set_elem_delete_post(info, deleted, ELEM_DELETE_COLL);
+            htree_elem_item *next = deleted->next;
+            do_set_elem_delete_post(info, (set_elem_item *)deleted, ELEM_DELETE_COLL);
             deleted = next;
         }
 
-        if (htree->root->tot_elem_cnt == 0) {
-            do_set_node_unlink(htree, NULL, 0);
-            space_decreased += slabs_space_size(sizeof(htree_node));
-        }
         if (info->stotal > 0 && space_decreased > 0) { /* apply memory space */
             do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_SET, space_decreased);
         }
@@ -870,8 +519,8 @@ void set_elem_get_all(set_meta_info *info, elems_result_t *eresult)
 {
     htree_meta *htree = &info->htree;
     assert(eresult->elem_arrsz >= info->ccnt && eresult->elem_count == 0);
-    eresult->elem_count = do_set_elem_get_all(htree, htree->root, false,
-                                              (set_elem_item**)(eresult->elem_array), NULL);
+    eresult->elem_count = htree_elem_get_bulk(htree, htree->root, 0 /* all */,
+                                              false, (htree_elem_item**)(eresult->elem_array), NULL);
     assert(eresult->elem_count == info->ccnt);
 }
 

--- a/engines/default/hash_tree.c
+++ b/engines/default/hash_tree.c
@@ -17,8 +17,58 @@
  */
 #include "hash_tree.h"
 #include "default_engine.h"
+#include <stdlib.h>
 #include <assert.h>
 
+/*
+ * Hash table management
+ */
+typedef struct hash_node {
+    int cnt;
+    int keys[3];
+} hash_node;
+
+typedef struct hash_table {
+    hash_node *buckets;
+    int capacity;
+} hash_table;
+
+static bool hash_init(hash_table *ht, int count)
+{
+    ht->capacity = (int)(1.3 * (double)count);
+    ht->buckets = (hash_node*)calloc(ht->capacity, sizeof(hash_node));
+    if (ht->buckets == NULL)
+        return false;
+    return true;
+}
+
+static void hash_free(hash_table *ht)
+{
+    if (ht->buckets) {
+        free(ht->buckets);
+        ht->buckets = NULL;
+        ht->capacity = 0;
+    }
+}
+
+static bool hash_insert(hash_table *ht, int key)
+{
+    size_t idx = key % ht->capacity;
+    hash_node *bucket = &ht->buckets[idx];
+    if (bucket->cnt == 3)
+        return false;
+    for (int i = 0; i < bucket->cnt; i++) {
+        if (bucket->keys[i] == key)
+            return false;
+    }
+    bucket->keys[bucket->cnt] = key;
+    bucket->cnt++;
+    return true;
+}
+
+/*
+ * Hash tree manangement
+ */
 static htree_node *do_htree_node_alloc(uint8_t hash_depth)
 {
     size_t ntotal = sizeof(htree_node);
@@ -35,6 +85,11 @@ static htree_node *do_htree_node_alloc(uint8_t hash_depth)
         memset(node->htab, 0, HTREE_HASHTAB_SIZE*sizeof(void*));
     }
     return node;
+}
+
+static void do_htree_node_free(htree_node *node)
+{
+    do_item_mem_free(node, sizeof(htree_node));
 }
 
 static void do_htree_node_link(htree_meta *htree,
@@ -59,6 +114,50 @@ static void do_htree_node_link(htree_meta *htree,
         par_node->htab[par_hidx] = node;
         par_node->hcnt[par_hidx] = -1; /* child hash node */
     }
+}
+
+static void do_htree_node_unlink(htree_meta *htree,
+                                 htree_node *par_node, const int par_hidx)
+{
+    htree_node *node;
+
+    if (par_node == NULL) {
+        node = htree->root;
+        htree->root = NULL;
+        assert(node->tot_elem_cnt == 0);
+    } else {
+        assert(par_node->hcnt[par_hidx] == -1); /* child hash node */
+        htree_elem_item *head = NULL;
+        htree_elem_item *elem;
+        int hidx, fcnt = 0;
+
+        node = (htree_node *)par_node->htab[par_hidx];
+        assert(node->tot_elem_cnt < (HTREE_MAX_HASHCHAIN_SIZE/2));
+
+        for (hidx = 0; hidx < HTREE_HASHTAB_SIZE; hidx++) {
+            assert(node->hcnt[hidx] >= 0);
+            if (node->hcnt[hidx] > 0) {
+                fcnt += node->hcnt[hidx];
+                while (node->htab[hidx] != NULL) {
+                    elem = node->htab[hidx];
+                    node->htab[hidx] = elem->next;
+                    node->hcnt[hidx] -= 1;
+
+                    elem->next = head;
+                    head = elem;
+                }
+                assert(node->hcnt[hidx] == 0);
+            }
+        }
+        assert(fcnt == node->tot_elem_cnt);
+        node->tot_elem_cnt = 0;
+
+        par_node->htab[par_hidx] = head;
+        par_node->hcnt[par_hidx] = fcnt;
+    }
+
+    /* free the node */
+    do_htree_node_free(node);
 }
 
 static ENGINE_ERROR_CODE do_htree_elem_link(htree_meta *htree,
@@ -91,6 +190,243 @@ static ENGINE_ERROR_CODE do_htree_elem_link(htree_meta *htree,
         par_node = par_node->htab[par_hidx];
     }
     return ENGINE_SUCCESS;
+}
+
+static void do_htree_elem_unlink(htree_node *node, const int hidx,
+                                 htree_elem_item *prev, htree_elem_item *elem)
+{
+    if (prev != NULL) prev->next = elem->next;
+    else              node->htab[hidx] = elem->next;
+    elem->linked--;
+    node->hcnt[hidx] -= 1;
+    node->tot_elem_cnt -= 1;
+}
+
+static htree_elem_item *do_htree_elem_delete(htree_meta *htree, htree_node *node,
+                                             const int hval, const char *key, const int nkey,
+                                             size_t *space_decreased)
+{
+    htree_elem_item *deleted = NULL;
+    int hidx = HTREE_GET_HASHIDX(hval, node->hdepth);
+
+    if (node->hcnt[hidx] == -1) {
+        htree_node *child_node = node->htab[hidx];
+        deleted = do_htree_elem_delete(htree, child_node, hval, key, nkey, space_decreased);
+        if (deleted) {
+            if (child_node->tot_elem_cnt < (HTREE_MAX_HASHCHAIN_SIZE/2)) {
+                do_htree_node_unlink(htree, node, hidx);
+                *space_decreased += slabs_space_size(sizeof(htree_node));
+            }
+            node->tot_elem_cnt -= 1;
+        }
+    } else {
+        if (node->hcnt[hidx] > 0) {
+            htree_elem_item *prev = NULL;
+            htree_elem_item *elem = node->htab[hidx];
+            while (elem != NULL) {
+                uint16_t nkey;
+                const void *key = htree->ops->get_key(elem, &nkey);
+                if (htree_hash_eq(hval, key, nkey, elem->hval, key, nkey)) {
+                    do_htree_elem_unlink(node, hidx, prev, elem);
+                    deleted = elem;
+                    break;
+                }
+                prev = elem;
+                elem = elem->next;
+            }
+        }
+    }
+    return deleted;
+}
+
+static uint32_t do_htree_elem_delete_bulk(htree_meta *htree, htree_node *node, const uint32_t count,
+                                          htree_elem_item **deleted_head,
+                                          size_t *space_decreased)
+{
+    int hidx;
+    uint32_t fcnt = 0;
+
+    for (hidx = 0; hidx < HTREE_HASHTAB_SIZE; hidx++) {
+        if (node->hcnt[hidx] == -1) {
+            htree_node *child_node = (htree_node *)node->htab[hidx];
+            uint32_t rcnt = (count > 0 ? (count - fcnt) : 0);
+            uint32_t ecnt = do_htree_elem_delete_bulk(htree, child_node, rcnt, deleted_head, space_decreased);
+            fcnt += ecnt;
+            if (child_node->tot_elem_cnt < (HTREE_MAX_HASHCHAIN_SIZE/2)) {
+                do_htree_node_unlink(htree, node, hidx);
+                *space_decreased += slabs_space_size(sizeof(htree_node));
+            }
+            node->tot_elem_cnt -= ecnt;
+        } else if (node->hcnt[hidx] > 0) {
+            htree_elem_item *elem = node->htab[hidx];
+            while (elem != NULL) {
+                fcnt++;
+                do_htree_elem_unlink(node, hidx, NULL, elem);
+
+                /* link deleted elem into list; returned to caller */
+                elem->next = *deleted_head;
+                *deleted_head = elem;
+
+                if (count > 0 && fcnt >= count) break;
+                elem = node->htab[hidx];
+            }
+        }
+        if (count > 0 && fcnt >= count) break;
+    }
+    return fcnt;
+}
+
+static uint32_t do_htree_elem_get_bulk(htree_meta *htree, htree_node *node, const uint32_t count,
+                                       const bool delete, htree_elem_item **elem_array,
+                                       size_t *space_decreased)
+{
+    assert(elem_array != NULL);
+    int hidx;
+    size_t fcnt = 0; /* found count */
+
+    for (hidx = 0; hidx < HTREE_HASHTAB_SIZE; hidx++) {
+        if (node->hcnt[hidx] == -1) {
+            htree_node *child_node = (htree_node *)node->htab[hidx];
+            size_t rcnt = (count > 0 ? (count - fcnt) : 0);
+            size_t ecnt = do_htree_elem_get_bulk(htree, child_node, rcnt, delete, &elem_array[fcnt], space_decreased);
+            fcnt += ecnt;
+            if (delete) {
+                if (child_node->tot_elem_cnt < (HTREE_MAX_HASHCHAIN_SIZE/2)) {
+                    do_htree_node_unlink(htree, node, hidx);
+                    *space_decreased += slabs_space_size(sizeof(htree_node));
+                }
+                node->tot_elem_cnt -= ecnt;
+            }
+        } else if (node->hcnt[hidx] > 0) {
+            htree_elem_item *elem = node->htab[hidx];
+            while (elem != NULL) {
+                elem->refcount++;
+                elem_array[fcnt] = elem;
+                fcnt++;
+                if (delete) do_htree_elem_unlink(node, hidx, NULL, elem);
+                if (count > 0 && fcnt >= count) break;
+                elem = (delete ? node->htab[hidx] : elem->next);
+            }
+        }
+        if (count > 0 && fcnt >= count) break;
+    }
+    return fcnt;
+}
+
+static htree_elem_item *do_htree_elem_get_by_offset(htree_meta *htree, htree_node *node,
+                                                    uint32_t offset, const bool delete,
+                                                    size_t *space_decreased)
+{
+    int hidx;
+    for (hidx = 0; hidx < HTREE_HASHTAB_SIZE; hidx++) {
+        if (node->hcnt[hidx] == -1) {
+            htree_node *child_node = (htree_node *)node->htab[hidx];
+            if (offset >= child_node->tot_elem_cnt) {
+                offset -= child_node->tot_elem_cnt;
+                continue;
+            }
+            htree_elem_item *found = do_htree_elem_get_by_offset(htree, child_node, offset, delete, space_decreased);
+            if (delete) {
+                if (child_node->tot_elem_cnt < (HTREE_MAX_HASHCHAIN_SIZE/2)) {
+                    do_htree_node_unlink(htree, node, hidx);
+                    *space_decreased += slabs_space_size(sizeof(htree_node));
+                }
+                node->tot_elem_cnt -= 1;
+            }
+            return found;
+        } else if (node->hcnt[hidx] > 0) {
+            if (offset >= node->hcnt[hidx]) {
+                offset -= node->hcnt[hidx];
+                continue;
+            }
+            htree_elem_item *prev = NULL;
+            htree_elem_item *elem = node->htab[hidx];
+            while (offset > 0) {
+                prev = elem;
+                elem = elem->next;
+                offset -= 1;
+            }
+            elem->refcount++;
+            if (delete) do_htree_elem_unlink(node, hidx, prev, elem);
+            return elem;
+        }
+    }
+    return NULL;
+}
+
+static int do_htree_elem_get_sampling(htree_meta *htree, htree_node *node,
+                                      uint32_t remain, const uint32_t count,
+                                      htree_elem_item **elem_array)
+{
+    int hidx;
+    int fcnt = 0; /* found count */
+
+    for (hidx = 0; hidx < HTREE_HASHTAB_SIZE; hidx++) {
+        if (node->hcnt[hidx] == -1) {
+            htree_node *child_node = (htree_node *)node->htab[hidx];
+            fcnt += do_htree_elem_get_sampling(htree, child_node, remain,
+                                               count - fcnt, &elem_array[fcnt]);
+            remain -= child_node->tot_elem_cnt;
+        } else if (node->hcnt[hidx] > 0) {
+            htree_elem_item *elem = node->htab[hidx];
+            while (elem != NULL) {
+                if ((rand() % remain) < (count - fcnt)) {
+                    elem->refcount++;
+                    elem_array[fcnt] = elem;
+                    fcnt++;
+                    if (fcnt >= count) break;
+                }
+                remain -= 1;
+                elem = elem->next;
+            }
+        }
+        if (fcnt >= count) break;
+    }
+    return fcnt;
+}
+
+static uint32_t do_htree_elem_get_rand(htree_meta *htree, const uint32_t ccnt, const uint32_t count,
+                                       const bool delete, htree_elem_item **elem_array,
+                                       size_t *space_decreased)
+{
+    assert(elem_array != NULL);
+    uint32_t fcnt = 0;
+
+    if (delete) { /* Deleting partial elements */
+        while (fcnt < count) {
+            int rand_offset = (rand() % ccnt);
+            htree_elem_item *found = do_htree_elem_get_by_offset(htree, htree->root,
+                                                                 rand_offset, delete, space_decreased);
+            assert(found != NULL);
+            elem_array[fcnt++] = found;
+        }
+    } else if (count <= ccnt / 10) { /* Use hash table */
+        hash_table offset_ht;
+        if (!hash_init(&offset_ht, count))
+            return 0;
+        while (fcnt < count) {
+            int rand_offset = (rand() % ccnt);
+            if (hash_insert(&offset_ht, rand_offset)) {
+                htree_elem_item *found = do_htree_elem_get_by_offset(htree, htree->root,
+                                                                   rand_offset, false, NULL);
+                assert(found != NULL);
+                elem_array[fcnt++] = found;
+            }
+        }
+        hash_free(&offset_ht);
+    } else { /* Use sampling */
+        fcnt = do_htree_elem_get_sampling(htree, htree->root, ccnt, count,
+                                          elem_array);
+        for (int i = fcnt - 1; i > 0; i--) {
+            int rand_idx = rand() % (i + 1);
+            if (rand_idx != i) {
+                htree_elem_item *temp = elem_array[i];
+                elem_array[i] = elem_array[rand_idx];
+                elem_array[rand_idx] = temp;
+            }
+        }
+    }
+    return fcnt;
 }
 
 /*
@@ -221,4 +557,64 @@ htree_elem_item *htree_elem_replace(htree_elem_pos *pos, htree_elem_item *new_el
     assert(old_elem->linked == 0);
 
     return old_elem;
+}
+
+htree_elem_item *htree_elem_delete(htree_meta *htree, htree_node *node,
+                                   const int hval, const char *key, const int nkey,
+                                   size_t *space_decreased)
+{
+    htree_elem_item *deleted = do_htree_elem_delete(htree, node, hval, key, nkey, space_decreased);
+
+    if (deleted != NULL && htree->root->tot_elem_cnt == 0) {
+        do_htree_node_unlink(htree, NULL, 0);
+        *space_decreased += slabs_space_size(sizeof(htree_node));
+    }
+    return deleted;
+}
+
+uint32_t htree_elem_delete_bulk(htree_meta *htree, htree_node *node, const uint32_t count,
+                                htree_elem_item **deleted_head,
+                                size_t *space_decreased)
+{
+    int fcnt = do_htree_elem_delete_bulk(htree, node, count, deleted_head, space_decreased);
+
+    if (fcnt > 0 && htree->root->tot_elem_cnt == 0) {
+        do_htree_node_unlink(htree, NULL, 0);
+        *space_decreased += slabs_space_size(sizeof(htree_node));
+    }
+
+    return fcnt;
+}
+
+uint32_t htree_elem_get_bulk(htree_meta *htree, htree_node *node, const uint32_t count,
+                             const bool delete, htree_elem_item **elem_array,
+                             size_t *space_decreased)
+{
+    uint32_t fcnt = do_htree_elem_get_bulk(htree, node, count, delete, elem_array, space_decreased);
+
+    if (delete) {
+        if (fcnt > 0 && htree->root->tot_elem_cnt == 0) {
+            do_htree_node_unlink(htree, NULL, 0);
+            *space_decreased += slabs_space_size(sizeof(htree_node));
+        }
+    }
+
+    return fcnt;
+}
+
+uint32_t htree_elem_get_rand(htree_meta *htree, const uint32_t ccnt, const uint32_t count,
+                             const bool delete, htree_elem_item **elem_array,
+                             size_t *space_decreased)
+{
+    uint32_t fcnt = do_htree_elem_get_rand(htree, ccnt, count, delete, elem_array, space_decreased);
+
+
+    if (delete) {
+        if (fcnt > 0 && htree->root->tot_elem_cnt == 0) {
+            do_htree_node_unlink(htree, NULL, 0);
+            *space_decreased += slabs_space_size(sizeof(htree_node));
+        }
+    }
+
+    return fcnt;
 }

--- a/engines/default/hash_tree.c
+++ b/engines/default/hash_tree.c
@@ -17,3 +17,158 @@
  */
 #include "hash_tree.h"
 #include "default_engine.h"
+#include <assert.h>
+
+static htree_node *do_htree_node_alloc(uint8_t hash_depth)
+{
+    size_t ntotal = sizeof(htree_node);
+
+    htree_node *node = do_item_mem_alloc(ntotal, LRU_CLSID_FOR_SMALL);
+    if (node != NULL) {
+        node->slabs_clsid = slabs_clsid(ntotal);
+        assert(node->slabs_clsid > 0);
+
+        node->refcount    = 0;
+        node->hdepth      = hash_depth;
+        node->tot_elem_cnt = 0;
+        memset(node->hcnt, 0, HTREE_HASHTAB_SIZE*sizeof(uint16_t));
+        memset(node->htab, 0, HTREE_HASHTAB_SIZE*sizeof(void*));
+    }
+    return node;
+}
+
+static void do_htree_node_link(htree_meta *htree,
+                             htree_node *par_node, const int par_hidx,
+                             htree_node *node)
+{
+    if (par_node == NULL) {
+        htree->root = node;
+    } else {
+        htree_elem_item *elem;
+        while (par_node->htab[par_hidx] != NULL) {
+            elem = par_node->htab[par_hidx];
+            par_node->htab[par_hidx] = elem->next;
+
+            int hidx = HTREE_GET_HASHIDX(elem->hval, node->hdepth);
+            elem->next = node->htab[hidx];
+            node->htab[hidx] = elem;
+            node->hcnt[hidx] += 1;
+            node->tot_elem_cnt += 1;
+        }
+        assert(node->tot_elem_cnt == par_node->hcnt[par_hidx]);
+        par_node->htab[par_hidx] = node;
+        par_node->hcnt[par_hidx] = -1; /* child hash node */
+    }
+}
+
+static ENGINE_ERROR_CODE do_htree_elem_link(htree_meta *htree,
+                                            htree_node *node, int hidx,
+                                            htree_elem_item *elem, size_t *space_increased)
+{
+    if (node->hcnt[hidx] >= HTREE_MAX_HASHCHAIN_SIZE) {
+        htree_node *n_node = do_htree_node_alloc(node->hdepth+1);
+        if (n_node == NULL) {
+            return ENGINE_ENOMEM;
+        }
+        do_htree_node_link(htree, node, hidx, n_node);
+        *space_increased += slabs_space_size(sizeof(htree_node));
+
+        node = n_node;
+        hidx = HTREE_GET_HASHIDX(elem->hval, node->hdepth);
+    }
+
+    elem->linked++;
+    elem->next = node->htab[hidx];
+    node->htab[hidx] = elem;
+    node->hcnt[hidx] += 1;
+    node->tot_elem_cnt += 1;
+
+    htree_node *par_node = htree->root;
+    while (par_node != node) {
+        par_node->tot_elem_cnt += 1;
+        int par_hidx = HTREE_GET_HASHIDX(elem->hval, par_node->hdepth);
+        assert(par_node->hcnt[par_hidx] == -1);
+        par_node = par_node->htab[par_hidx];
+    }
+    return ENGINE_SUCCESS;
+}
+
+/*
+ * Hash tree Interface Functions
+ */
+void htree_init(htree_meta *htree, htree_ops *ops)
+{
+    htree->root = NULL;
+    htree->ops  = ops;
+}
+
+htree_elem_item *htree_elem_find(htree_meta *htree,
+                                 const int hval,
+                                 const void *key, uint16_t nkey,
+                                 htree_elem_pos *pos)
+{
+    if (htree->root == NULL) {
+        return NULL;
+    }
+
+    htree_node *node = htree->root;
+    int hidx;
+
+    while (node != NULL) {
+        hidx = HTREE_GET_HASHIDX(hval, node->hdepth);
+        if (node->hcnt[hidx] >= 0)
+            break;
+        node = node->htab[hidx];
+    }
+
+    htree_elem_item *prev = NULL;
+    htree_elem_item *elem;
+    for (elem = node->htab[hidx]; elem != NULL; elem = elem->next) {
+        uint16_t enkey;
+        const void *ekey = htree->ops->get_key(elem, &enkey);
+        if (htree_hash_eq(hval, key, nkey, elem->hval, ekey, enkey))
+            break;
+        prev = elem;
+    }
+
+    if (pos != NULL) {
+        pos->node = node;
+        pos->prev = prev;
+        pos->hidx = hidx;
+    }
+
+    return elem;
+}
+
+ENGINE_ERROR_CODE htree_elem_insert(htree_meta *htree, htree_elem_item *elem,
+                                    size_t *space_increased)
+{
+    htree_node *node;
+    int hidx;
+    /* create the root hash node if it does not exist */
+    if (htree->root == NULL) {
+        node = do_htree_node_alloc(0);
+        if (node == NULL) {
+            return ENGINE_ENOMEM;
+        }
+        do_htree_node_link(htree, NULL, 0, node);
+        *space_increased += slabs_space_size(sizeof(htree_node));
+
+        hidx = HTREE_GET_HASHIDX(elem->hval, 0);
+        return do_htree_elem_link(htree, node, hidx, elem, space_increased);
+    }
+
+    htree_elem_item *find;
+    htree_elem_pos pos;
+
+    uint16_t nkey;
+    const void *key = htree->ops->get_key(elem, &nkey);
+    find = htree_elem_find(htree, elem->hval, key, nkey, &pos);
+    if (find != NULL) {
+        return ENGINE_ELEM_EEXISTS;
+    }
+
+    node = pos.node;
+    hidx = pos.hidx;
+    return do_htree_elem_link(htree, node, hidx, elem, space_increased);
+}

--- a/engines/default/hash_tree.c
+++ b/engines/default/hash_tree.c
@@ -276,6 +276,50 @@ static uint32_t do_htree_elem_delete_bulk(htree_meta *htree, htree_node *node, c
     return fcnt;
 }
 
+static bool do_htree_elem_get(htree_meta *htree, htree_node *node,
+                              const int hval, const void *key, const uint16_t nkey,
+                              const bool delete, htree_elem_item **elem_array,
+                              size_t *space_decreased)
+{
+    assert(elem_array != NULL);
+    bool ret;
+    int hidx = HTREE_GET_HASHIDX(hval, node->hdepth);
+
+    if (node->hcnt[hidx] == -1) {
+        htree_node *child_node = node->htab[hidx];
+        ret = do_htree_elem_get(htree, child_node, hval, key, nkey, delete, elem_array, space_decreased);
+        if (ret && delete) {
+            if (child_node->tot_elem_cnt < (HTREE_MAX_HASHCHAIN_SIZE/2)) {
+                do_htree_node_unlink(htree, node, hidx);
+                *space_decreased += slabs_space_size(sizeof(htree_node));
+            }
+            node->tot_elem_cnt -= 1;
+        }
+    } else {
+        ret = false;
+        if (node->hcnt[hidx] > 0) {
+            htree_elem_item *prev = NULL;
+            htree_elem_item *elem = node->htab[hidx];
+            while (elem != NULL) {
+                uint16_t enkey;
+                const void *ekey = htree->ops->get_key(elem, &enkey);
+                if (htree_hash_eq(hval, key, nkey, elem->hval, ekey, enkey)) {
+                    elem->refcount++;
+                    elem_array[0] = elem;
+                    if (delete) {
+                        do_htree_elem_unlink(node, hidx, prev, elem);
+                    }
+                    ret = true;
+                    break;
+                }
+                prev = elem;
+                elem = elem->next;
+            }
+        }
+    }
+    return ret;
+}
+
 static uint32_t do_htree_elem_get_bulk(htree_meta *htree, htree_node *node, const uint32_t count,
                                        const bool delete, htree_elem_item **elem_array,
                                        size_t *space_decreased)
@@ -584,6 +628,23 @@ uint32_t htree_elem_delete_bulk(htree_meta *htree, htree_node *node, const uint3
     }
 
     return fcnt;
+}
+
+bool htree_elem_get(htree_meta *htree, htree_node *node,
+                    const int hval, const void *key, const uint16_t nkey,
+                    const bool delete, htree_elem_item **elem_array,
+                    size_t *space_decreased)
+{
+    bool ret = do_htree_elem_get(htree, node, hval, key, nkey, delete, elem_array, space_decreased);
+
+    if (delete) {
+        if (ret && htree->root->tot_elem_cnt == 0) {
+            do_htree_node_unlink(htree, NULL, 0);
+            *space_decreased += slabs_space_size(sizeof(htree_node));
+        }
+    }
+
+    return ret;
 }
 
 uint32_t htree_elem_get_bulk(htree_meta *htree, htree_node *node, const uint32_t count,

--- a/engines/default/hash_tree.c
+++ b/engines/default/hash_tree.c
@@ -1,0 +1,19 @@
+/*
+ * arcus-memcached - Arcus memory cache server
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2020 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "hash_tree.h"
+#include "default_engine.h"

--- a/engines/default/hash_tree.c
+++ b/engines/default/hash_tree.c
@@ -20,6 +20,18 @@
 #include <stdlib.h>
 #include <assert.h>
 
+#define HTREE_HASHIDX_MASK 0x0000000F
+#define HTREE_MAX_HASHCHAIN_SIZE 64
+
+#define HTREE_GET_HASHIDX(hval, hdepth) \
+        (((hval) & (HTREE_HASHIDX_MASK << ((hdepth)*4))) >> ((hdepth)*4))
+
+static inline int htree_hash_eq(const int h1, const void *k1, size_t nkey1,
+                                const int h2, const void *k2, size_t nkey2)
+{
+    return (h1 == h2 && nkey1 == nkey2 && memcmp(k1, k2, nkey1) == 0);
+}
+
 /*
  * Hash table management
  */

--- a/engines/default/hash_tree.c
+++ b/engines/default/hash_tree.c
@@ -172,3 +172,53 @@ ENGINE_ERROR_CODE htree_elem_insert(htree_meta *htree, htree_elem_item *elem,
     hidx = pos.hidx;
     return do_htree_elem_link(htree, node, hidx, elem, space_increased);
 }
+
+ENGINE_ERROR_CODE htree_elem_add(htree_meta *htree, htree_elem_item *elem,
+                                 htree_elem_pos *pos, size_t *space_increased)
+{
+    htree_node *node;
+    int hidx;
+
+    if (htree->root == NULL) {
+        node = do_htree_node_alloc(0);
+        if (node == NULL) {
+            return ENGINE_ENOMEM;
+        }
+        do_htree_node_link(htree, NULL, 0, node);
+        *space_increased += slabs_space_size(sizeof(htree_node));
+
+        hidx = HTREE_GET_HASHIDX(elem->hval, 0);
+        return do_htree_elem_link(htree, node, hidx, elem, space_increased);
+    }
+
+    node = pos->node;
+    hidx = pos->hidx;
+    return do_htree_elem_link(htree, node, hidx, elem, space_increased);
+}
+
+htree_elem_item *htree_elem_replace(htree_elem_pos *pos, htree_elem_item *new_elem)
+{
+    htree_elem_item *prev = pos->prev;
+    htree_elem_item *old_elem;
+    int hidx = pos->hidx;
+
+    if (prev != NULL) {
+        old_elem = prev->next;
+    } else {
+        old_elem = (htree_elem_item *)pos->node->htab[hidx];
+    }
+    assert(new_elem->hval == old_elem->hval);
+
+    new_elem->next = old_elem->next;
+    if (prev != NULL) {
+        prev->next = new_elem;
+    } else {
+        pos->node->htab[hidx] = new_elem;
+    }
+    new_elem->linked++;
+
+    old_elem->linked--;
+    assert(old_elem->linked == 0);
+
+    return old_elem;
+}

--- a/engines/default/hash_tree.h
+++ b/engines/default/hash_tree.h
@@ -25,17 +25,6 @@
 #include <memcached/engine.h>
 
 #define HTREE_HASHTAB_SIZE 16
-#define HTREE_HASHIDX_MASK 0x0000000F
-#define HTREE_MAX_HASHCHAIN_SIZE 64
-
-#define HTREE_GET_HASHIDX(hval, hdepth) \
-        (((hval) & (HTREE_HASHIDX_MASK << ((hdepth)*4))) >> ((hdepth)*4))
-
-static inline int htree_hash_eq(const int h1, const void *k1, size_t nkey1,
-                                const int h2, const void *k2, size_t nkey2)
-{
-    return (h1 == h2 && nkey1 == nkey2 && memcmp(k1, k2, nkey1) == 0);
-}
 
 extern int genhash_string_hash(const void* p, size_t nkey);
 

--- a/engines/default/hash_tree.h
+++ b/engines/default/hash_tree.h
@@ -1,0 +1,79 @@
+/*
+ * arcus-memcached - Arcus memory cache server
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2020 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef HASH_TREE_H
+#define HASH_TREE_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include <sys/types.h>
+#include <memcached/engine.h>
+
+#define HTREE_HASHTAB_SIZE 16
+#define HTREE_HASHIDX_MASK 0x0000000F
+#define HTREE_MAX_HASHCHAIN_SIZE 64
+
+#define HTREE_GET_HASHIDX(hval, hdepth) \
+        (((hval) & (HTREE_HASHIDX_MASK << ((hdepth)*4))) >> ((hdepth)*4))
+
+static inline int htree_hash_eq(const int h1, const void *k1, size_t nkey1,
+                                const int h2, const void *k2, size_t nkey2)
+{
+    return (h1 == h2 && nkey1 == nkey2 && memcmp(k1, k2, nkey1) == 0);
+}
+
+/* Layout contract for hash-tree elements.
+ * Any elem_item used with hash_tree functions must begin with these
+ * fields in this exact order. Fields beyond this point may differ. */
+typedef struct _htree_elem_item {
+    uint16_t refcount;
+    uint8_t  slabs_clsid;          /* which slab class we're in */
+    uint8_t  linked;               /* link count */
+    uint8_t  reserved[4];          /* available for use by the caller's own header fields */
+    struct _htree_elem_item *next; /* hash chain next */
+    uint32_t hval;                 /* hash value */
+} htree_elem_item;
+
+typedef struct _htree_node {
+    uint16_t refcount;
+    uint8_t  slabs_clsid;
+    uint8_t  hdepth;
+    uint32_t tot_elem_cnt;
+    int16_t  hcnt[HTREE_HASHTAB_SIZE];
+    void    *htab[HTREE_HASHTAB_SIZE];
+} htree_node;
+
+/* ops: collection-specific key extraction */
+typedef struct {
+    const void *(*get_key)(const htree_elem_item *elem, uint16_t *nkey);
+} htree_ops;
+
+typedef struct _htree_meta {
+    htree_node *root;
+    htree_ops  *ops;
+} htree_meta;
+
+/* Position context for hash-tree mutation operations (add, replace).
+ * Filled by htree_elem_find. */
+typedef struct {
+    htree_node      *node;
+    htree_elem_item *prev;
+    int              hidx;
+} htree_elem_pos;
+
+#endif

--- a/engines/default/hash_tree.h
+++ b/engines/default/hash_tree.h
@@ -101,6 +101,11 @@ uint32_t htree_elem_delete_bulk(htree_meta *htree, htree_node *node, const uint3
                                 htree_elem_item **deleted_head,
                                 size_t *space_decreased);
 
+bool htree_elem_get(htree_meta *htree, htree_node *node,
+                    const int hval, const void *key, const uint16_t nkey,
+                    const bool delete, htree_elem_item **elem_array,
+                    size_t *space_decreased);
+
 uint32_t htree_elem_get_bulk(htree_meta *htree, htree_node *node, const uint32_t count,
                              const bool delete, htree_elem_item **elem_array,
                              size_t *space_decreased);

--- a/engines/default/hash_tree.h
+++ b/engines/default/hash_tree.h
@@ -37,6 +37,8 @@ static inline int htree_hash_eq(const int h1, const void *k1, size_t nkey1,
     return (h1 == h2 && nkey1 == nkey2 && memcmp(k1, k2, nkey1) == 0);
 }
 
+extern int genhash_string_hash(const void* p, size_t nkey);
+
 /* Layout contract for hash-tree elements.
  * Any elem_item used with hash_tree functions must begin with these
  * fields in this exact order. Fields beyond this point may differ. */
@@ -75,5 +77,15 @@ typedef struct {
     htree_elem_item *prev;
     int              hidx;
 } htree_elem_pos;
+
+void htree_init(htree_meta *htree, htree_ops *ops);
+
+htree_elem_item *htree_elem_find(htree_meta *htree,
+                                 const int hval,
+                                 const void *key, uint16_t nkey,
+                                 htree_elem_pos *pos);
+
+ENGINE_ERROR_CODE htree_elem_insert(htree_meta *htree, htree_elem_item *elem,
+                                    size_t *space_increased);
 
 #endif

--- a/engines/default/hash_tree.h
+++ b/engines/default/hash_tree.h
@@ -88,4 +88,9 @@ htree_elem_item *htree_elem_find(htree_meta *htree,
 ENGINE_ERROR_CODE htree_elem_insert(htree_meta *htree, htree_elem_item *elem,
                                     size_t *space_increased);
 
+ENGINE_ERROR_CODE htree_elem_add(htree_meta *htree, htree_elem_item *elem,
+                                 htree_elem_pos *pos, size_t *space_increased);
+
+htree_elem_item *htree_elem_replace(htree_elem_pos *pos, htree_elem_item *new_elem);
+
 #endif

--- a/engines/default/hash_tree.h
+++ b/engines/default/hash_tree.h
@@ -93,4 +93,20 @@ ENGINE_ERROR_CODE htree_elem_add(htree_meta *htree, htree_elem_item *elem,
 
 htree_elem_item *htree_elem_replace(htree_elem_pos *pos, htree_elem_item *new_elem);
 
+htree_elem_item *htree_elem_delete(htree_meta *htree, htree_node *node,
+                                   const int hval, const char *key, const int nkey,
+                                   size_t *space_decreased);
+
+uint32_t htree_elem_delete_bulk(htree_meta *htree, htree_node *node, const uint32_t count,
+                                htree_elem_item **deleted_head,
+                                size_t *space_decreased);
+
+uint32_t htree_elem_get_bulk(htree_meta *htree, htree_node *node, const uint32_t count,
+                             const bool delete, htree_elem_item **elem_array,
+                             size_t *space_decreased);
+
+uint32_t htree_elem_get_rand(htree_meta *htree, const uint32_t ccnt, const uint32_t count,
+                             const bool delete, htree_elem_item **elem_array,
+                             size_t *space_decreased);
+
 #endif

--- a/engines/default/item_base.h
+++ b/engines/default/item_base.h
@@ -21,6 +21,7 @@
 #include <memcached/engine.h>
 #include <memcached/util.h>
 #include <memcached/visibility.h>
+#include "hash_tree.h"
 
 /* max collection size */
 #define MINIMUM_MAX_COLL_SIZE  10000
@@ -220,20 +221,6 @@ typedef struct _list_meta_info {
     list_elem_item *tail;
 } list_meta_info;
 
-/* set meta info */
-#define SET_HASHTAB_SIZE 16
-#define SET_HASHIDX_MASK 0x0000000F
-#define SET_MAX_HASHCHAIN_SIZE 64
-
-typedef struct _set_hash_node {
-    uint16_t refcount;
-    uint8_t  slabs_clsid;         /* which slab class we're in */
-    uint8_t  hdepth;
-    uint32_t tot_elem_cnt;
-    int16_t  hcnt[SET_HASHTAB_SIZE];
-    void    *htab[SET_HASHTAB_SIZE];
-} set_hash_node;
-
 typedef struct _set_meta_info {
     int32_t  mcnt;      /* maximum count */
     int32_t  ccnt;      /* current count */
@@ -241,7 +228,7 @@ typedef struct _set_meta_info {
     uint8_t  mflags;    /* sticky, readable flags */
     uint16_t itdist;    /* distance from hash item (unit: sizeof(size_t)) */
     uint32_t stotal;    /* total space */
-    set_hash_node *root;
+    htree_meta htree;
 } set_meta_info;
 
 /* map meta info */

--- a/engines/default/item_base.h
+++ b/engines/default/item_base.h
@@ -231,20 +231,6 @@ typedef struct _set_meta_info {
     htree_meta htree;
 } set_meta_info;
 
-/* map meta info */
-#define MAP_HASHTAB_SIZE 16
-#define MAP_HASHIDX_MASK 0x0000000F
-#define MAP_MAX_HASHCHAIN_SIZE 64
-
-typedef struct _map_hash_node {
-    uint16_t refcount;
-    uint8_t  slabs_clsid;         /* which slab class we're in */
-    uint8_t  hdepth;
-    uint32_t tot_elem_cnt;
-    int16_t  hcnt[MAP_HASHTAB_SIZE];
-    void    *htab[MAP_HASHTAB_SIZE];
-} map_hash_node;
-
 typedef struct _map_meta_info {
     int32_t  mcnt;      /* maximum count */
     int32_t  ccnt;      /* current count */
@@ -252,7 +238,7 @@ typedef struct _map_meta_info {
     uint8_t  mflags;    /* sticky, readable flags */
     uint16_t itdist;    /* distance from hash item (unit: sizeof(size_t)) */
     uint32_t stotal;    /* total space */
-    map_hash_node *root;
+    htree_meta htree;
 } map_meta_info;
 
 /* btree meta info */


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/844#issuecomment-4278095307

### ⌨️ What I did
set, map 컬렉션에 중복으로 존재하던 hash tree 구현을 hash_tree.c/h로 추출하였습니다.

- `set_hash_node`, `map_hash_node` 및 관련 상수를 제거하고 `htree_node`, `htree_meta`로 통일하였습니다.
- `set_meta_info`, `map_meta_info`의 `root` 필드를 `htree_meta htree`로 교체하였습니다.
- `htree_ops`의 `get_key` 콜백으로 컬렉션별 키 추출 로직을 분리하였습니다. (기존 `elem->value/nbytes`, `elem->data/nfield` 직접 접근 → `htree_ops.get_key` 콜백으로 추출. set은 `set_get_key`, map은 `map_get_key`를 등록)

- hash tree의 공개 API를 `hash_tree.h`에 정의하였습니다.

| 함수 | 설명 |
|------|------|
| `htree_init` | htree 초기화 (root=NULL, ops 설정) |
| `htree_elem_find` | key 기반 탐색, 삽입/교체 위치(`htree_elem_pos`) 반환 |
| `htree_elem_insert` | 중복 검사 포함 삽입 |
| `htree_elem_add` | 이미 찾은 위치에 삽입 |
| `htree_elem_replace` | 위치 기반 교체 |
| `htree_elem_delete` | 단건 삭제, deleted elem 반환하여 caller가 후처리 |
| `htree_elem_delete_bulk` | 다건 삭제, `deleted_head`로 chain 반환하여 caller가 후처리 |
| `htree_elem_get` | refcount++ 포함 단건 조회, `delete=true`면 delete도 수행. elem_array 인자에 반환 |
| `htree_elem_get_bulk` | 전체 또는 count개 조회. elem_array 인자에 반환 |
| `htree_elem_get_rand` | 랜덤 샘플링 조회 |