### PR TITLE
INTERNAL: Add traverse_init/traverse_next interface for collection traversal

### DIFF
--- a/engines/default/coll_btree.c
+++ b/engines/default/coll_btree.c
@@ -4589,6 +4589,34 @@ ENGINE_ERROR_CODE btree_apply_elem_delete_logical(void *engine, hash_item *it,
     return ret;
 }
 
+void btree_traverse_init(coll_meta_info *info, void *posi)
+{
+    btree_elem_posi *bp = (btree_elem_posi *)posi;
+    btree_indx_node *node = ((btree_meta_info *)info)->root;
+    if (node == NULL || node->used_count == 0) {
+        bp->node = NULL;
+        return;
+    }
+    bp->node = do_btree_get_first_leaf(node, NULL);
+    bp->indx = 0;
+}
+
+uint32_t btree_traverse_next(void *posi, void **elem_array, uint32_t count)
+{
+    btree_elem_posi *bp = (btree_elem_posi *)posi;
+    uint32_t fcnt = 0;
+    while (fcnt < count && bp->node != NULL) {
+        btree_elem_item *elem = BTREE_GET_ELEM_ITEM(bp->node, bp->indx);
+        elem->refcount++;
+        elem_array[fcnt++] = elem;
+        if (++bp->indx >= bp->node->used_count) {
+            bp->node = bp->node->next;
+            bp->indx = 0;
+        }
+    }
+    return fcnt;
+}
+
 /*
  * External Functions
  */

--- a/engines/default/coll_btree.h
+++ b/engines/default/coll_btree.h
@@ -123,6 +123,9 @@ ENGINE_ERROR_CODE btree_apply_elem_delete_logical(void *engine, hash_item *it,
                                                   const uint32_t offset, const uint32_t count,
                                                   const bool drop_if_empty);
 
+void btree_traverse_init(coll_meta_info *info, void *posi);
+uint32_t btree_traverse_next(void *posi, void **elem_array, uint32_t count);
+
 ENGINE_ERROR_CODE item_btree_coll_init(void *engine_ptr);
 void item_btree_coll_final(void *engine_ptr);
 

--- a/engines/default/coll_list.c
+++ b/engines/default/coll_list.c
@@ -52,6 +52,10 @@ static inline void UNLOCK_CACHE(void)
 /*
  * LIST collection management
  */
