### PR TITLE
FIX: Revert cookie parameter to item_store

### DIFF
--- a/engines/default/default_engine.c
+++ b/engines/default/default_engine.c
@@ -415,7 +415,7 @@ default_store(ENGINE_HANDLE* handle, const void *cookie,
     VBUCKET_GUARD(engine, vbucket);
 
     ACTION_BEFORE_WRITE(cookie, item_get_key(it), it->nkey);
-    ret = item_store(it, cas, operation);
+    ret = item_store(it, cas, operation, cookie);
     ACTION_AFTER_WRITE(cookie, engine, ret);
     return ret;
 }

--- a/engines/default/items.c
+++ b/engines/default/items.c
@@ -317,7 +317,8 @@ void item_release(hash_item *item)
  * Stores an item in the cache (high level, obeys set/add/replace semantics)
  */
 ENGINE_ERROR_CODE item_store(hash_item *item, uint64_t *cas,
-                             ENGINE_STORE_OPERATION operation)
+                             ENGINE_STORE_OPERATION operation,
+                             const void *cookie)
 {
     ENGINE_ERROR_CODE ret;
     PERSISTENCE_ACTION_BEGIN(cookie, UPD_STORE);

--- a/engines/default/items.h
+++ b/engines/default/items.h
@@ -119,7 +119,8 @@ void item_release(hash_item *it);
  *       there so that we can get it from the item instead?
  */
 ENGINE_ERROR_CODE item_store(hash_item *item,
-                             uint64_t *cas, ENGINE_STORE_OPERATION operation);
+                             uint64_t *cas, ENGINE_STORE_OPERATION operation,
+                             const void *cookie);
 
 ENGINE_ERROR_CODE item_arithmetic(const void *key, const uint32_t nkey,
                                   const bool increment,


### PR DESCRIPTION
### 🔗 Related Issue

- #979

> 현재 item 생성 시 cookie를 사용하는 경우는 persistence sync 시 client에게 로깅 완료 알림을 보내기 위한 용도입니다.
가장 상위 API인 map_elem_insert 등에서 cookie를 받아 PERSISTENCE_ACTION_BEGIN에 전달하는 구조인데,
이번 PR에서 제거한 cookie는 그 하위의 do_map_item_alloc, do_map_node_alloc 등 내부 alloc 함수에서
불필요하게 전달되던 것이므로 CE, EE 모두 영향이 없습니다.

```
In file included from engines/default/item_clog.h:23,
                 from engines/default/items.c:35:
engines/default/items.c: In function 'item_store':
engines/default/items.c:323:30: error: 'cookie' undeclared (first use in this function)
  323 |     PERSISTENCE_ACTION_BEGIN(cookie, UPD_STORE);
      |                              ^~~~~~
engines/default/cmdlogmgr.h:33:38: note: in definition of macro 'PERSISTENCE_ACTION_BEGIN'
   33 |             if (cmdlog_waiter_begin((c),(u)) == NULL) \
      |                                      ^
engines/default/items.c:323:30: note: each undeclared identifier is reported only once for each function it appears in
  323 |     PERSISTENCE_ACTION_BEGIN(cookie, UPD_STORE);
      |                              ^~~~~~
engines/default/cmdlogmgr.h:33:38: note: in definition of macro 'PERSISTENCE_ACTION_BEGIN'
   33 |             if (cmdlog_waiter_begin((c),(u)) == NULL) \
      | 
```

### ⌨️ What I did

- `item_store()`는 `PERSISTENCE_ACTION_BEGIN` 호출하는 상위 API이므로, cookie 인자 유지합니다.
- @zhy2on persistence 관련 구현 변경할 때는 configure 수행 시 `--enable-persistnece` 옵션 주어 빌드해야 합니다.