+typedef struct {
+    list_elem_item *curr;
+} list_elem_posi;
+
 static inline uint32_t do_list_elem_ntotal(list_elem_item *elem)
 {
     return sizeof(list_elem_item) + elem->nbytes;
@@ -808,6 +812,24 @@ ENGINE_ERROR_CODE list_apply_elem_delete(void *engine, hash_item *it,
     UNLOCK_CACHE();
 
     return ret;
+}
+
+void list_traverse_init(coll_meta_info *info, void *posi)
+{
+    list_elem_posi *lp = (list_elem_posi *)posi;
+    lp->curr = ((list_meta_info *)info)->head;
+}
+
+uint32_t list_traverse_next(void *posi, void **elem_array, uint32_t count)
+{
+    list_elem_posi *lp = (list_elem_posi *)posi;
+    uint32_t fcnt = 0;
+    while (fcnt < count && lp->curr != NULL) {
+        lp->curr->refcount++;
+        elem_array[fcnt++] = lp->curr;
+        lp->curr = lp->curr->next;
+    }
+    return fcnt;
 }
 
 /*

--- a/engines/default/coll_list.h
+++ b/engines/default/coll_list.h
@@ -69,6 +69,9 @@ ENGINE_ERROR_CODE list_apply_elem_delete(void *engine, hash_item *it,
                                          const int nelems, const int index,
                                          const int count, const bool drop_if_empty);
 
+void list_traverse_init(coll_meta_info *info, void *posi);
+uint32_t list_traverse_next(void *posi, void **elem_array, uint32_t count);
+
 ENGINE_ERROR_CODE item_list_coll_init(void *engine_ptr);
 void item_list_coll_final(void *engine_ptr);
 

--- a/engines/default/coll_map.c
+++ b/engines/default/coll_map.c
@@ -55,6 +55,19 @@ static inline void UNLOCK_CACHE(void)
 /*
  * MAP collection manangement
  */
+#define MAP_MAX_DEPTH 8  /* 32-bit hash, 4bits per level */
+
+typedef struct {
+    map_hash_node *node;
+    int            hidx;
+} map_path_entry;
+
+typedef struct {
+    map_elem_item *curr;
+    map_path_entry path[MAP_MAX_DEPTH];
+    int            depth;
+} map_elem_posi;
+
 /* map element previous info internally used */
 typedef struct _map_prev_info {
     map_hash_node *node;
@@ -781,6 +794,30 @@ static ENGINE_ERROR_CODE do_map_elem_insert(hash_item *it, map_elem_item *elem,
     return ENGINE_SUCCESS;
 }
 
+static void do_map_traverse_advance(map_elem_posi *posi)
+{
+    while (posi->depth >= 0) {
+        map_hash_node *node = posi->path[posi->depth].node;
+        int hidx;
+
+        for (hidx = posi->path[posi->depth].hidx; hidx < MAP_HASHTAB_SIZE; hidx++) {
+            if (node->hcnt[hidx] == -1) {
+                posi->path[posi->depth].hidx = hidx + 1;
+                posi->depth++;
+                posi->path[posi->depth].node = (map_hash_node *)node->htab[hidx];
+                posi->path[posi->depth].hidx = 0;
+                break;
+            } else if (node->hcnt[hidx] > 0) {
+                posi->path[posi->depth].hidx = hidx + 1;
+                posi->curr = (map_elem_item *)node->htab[hidx];
+                return;
+            }
+        }
+        if (hidx >= MAP_HASHTAB_SIZE) posi->depth--;
+    }
+    posi->curr = NULL;
+}
+
 /*
  * MAP Interface Functions
  */
@@ -1232,6 +1269,34 @@ ENGINE_ERROR_CODE map_apply_elem_delete(void *engine, hash_item *it,
     UNLOCK_CACHE();
 
     return ret;
+}
+
+void map_traverse_init(coll_meta_info *info, void *posi)
+{
+    map_elem_posi *mp = (map_elem_posi *)posi;
+    if (((map_meta_info *)info)->root == NULL) {
+        mp->curr = NULL;
+        return;
+    }
+    mp->path[0].node = ((map_meta_info *)info)->root;
+    mp->path[0].hidx = 0;
+    mp->depth = 0;
+    do_map_traverse_advance(mp);
+}
+
+uint32_t map_traverse_next(void *posi, void **elem_array, uint32_t count)
+{
+    map_elem_posi *mp = (map_elem_posi *)posi;
+    uint32_t fcnt = 0;
+    while (fcnt < count && mp->curr != NULL) {
+        mp->curr->refcount++;
+        elem_array[fcnt++] = mp->curr;
+        if (mp->curr->next != NULL)
+            mp->curr = mp->curr->next;
+        else
+            do_map_traverse_advance(mp);
+    }
+    return fcnt;
 }
 
 /*

--- a/engines/default/coll_map.h
+++ b/engines/default/coll_map.h
@@ -73,6 +73,9 @@ ENGINE_ERROR_CODE map_apply_elem_delete(void *engine, hash_item *it,
                                         const char *field, const uint32_t nfield,
                                         const bool drop_if_empty);
 
+void map_traverse_init(coll_meta_info *info, void *posi);
+uint32_t map_traverse_next(void *posi, void **elem_array, uint32_t count);
+
 ENGINE_ERROR_CODE item_map_coll_init(void *engine_ptr);
 void item_map_coll_final(void *engine_ptr);
 

--- a/engines/default/coll_set.c
+++ b/engines/default/coll_set.c
@@ -101,6 +101,19 @@ static bool hash_insert(hash_table *ht, int key)
 /*
  * SET collection manangement
  */
+#define SET_MAX_DEPTH 8  /* 32-bit hash, 4bits per level */
+
+typedef struct {
+    set_hash_node *node;
+    int            hidx;
+} set_path_entry;
+
+typedef struct {
+    set_elem_item *curr;
+    set_path_entry path[SET_MAX_DEPTH];
+    int            depth;
+} set_elem_posi;
+
 typedef struct _set_prev_info {
     set_hash_node *node;
     set_elem_item *prev;
@@ -754,6 +767,30 @@ static ENGINE_ERROR_CODE do_set_elem_insert(hash_item *it, set_elem_item *elem)
     return ENGINE_SUCCESS;
 }
 
+static void do_set_traverse_advance(set_elem_posi *posi)
+{
+    while (posi->depth >= 0) {
+        set_hash_node *node = posi->path[posi->depth].node;
+        int hidx;
+
+        for (hidx = posi->path[posi->depth].hidx; hidx < SET_HASHTAB_SIZE; hidx++) {
+            if (node->hcnt[hidx] == -1) {
+                posi->path[posi->depth].hidx = hidx + 1;
+                posi->depth++;
+                posi->path[posi->depth].node = (set_hash_node *)node->htab[hidx];
+                posi->path[posi->depth].hidx = 0;
+                break;
+            } else if (node->hcnt[hidx] > 0) {
+                posi->path[posi->depth].hidx = hidx + 1;
+                posi->curr = (set_elem_item *)node->htab[hidx];
+                return;
+            }
+        }
+        if (hidx >= SET_HASHTAB_SIZE) posi->depth--;
+    }
+    posi->curr = NULL;
+}
+
 /*
  * SET Interface Functions
  */
@@ -1193,6 +1230,34 @@ ENGINE_ERROR_CODE set_apply_elem_delete(void *engine, hash_item *it,
     UNLOCK_CACHE();
 
     return ret;
+}
+
+void set_traverse_init(coll_meta_info *info, void *posi)
+{
+    set_elem_posi *sp = (set_elem_posi *)posi;
+    if (((set_meta_info *)info)->root == NULL) {
+        sp->curr = NULL;
+        return;
+    }
+    sp->path[0].node = ((set_meta_info *)info)->root;
+    sp->path[0].hidx = 0;
+    sp->depth = 0;
+    do_set_traverse_advance(sp);
+}
+
+uint32_t set_traverse_next(void *posi, void **elem_array, uint32_t count)
+{
+    set_elem_posi *sp = (set_elem_posi *)posi;
+    uint32_t fcnt = 0;
+    while (fcnt < count && sp->curr != NULL) {
+        sp->curr->refcount++;
+        elem_array[fcnt++] = sp->curr;
+        if (sp->curr->next != NULL)
+            sp->curr = sp->curr->next;
+        else
+            do_set_traverse_advance(sp);
+    }
+    return fcnt;
 }
 
 /*

--- a/engines/default/coll_set.h
+++ b/engines/default/coll_set.h
@@ -71,6 +71,9 @@ ENGINE_ERROR_CODE set_apply_elem_delete(void *engine, hash_item *it,
                                         const char *value, const uint32_t nbytes,
                                         const bool drop_if_empty);
 
+void set_traverse_init(coll_meta_info *info, void *posi);
+uint32_t set_traverse_next(void *posi, void **elem_array, uint32_t count);
+
 ENGINE_ERROR_CODE item_set_coll_init(void *engine_ptr);
 void item_set_coll_final(void *engine_ptr);
 


### PR DESCRIPTION
### 🔗 Related Issue

- jam2in/arcus-memcached-EE#1136

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 컬렉션(list, set, map, btree)에 순차 순회 인터페이스를 추가했습니다.
- position 구조체를 `**_elem_posi` 네이밍으로 통일했습니다.
- `traverse_init`: 순회 시작 위치(position)를 첫 번째 요소로 초기화합니다.
- `traverse_next`: 현재 position에서 N개의 요소를 `elem_array`에 담고 position을 전진시킵니다.
- `do_{map/set}_traverse_advance`: set/map은 htree 구조상 elem chain 내에서는 curr->next로 이동하지만, chain이 끝나면 node 간 이동을 위해 path를 이용한 DFS 탐색이 필요합니다.
  do_set_traverse_advance / do_map_traverse_advance가 이를 담당합니다.
  path[depth]는 각 depth에서 다음에 재개할 slot(북마크)을 기록하고, DFS로 다음 elem chain head를 찾아 curr에 설정합니다.
  list / btree는 leaf가 연결 리스트로 연결되어 있어 해당 함수가 불필요합니다.