### PR TITLE
INTERNAL: Extract hash tree module from set/map collection

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -171,6 +171,8 @@ default_engine_la_SOURCES= \
                     engines/default/item_clog.h \
                     engines/default/item_base.c \
                     engines/default/item_base.h \
+                    engines/default/hash_tree.c \
+                    engines/default/hash_tree.h \
                     engines/default/coll_list.c \
                     engines/default/coll_list.h \
                     engines/default/coll_set.c \

--- a/engines/default/coll_map.c
+++ b/engines/default/coll_map.c
@@ -38,9 +38,6 @@ static struct default_engine *engine=NULL;
 static struct engine_config  *config=NULL; // engine config
 static EXTENSION_LOGGER_DESCRIPTOR *logger;
 
-/* used by set and map collection */
-extern int genhash_string_hash(const void* p, size_t nkey);
-
 /* Cache Lock */
 static inline void LOCK_CACHE(void)
 {
@@ -55,34 +52,14 @@ static inline void UNLOCK_CACHE(void)
 /*
  * MAP collection manangement
  */
-#define MAP_MAX_DEPTH 8  /* 32-bit hash, 4bits per level */
-
-typedef struct {
-    map_hash_node *node;
-    int            hidx;
-} map_path_entry;
-
-typedef struct {
-    map_elem_item *curr;
-    map_path_entry path[MAP_MAX_DEPTH];
-    int            depth;
-} map_elem_posi;
-
-/* map element previous info internally used */
-typedef struct _map_prev_info {
-    map_hash_node *node;
-    map_elem_item *prev;
-    uint16_t       hidx;
-} map_prev_info;
-
-#define MAP_GET_HASHIDX(hval, hdepth) \
-        (((hval) & (MAP_HASHIDX_MASK << ((hdepth)*4))) >> ((hdepth)*4))
-
-static inline int map_hash_eq(const int h1, const void *v1, size_t vlen1,
-                              const int h2, const void *v2, size_t vlen2)
+static const void *map_get_key(const htree_elem_item *elem, uint16_t *nkey)
 {
-    return (h1 == h2 && vlen1 == vlen2 && memcmp(v1, v2, vlen1) == 0);
+    map_elem_item *e = (map_elem_item *)elem;
+    *nkey = e->nfield;
+    return e->data;
 }
+
+static htree_ops map_htree_ops = { map_get_key };
 
 static inline uint32_t do_map_elem_ntotal(map_elem_item *elem)
 {
@@ -147,33 +124,10 @@ static hash_item *do_map_item_alloc(const void *key, const uint32_t nkey,
         if (attrp->readable == 1)              info->mflags |= COLL_META_FLAG_READABLE;
         info->itdist  = (uint16_t)((size_t*)info-(size_t*)it);
         info->stotal  = 0;
-        info->root    = NULL;
+        htree_init(&info->htree, &map_htree_ops);
         assert((hash_item*)COLL_GET_HASH_ITEM(info) == it);
     }
     return it;
-}
-
-static map_hash_node *do_map_node_alloc(uint8_t hash_depth)
-{
-    size_t ntotal = sizeof(map_hash_node);
-
-    map_hash_node *node = do_item_mem_alloc(ntotal, LRU_CLSID_FOR_SMALL);
-    if (node != NULL) {
-        node->slabs_clsid = slabs_clsid(ntotal);
-        assert(node->slabs_clsid > 0);
-
-        node->refcount    = 0;
-        node->hdepth      = hash_depth;
-        node->tot_elem_cnt = 0;
-        memset(node->hcnt, 0, MAP_HASHTAB_SIZE*sizeof(uint16_t));
-        memset(node->htab, 0, MAP_HASHTAB_SIZE*sizeof(void*));
-    }
-    return node;
-}
-
-static void do_map_node_free(map_hash_node *node)
-{
-    do_item_mem_free(node, sizeof(map_hash_node));
 }
 
 static map_elem_item *do_map_elem_alloc(const int nfield,
@@ -212,203 +166,6 @@ static void do_map_elem_release(map_elem_item *elem)
     }
 }
 
-static void do_map_node_link(map_meta_info *info,
-                             map_hash_node *par_node, const int par_hidx,
-                             map_hash_node *node)
-{
-    if (par_node == NULL) {
-        info->root = node;
-    } else {
-        map_elem_item *elem;
-        while (par_node->htab[par_hidx] != NULL) {
-            elem = par_node->htab[par_hidx];
-            par_node->htab[par_hidx] = elem->next;
-
-            int hidx = MAP_GET_HASHIDX(elem->hval, node->hdepth);
-            elem->next = node->htab[hidx];
-            node->htab[hidx] = elem;
-            node->hcnt[hidx] += 1;
-            node->tot_elem_cnt += 1;
-        }
-        assert(node->tot_elem_cnt == par_node->hcnt[par_hidx]);
-        par_node->htab[par_hidx] = node;
-        par_node->hcnt[par_hidx] = -1; /* child hash node */
-    }
-}
-
-static void do_map_node_unlink(map_meta_info *info,
-                               map_hash_node *par_node, const int par_hidx)
-{
-    map_hash_node *node;
-
-    if (par_node == NULL) {
-        node = info->root;
-        info->root = NULL;
-        assert(node->tot_elem_cnt == 0);
-    } else {
-        assert(par_node->hcnt[par_hidx] == -1); /* child hash node */
-        map_elem_item *head = NULL;
-        map_elem_item *elem;
-        int hidx, fcnt = 0;
-
-        node = (map_hash_node *)par_node->htab[par_hidx];
-        assert(node->tot_elem_cnt < (MAP_MAX_HASHCHAIN_SIZE/2));
-
-        for (hidx = 0; hidx < MAP_HASHTAB_SIZE; hidx++) {
-            assert(node->hcnt[hidx] >= 0);
-            if (node->hcnt[hidx] > 0) {
-                fcnt += node->hcnt[hidx];
-                while (node->htab[hidx] != NULL) {
-                    elem = node->htab[hidx];
-                    node->htab[hidx] = elem->next;
-                    node->hcnt[hidx] -= 1;
-
-                    elem->next = head;
-                    head = elem;
-                }
-                assert(node->hcnt[hidx] == 0);
-            }
-        }
-        assert(fcnt == node->tot_elem_cnt);
-        node->tot_elem_cnt = 0;
-
-        par_node->htab[par_hidx] = head;
-        par_node->hcnt[par_hidx] = fcnt;
-    }
-
-    /* free the node */
-    do_map_node_free(node);
-}
-
-static map_elem_item *do_map_elem_find(map_meta_info *info,
-                                       const int hval,
-                                       const void *key, uint16_t nkey,
-                                       map_prev_info *pinfo)
-{
-    if (info->root == NULL) {
-        return NULL;
-    }
-
-    map_hash_node *node = info->root;
-    int hidx;
-
-    while (node != NULL) {
-        hidx = MAP_GET_HASHIDX(hval, node->hdepth);
-        if (node->hcnt[hidx] >= 0) /* map element hash chain */
-            break;
-        node = node->htab[hidx];
-    }
-
-    map_elem_item *prev = NULL;
-    map_elem_item *elem;
-    for (elem = node->htab[hidx]; elem != NULL; elem = elem->next) {
-        if (map_hash_eq(hval, key, nkey, elem->hval, elem->data, elem->nfield)) {
-            break;
-        }
-        prev = elem;
-    }
-
-    if (pinfo != NULL) {
-        pinfo->node = node;
-        pinfo->prev = prev;
-        pinfo->hidx = hidx;
-    }
-    return elem;
-}
-
-static map_elem_item *do_htree_elem_replace(map_meta_info *info,
-                                            map_prev_info *pinfo, map_elem_item *new_elem)
-{
-    map_elem_item *prev = pinfo->prev;
-    map_elem_item *old_elem;
-
-    if (prev != NULL) {
-        old_elem = prev->next;
-    } else {
-        old_elem = (map_elem_item *)pinfo->node->htab[pinfo->hidx];
-    }
-    assert(new_elem->hval == old_elem->hval);
-
-    new_elem->next = old_elem->next;
-    if (prev != NULL) {
-        prev->next = new_elem;
-    } else {
-        pinfo->node->htab[pinfo->hidx] = new_elem;
-    }
-    new_elem->linked++;
-
-    old_elem->linked--;
-    assert(old_elem->linked == 0);
-
-    return old_elem;
-}
-
-static ENGINE_ERROR_CODE do_htree_elem_link(map_meta_info *info,
-                                            map_hash_node *node, int hidx,
-                                            map_elem_item *elem, size_t *space_increased)
-{
-    if (node->hcnt[hidx] >= MAP_MAX_HASHCHAIN_SIZE) {
-        map_hash_node *n_node = do_map_node_alloc(node->hdepth+1);
-        if (n_node == NULL) {
-            return ENGINE_ENOMEM;
-        }
-        do_map_node_link(info, node, hidx, n_node);
-        *space_increased += slabs_space_size(sizeof(map_hash_node));
-
-        node = n_node;
-        hidx = MAP_GET_HASHIDX(elem->hval, node->hdepth);
-    }
-
-    elem->linked++;
-    elem->next = node->htab[hidx];
-    node->htab[hidx] = elem;
-    node->hcnt[hidx] += 1;
-    node->tot_elem_cnt += 1;
-
-    map_hash_node *par_node = info->root;
-    while (par_node != node) {
-        par_node->tot_elem_cnt += 1;
-        int par_hidx = MAP_GET_HASHIDX(elem->hval, par_node->hdepth);
-        assert(par_node->hcnt[par_hidx] == -1);
-        par_node = par_node->htab[par_hidx];
-    }
-    return ENGINE_SUCCESS;
-}
-
-static ENGINE_ERROR_CODE do_htree_elem_add(map_meta_info *info, map_elem_item *elem,
-                                           map_prev_info *pinfo, size_t *space_increased)
-{
-    map_hash_node *node;
-    int hidx;
-
-    if (info->root == NULL) {
-        node = do_map_node_alloc(0);
-        if (node == NULL) {
-            return ENGINE_ENOMEM;
-        }
-        do_map_node_link(info, NULL, 0, node);
-        *space_increased += slabs_space_size(sizeof(map_hash_node));
-
-        hidx = MAP_GET_HASHIDX(elem->hval, 0);
-        return do_htree_elem_link(info, node, hidx, elem, space_increased);
-    }
-
-    node = pinfo->node;
-    hidx = pinfo->hidx;
-    return do_htree_elem_link(info, node, hidx, elem, space_increased);
-}
-
-static void do_map_elem_unlink(map_meta_info *info,
-                               map_hash_node *node, const int hidx,
-                               map_elem_item *prev, map_elem_item *elem)
-{
-    if (prev != NULL) prev->next = elem->next;
-    else              node->htab[hidx] = elem->next;
-    elem->linked--;
-    node->hcnt[hidx] -= 1;
-    node->tot_elem_cnt -= 1;
-}
-
 static void do_map_elem_delete_post(map_meta_info *info,
                                     map_elem_item *elem,
                                     enum elem_delete_cause cause)
@@ -425,186 +182,39 @@ static void do_map_elem_delete_post(map_meta_info *info,
     }
 }
 
-static bool do_map_elem_get_by_field(map_meta_info *info, map_hash_node *node, const int hval,
-                                     const field_t *field, const bool delete,
-                                     map_elem_item **elem_array, size_t *space_decreased)
-{
-    assert(elem_array != NULL);
-    bool ret;
-    int hidx = MAP_GET_HASHIDX(hval, node->hdepth);
-
-    if (node->hcnt[hidx] == -1) {
-        map_hash_node *child_node = node->htab[hidx];
-        ret = do_map_elem_get_by_field(info, child_node, hval, field, delete, elem_array, space_decreased);
-        if (ret && delete) {
-            if (child_node->tot_elem_cnt < (MAP_MAX_HASHCHAIN_SIZE/2)) {
-                do_map_node_unlink(info, node, hidx);
-                *space_decreased += slabs_space_size(sizeof(map_hash_node));
-            }
-            node->tot_elem_cnt -= 1;
-        }
-    } else {
-        ret = false;
-        if (node->hcnt[hidx] > 0) {
-            map_elem_item *prev = NULL;
-            map_elem_item *elem = node->htab[hidx];
-            while (elem != NULL) {
-                if (map_hash_eq(hval, field->value, field->length, elem->hval, elem->data, elem->nfield)) {
-                    elem->refcount++;
-                    elem_array[0] = elem;
-                    if (delete) {
-                        do_map_elem_unlink(info, node, hidx, prev, elem);
-                    }
-                    ret = true;
-                    break;
-                }
-                prev = elem;
-                elem = elem->next;
-            }
-        }
-    }
-    return ret;
-}
-
-static map_elem_item *do_map_elem_delete_by_field(map_meta_info *info, map_hash_node *node, const int hval,
-                                                  const field_t *field, size_t *space_decreased)
-{
-    map_elem_item *deleted = NULL;
-    int hidx = MAP_GET_HASHIDX(hval, node->hdepth);
-
-    if (node->hcnt[hidx] == -1) {
-        map_hash_node *child_node = node->htab[hidx];
-        deleted = do_map_elem_delete_by_field(info, child_node, hval, field, space_decreased);
-        if (deleted) {
-            if (child_node->tot_elem_cnt < (MAP_MAX_HASHCHAIN_SIZE/2)) {
-                do_map_node_unlink(info, node, hidx);
-                *space_decreased += slabs_space_size(sizeof(map_hash_node));
-            }
-            node->tot_elem_cnt -= 1;
-        }
-    } else {
-        if (node->hcnt[hidx] > 0) {
-            map_elem_item *prev = NULL;
-            map_elem_item *elem = node->htab[hidx];
-            while (elem != NULL) {
-                if (map_hash_eq(hval, field->value, field->length, elem->hval, elem->data, elem->nfield)) {
-                    do_map_elem_unlink(info, node, hidx, prev, elem);
-                    deleted = elem;
-                    break;
-                }
-                prev = elem;
-                elem = elem->next;
-            }
-        }
-    }
-    return deleted;
-}
-
-static int do_map_elem_get_all(map_meta_info *info, map_hash_node *node,
-                               const bool delete, map_elem_item **elem_array, size_t *space_decreased)
-{
-    assert(elem_array != NULL);
-    int hidx;
-    int fcnt = 0; /* found count */
-
-    for (hidx = 0; hidx < MAP_HASHTAB_SIZE; hidx++) {
-        if (node->hcnt[hidx] == -1) {
-            map_hash_node *child_node = (map_hash_node *)node->htab[hidx];
-            int ecnt = do_map_elem_get_all(info, child_node, delete, &elem_array[fcnt], space_decreased);
-            fcnt += ecnt;
-            if (delete) {
-                if (child_node->tot_elem_cnt < (MAP_MAX_HASHCHAIN_SIZE/2)) {
-                    do_map_node_unlink(info, node, hidx);
-                    *space_decreased += slabs_space_size(sizeof(map_hash_node));
-                }
-                node->tot_elem_cnt -= ecnt;
-            }
-        } else if (node->hcnt[hidx] > 0) {
-            map_elem_item *elem = node->htab[hidx];
-            while (elem != NULL) {
-                elem->refcount++;
-                elem_array[fcnt] = elem;
-                fcnt++;
-                if (delete) do_map_elem_unlink(info, node, hidx, NULL, elem);
-                elem = (delete ? node->htab[hidx] : elem->next);
-            }
-        }
-    }
-    return fcnt;
-}
-
-static int do_map_elem_delete_by_count(map_meta_info *info, map_hash_node *node,
-                                       const uint32_t count, map_elem_item **deleted_head,
-                                       size_t *space_decreased)
-{
-    int hidx;
-    int fcnt = 0;
-
-    for (hidx = 0; hidx < MAP_HASHTAB_SIZE; hidx++) {
-        if (node->hcnt[hidx] == -1) {
-            map_hash_node *child_node = (map_hash_node *)node->htab[hidx];
-            int rcnt = (count > 0 ? (count - fcnt) : 0);
-            int ecnt = do_map_elem_delete_by_count(info, child_node, rcnt, deleted_head, space_decreased);
-            fcnt += ecnt;
-            if (child_node->tot_elem_cnt < (MAP_MAX_HASHCHAIN_SIZE/2)) {
-                do_map_node_unlink(info, node, hidx);
-                *space_decreased += slabs_space_size(sizeof(map_hash_node));
-            }
-            node->tot_elem_cnt -= ecnt;
-        } else if (node->hcnt[hidx] > 0) {
-            map_elem_item *elem = node->htab[hidx];
-            while (elem != NULL) {
-                fcnt++;
-                do_map_elem_unlink(info, node, hidx, NULL, elem);
-
-                /* link deleted elem into list; returned to caller */
-                elem->next = *deleted_head;
-                *deleted_head = elem;
-
-                if (count > 0 && fcnt >= count) break;
-                elem = node->htab[hidx];
-            }
-        }
-        if (count > 0 && fcnt >= count) break;
-    }
-    return fcnt;
-}
-
 static uint32_t do_map_elem_delete(map_meta_info *info, const int numfields,
                                    const field_t *flist)
 {
+    htree_meta *htree = &info->htree;
     uint32_t delcnt = 0;
     enum elem_delete_cause cause = ELEM_DELETE_NORMAL;
     size_t space_decreased = 0;
-    map_elem_item *deleted = NULL;
+    htree_elem_item *deleted = NULL;
 
-    if (info->root != NULL) {
+    if (htree->root != NULL) {
         CLOG_ELEM_DELETE_BEGIN((coll_meta_info*)info, numfields, cause);
         if (numfields == 0) {
-            map_elem_item *deleted_head = NULL;
-            delcnt = do_map_elem_delete_by_count(info, info->root, 0, &deleted_head, &space_decreased);
+            htree_elem_item *deleted_head = NULL;
+            delcnt = htree_elem_delete_bulk(htree, 0 /* all */,
+                                            &deleted_head, &space_decreased);
 
             deleted = deleted_head;
             while (deleted != NULL) {
-                map_elem_item *next = deleted->next;
-                do_map_elem_delete_post(info, deleted, cause);
+                htree_elem_item *next = deleted->next;
+                do_map_elem_delete_post(info, (map_elem_item *)deleted, cause);
                 deleted = next;
             }
         } else {
             for (int ii = 0; ii < numfields; ii++) {
                 int hval = genhash_string_hash(flist[ii].value, flist[ii].length);
 
-                deleted = do_map_elem_delete_by_field(info, info->root, hval, &flist[ii], &space_decreased);
+                deleted = htree_elem_delete(htree, hval,
+                                            flist[ii].value, flist[ii].length, &space_decreased);
                 if (deleted != NULL) {
-                    do_map_elem_delete_post(info, deleted, cause);
+                    do_map_elem_delete_post(info, (map_elem_item *)deleted, cause);
                     delcnt++;
                 }
             }
-        }
-
-        if (info->root->tot_elem_cnt == 0) {
-            do_map_node_unlink(info, NULL, 0);
-            space_decreased += slabs_space_size(sizeof(map_hash_node));
         }
 
         if (info->stotal > 0 && space_decreased > 0) { /* apply memory space */
@@ -616,10 +226,10 @@ static uint32_t do_map_elem_delete(map_meta_info *info, const int numfields,
     return delcnt;
 }
 
-static ENGINE_ERROR_CODE do_map_elem_replace(map_meta_info *info, map_prev_info *pinfo,
+static ENGINE_ERROR_CODE do_map_elem_replace(map_meta_info *info, htree_prev_info *pinfo,
                                              map_elem_item *new_elem)
 {
-    map_elem_item *old_elem = (pinfo->prev != NULL) ? pinfo->prev->next
+    map_elem_item *old_elem = (pinfo->prev != NULL) ? (map_elem_item *)pinfo->prev->next
                                                     : (map_elem_item *)pinfo->node->htab[pinfo->hidx];
 #ifdef ENABLE_STICKY_ITEM
     /* sticky memory limit check */
@@ -630,7 +240,7 @@ static ENGINE_ERROR_CODE do_map_elem_replace(map_meta_info *info, map_prev_info 
         }
     }
 #endif
-    map_elem_item *replaced = do_htree_elem_replace(info, pinfo, new_elem);
+    map_elem_item *replaced = (map_elem_item *)htree_elem_replace(pinfo, (htree_elem_item *)new_elem);
     assert(replaced == old_elem);
 
     CLOG_MAP_ELEM_INSERT(info, old_elem, new_elem);
@@ -656,15 +266,11 @@ static ENGINE_ERROR_CODE do_map_elem_update(map_meta_info *info,
                                             const field_t *field, const char *value,
                                             const uint32_t nbytes)
 {
-    map_prev_info  pinfo;
+    htree_prev_info pinfo;
     map_elem_item *elem;
 
-    if (info->root == NULL) {
-        return ENGINE_ELEM_ENOENT;
-    }
-
     int hval = genhash_string_hash(field->value, field->length);
-    elem = do_map_elem_find(info, hval, field->value, field->length, &pinfo);
+    elem = (map_elem_item *)htree_elem_find(&info->htree, hval, field->value, field->length, &pinfo);
 
     if (elem == NULL) {
         return ENGINE_ELEM_ENOENT;
@@ -702,7 +308,7 @@ static uint32_t do_map_elem_get(map_meta_info *info,
                                 const int numfields, const field_t *flist,
                                 const bool delete, map_elem_item **elem_array)
 {
-    assert(info->root);
+    htree_meta *htree = &info->htree;
     uint32_t fcnt = 0;
     enum elem_delete_cause cause = ELEM_DELETE_NORMAL;
     size_t space_decreased = 0;
@@ -711,7 +317,8 @@ static uint32_t do_map_elem_get(map_meta_info *info,
         CLOG_ELEM_DELETE_BEGIN((coll_meta_info*)info, numfields, cause);
     }
     if (numfields == 0) {
-        fcnt = do_map_elem_get_all(info, info->root, delete, elem_array, &space_decreased);
+        fcnt = htree_elem_get_bulk(htree, 0 /* all */,
+                                   delete, (htree_elem_item **)elem_array, &space_decreased);
         if (delete) {
             for (int ii = 0; ii < fcnt; ii++) {
                 do_map_elem_delete_post(info, elem_array[ii], cause);
@@ -720,18 +327,15 @@ static uint32_t do_map_elem_get(map_meta_info *info,
     } else {
         for (int ii = 0; ii < numfields; ii++) {
             int hval = genhash_string_hash(flist[ii].value, flist[ii].length);
-            if (do_map_elem_get_by_field(info, info->root, hval, &flist[ii],
-                                         delete, &elem_array[fcnt], &space_decreased)) {
+            if (htree_elem_get(htree, hval,
+                               flist[ii].value, flist[ii].length,
+                               delete, (htree_elem_item **)&elem_array[fcnt], &space_decreased)) {
                 if (delete) do_map_elem_delete_post(info, elem_array[fcnt], cause);
                 fcnt++;
             }
         }
     }
     if (delete) {
-        if (info->root->tot_elem_cnt == 0) {
-            do_map_node_unlink(info, NULL, 0);
-            space_decreased += slabs_space_size(sizeof(map_hash_node));
-        }
         if (info->stotal > 0 && space_decreased > 0) { /* apply memory space */
             do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_MAP, space_decreased);
         }
@@ -744,19 +348,20 @@ static ENGINE_ERROR_CODE do_map_elem_insert(hash_item *it, map_elem_item *elem,
                                             const bool replace_if_exist, bool *replaced)
 {
     map_meta_info *info = (map_meta_info *)item_get_meta(it);
+    htree_meta *htree = &info->htree;
     ENGINE_ERROR_CODE ret;
-    map_prev_info pinfo;
-    map_elem_item *find;
+    htree_prev_info pinfo;
+    htree_elem_item *find;
 
     /* map hash value */
     elem->hval = genhash_string_hash(elem->data, elem->nfield);
-    find = do_map_elem_find(info, elem->hval, elem->data, elem->nfield, &pinfo);
+    find = htree_elem_find(htree, elem->hval, elem->data, elem->nfield, &pinfo);
 
     if (find != NULL) {
         if (!replace_if_exist) {
             return ENGINE_ELEM_EEXISTS;
         }
-        ENGINE_ERROR_CODE ret = do_map_elem_replace(info, &pinfo, elem);
+        ret = do_map_elem_replace(info, &pinfo, elem);
         if (ret != ENGINE_SUCCESS) {
             return ret;
         }
@@ -779,7 +384,7 @@ static ENGINE_ERROR_CODE do_map_elem_insert(hash_item *it, map_elem_item *elem,
     }
 
     size_t space_increased = 0;
-    ret = do_htree_elem_add(info, elem, &pinfo, &space_increased);
+    ret = htree_elem_add(htree, (htree_elem_item *)elem, &pinfo, &space_increased);
     if (ret != ENGINE_SUCCESS) {
         return ret;
     }
@@ -792,30 +397,6 @@ static ENGINE_ERROR_CODE do_map_elem_insert(hash_item *it, map_elem_item *elem,
     }
 
     return ENGINE_SUCCESS;
-}
-
-static void do_map_traverse_advance(map_elem_posi *posi)
-{
-    while (posi->depth >= 0) {
-        map_hash_node *node = posi->path[posi->depth].node;
-        int hidx;
-
-        for (hidx = posi->path[posi->depth].hidx; hidx < MAP_HASHTAB_SIZE; hidx++) {
-            if (node->hcnt[hidx] == -1) {
-                posi->path[posi->depth].hidx = hidx + 1;
-                posi->depth++;
-                posi->path[posi->depth].node = (map_hash_node *)node->htab[hidx];
-                posi->path[posi->depth].hidx = 0;
-                break;
-            } else if (node->hcnt[hidx] > 0) {
-                posi->path[posi->depth].hidx = hidx + 1;
-                posi->curr = (map_elem_item *)node->htab[hidx];
-                return;
-            }
-        }
-        if (hidx >= MAP_HASHTAB_SIZE) posi->depth--;
-    }
-    posi->curr = NULL;
 }
 
 /*
@@ -960,7 +541,7 @@ ENGINE_ERROR_CODE map_elem_delete(const char *key, const uint32_t nkey,
         *del_count = do_map_elem_delete(info, numfields, flist);
         if (*del_count > 0) {
             if (info->ccnt == 0 && drop_if_empty) {
-                assert(info->root == NULL);
+                assert(info->htree.root == NULL);
                 do_item_unlink(it, ITEM_UNLINK_NORMAL);
                 *dropped = true;
             }
@@ -1036,25 +617,22 @@ ENGINE_ERROR_CODE map_elem_get(const char *key, const uint32_t nkey,
 
 uint32_t map_elem_delete_with_count(map_meta_info *info, const uint32_t count)
 {
+    htree_meta *htree = &info->htree;
     uint32_t fcnt = 0;
     size_t space_decreased = 0;
 
     // cache_lock is held by caller.
-    if (info->root != NULL) {
-        map_elem_item *deleted_head = NULL;
-        fcnt = do_map_elem_delete_by_count(info, info->root, count, &deleted_head, &space_decreased);
+    if (htree->root != NULL) {
+        htree_elem_item *deleted_head = NULL;
+        fcnt = htree_elem_delete_bulk(htree, count, &deleted_head, &space_decreased);
 
-        map_elem_item *deleted = deleted_head;
+        htree_elem_item *deleted = deleted_head;
         while (deleted != NULL) {
-            map_elem_item *next = deleted->next;
-            do_map_elem_delete_post(info, deleted, ELEM_DELETE_COLL);
+            htree_elem_item *next = deleted->next;
+            do_map_elem_delete_post(info, (map_elem_item *)deleted, ELEM_DELETE_COLL);
             deleted = next;
         }
 
-        if (info->root->tot_elem_cnt == 0) {
-            do_map_node_unlink(info, NULL, 0);
-            space_decreased += slabs_space_size(sizeof(map_hash_node));
-        }
         if (info->stotal > 0 && space_decreased > 0) { /* apply memory space */
             do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_MAP, space_decreased);
         }
@@ -1065,8 +643,8 @@ uint32_t map_elem_delete_with_count(map_meta_info *info, const uint32_t count)
 void map_elem_get_all(map_meta_info *info, elems_result_t *eresult)
 {
     assert(eresult->elem_arrsz >= info->ccnt && eresult->elem_count == 0);
-    eresult->elem_count = do_map_elem_get_all(info, info->root, false,
-                                              (map_elem_item **)eresult->elem_array, NULL);
+    eresult->elem_count = htree_elem_get_bulk(&info->htree, 0 /* all */,
+                                              false, (htree_elem_item**)(eresult->elem_array), NULL);
     assert(eresult->elem_count == info->ccnt);
 }
 
@@ -1273,30 +851,12 @@ ENGINE_ERROR_CODE map_apply_elem_delete(void *engine, hash_item *it,
 
 void map_traverse_init(coll_meta_info *info, void *posi)
 {
-    map_elem_posi *mp = (map_elem_posi *)posi;
-    if (((map_meta_info *)info)->root == NULL) {
-        mp->curr = NULL;
-        return;
-    }
-    mp->path[0].node = ((map_meta_info *)info)->root;
-    mp->path[0].hidx = 0;
-    mp->depth = 0;
-    do_map_traverse_advance(mp);
+    htree_traverse_init(&((map_meta_info *)info)->htree, posi);
 }
 
 uint32_t map_traverse_next(void *posi, void **elem_array, uint32_t count)
 {
-    map_elem_posi *mp = (map_elem_posi *)posi;
-    uint32_t fcnt = 0;
-    while (fcnt < count && mp->curr != NULL) {
-        mp->curr->refcount++;
-        elem_array[fcnt++] = mp->curr;
-        if (mp->curr->next != NULL)
-            mp->curr = mp->curr->next;
-        else
-            do_map_traverse_advance(mp);
-    }
-    return fcnt;
+    return htree_traverse_next(posi, elem_array, count);
 }
 
 /*

--- a/engines/default/coll_set.c
+++ b/engines/default/coll_set.c
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 #include "config.h"
+#include "hash_tree.h"
 #include <fcntl.h>
 #include <errno.h>
 #include <stdlib.h>
@@ -38,9 +39,6 @@ static struct default_engine *engine=NULL;
 static struct engine_config  *config=NULL; // engine config
 static EXTENSION_LOGGER_DESCRIPTOR *logger;
 
-/* used by set and map collection */
-extern int genhash_string_hash(const void* p, size_t nkey);
-
 /* Cache Lock */
 static inline void LOCK_CACHE(void)
 {
@@ -53,81 +51,16 @@ static inline void UNLOCK_CACHE(void)
 }
 
 /*
- * Hash table management
- */
-typedef struct hash_node {
-    int cnt;
-    int keys[3];
-} hash_node;
-
-typedef struct hash_table {
-    hash_node *buckets;
-    int capacity;
-} hash_table;
-
-static bool hash_init(hash_table *ht, int count)
-{
-    ht->capacity = (int)(1.3 * (double)count);
-    ht->buckets = (hash_node*)calloc(ht->capacity, sizeof(hash_node));
-    if (ht->buckets == NULL)
-        return false;
-    return true;
-}
-
-static void hash_free(hash_table *ht)
-{
-    if (ht->buckets) {
-        free(ht->buckets);
-        ht->buckets = NULL;
-        ht->capacity = 0;
-    }
-}
-
-static bool hash_insert(hash_table *ht, int key)
-{
-    size_t idx = key % ht->capacity;
-    hash_node *bucket = &ht->buckets[idx];
-    if (bucket->cnt == 3)
-        return false;
-    for (int i = 0; i < bucket->cnt; i++) {
-        if (bucket->keys[i] == key)
-            return false;
-    }
-    bucket->keys[bucket->cnt] = key;
-    bucket->cnt++;
-    return true;
-}
-
-/*
  * SET collection manangement
  */
-#define SET_MAX_DEPTH 8  /* 32-bit hash, 4bits per level */
-
-typedef struct {
-    set_hash_node *node;
-    int            hidx;
-} set_path_entry;
-
-typedef struct {
-    set_elem_item *curr;
-    set_path_entry path[SET_MAX_DEPTH];
-    int            depth;
-} set_elem_posi;
-
-typedef struct _set_prev_info {
-    set_hash_node *node;
-    set_elem_item *prev;
-    uint16_t       hidx;
-} set_prev_info;
-
-#define SET_GET_HASHIDX(hval, hdepth) \
-        (((hval) & (SET_HASHIDX_MASK << ((hdepth)*4))) >> ((hdepth)*4))
-
-static inline int set_hash_eq(const int h1, const void *v1, size_t vlen1,
-                              const int h2, const void *v2, size_t vlen2)
+static const void *set_get_key(const htree_elem_item *elem, uint16_t *nkey)
 {
-    return (h1 == h2 && vlen1 == vlen2 && memcmp(v1, v2, vlen1) == 0);
+    set_elem_item *e = (set_elem_item *)elem;
+    *nkey = e->nbytes;
+    return e->value;
 }
+
+static htree_ops set_htree_ops = { set_get_key };
 
 static inline uint32_t do_set_elem_ntotal(set_elem_item *elem)
 {
@@ -192,33 +125,10 @@ static hash_item *do_set_item_alloc(const void *key, const uint32_t nkey,
         if (attrp->readable == 1)              info->mflags |= COLL_META_FLAG_READABLE;
         info->itdist  = (uint16_t)((size_t*)info-(size_t*)it);
         info->stotal  = 0;
-        info->root    = NULL;
+        htree_init(&info->htree, &set_htree_ops);
         assert((hash_item*)COLL_GET_HASH_ITEM(info) == it);
     }
     return it;
-}
-
-static set_hash_node *do_set_node_alloc(uint8_t hash_depth)
-{
-    size_t ntotal = sizeof(set_hash_node);
-
-    set_hash_node *node = do_item_mem_alloc(ntotal, LRU_CLSID_FOR_SMALL);
-    if (node != NULL) {
-        node->slabs_clsid = slabs_clsid(ntotal);
-        assert(node->slabs_clsid > 0);
-
-        node->refcount    = 0;
-        node->hdepth      = hash_depth;
-        node->tot_elem_cnt = 0;
-        memset(node->hcnt, 0, SET_HASHTAB_SIZE*sizeof(uint16_t));
-        memset(node->htab, 0, SET_HASHTAB_SIZE*sizeof(void*));
-    }
-    return node;
-}
-
-static void do_set_node_free(set_hash_node *node)
-{
-    do_item_mem_free(node, sizeof(set_hash_node));
 }
 
 static set_elem_item *do_set_elem_alloc(const uint32_t nbytes)
@@ -255,184 +165,6 @@ static void do_set_elem_release(set_elem_item *elem)
     }
 }
 
-static void do_set_node_link(set_meta_info *info,
-                             set_hash_node *par_node, const int par_hidx,
-                             set_hash_node *node)
-{
-    if (par_node == NULL) {
-        info->root = node;
-    } else {
-        set_elem_item *elem;
-        while (par_node->htab[par_hidx] != NULL) {
-            elem = par_node->htab[par_hidx];
-            par_node->htab[par_hidx] = elem->next;
-
-            int hidx = SET_GET_HASHIDX(elem->hval, node->hdepth);
-            elem->next = node->htab[hidx];
-            node->htab[hidx] = elem;
-            node->hcnt[hidx] += 1;
-            node->tot_elem_cnt += 1;
-        }
-        assert(node->tot_elem_cnt == par_node->hcnt[par_hidx]);
-        par_node->htab[par_hidx] = node;
-        par_node->hcnt[par_hidx] = -1; /* child hash node */
-    }
-}
-
-static void do_set_node_unlink(set_meta_info *info,
-                               set_hash_node *par_node, const int par_hidx)
-{
-    set_hash_node *node;
-
-    if (par_node == NULL) {
-        node = info->root;
-        info->root = NULL;
-        assert(node->tot_elem_cnt == 0);
-    } else {
-        assert(par_node->hcnt[par_hidx] == -1); /* child hash node */
-        set_elem_item *head = NULL;
-        set_elem_item *elem;
-        int hidx, fcnt = 0;
-
-        node = (set_hash_node *)par_node->htab[par_hidx];
-        assert(node->tot_elem_cnt < (SET_MAX_HASHCHAIN_SIZE/2));
-
-        for (hidx = 0; hidx < SET_HASHTAB_SIZE; hidx++) {
-            assert(node->hcnt[hidx] >= 0);
-            if (node->hcnt[hidx] > 0) {
-                fcnt += node->hcnt[hidx];
-                while (node->htab[hidx] != NULL) {
-                    elem = node->htab[hidx];
-                    node->htab[hidx] = elem->next;
-                    node->hcnt[hidx] -= 1;
-
-                    elem->next = head;
-                    head = elem;
-                }
-                assert(node->hcnt[hidx] == 0);
-            }
-        }
-        assert(fcnt == node->tot_elem_cnt);
-        node->tot_elem_cnt = 0;
-
-        par_node->htab[par_hidx] = head;
-        par_node->hcnt[par_hidx] = fcnt;
-    }
-
-    /* free the node */
-    do_set_node_free(node);
-}
-
-static set_elem_item *do_set_elem_find(set_meta_info *info,
-                                       const int hval,
-                                       const void *key, uint16_t nkey,
-                                       set_prev_info *pinfo)
-{
-    if (info->root == NULL) {
-        return NULL;
-    }
-
-    set_hash_node *node = info->root;
-    int hidx;
-
-    while (node != NULL) {
-        hidx = SET_GET_HASHIDX(hval, node->hdepth);
-        if (node->hcnt[hidx] >= 0)
-            break;
-        node = node->htab[hidx];
-    }
-
-    set_elem_item *prev = NULL;
-    set_elem_item *elem;
-    for (elem = node->htab[hidx]; elem != NULL; elem = elem->next) {
-        if (set_hash_eq(hval, key, nkey, elem->hval, elem->value, elem->nbytes))
-            break;
-        prev = elem;
-    }
-
-    if (pinfo != NULL) {
-        pinfo->node = node;
-        pinfo->prev = prev;
-        pinfo->hidx = hidx;
-    }
-
-    return elem;
-}
-
-static ENGINE_ERROR_CODE do_htree_elem_link(set_meta_info *info,
-                                            set_hash_node *node, int hidx,
-                                            set_elem_item *elem, size_t *space_increased)
-{
-    if (node->hcnt[hidx] >= SET_MAX_HASHCHAIN_SIZE) {
-        set_hash_node *n_node = do_set_node_alloc(node->hdepth+1);
-        if (n_node == NULL) {
-            return ENGINE_ENOMEM;
-        }
-        do_set_node_link(info, node, hidx, n_node);
-        *space_increased += slabs_space_size(sizeof(set_hash_node));
-
-        node = n_node;
-        hidx = SET_GET_HASHIDX(elem->hval, node->hdepth);
-    }
-
-    elem->linked++;
-    elem->next = node->htab[hidx];
-    node->htab[hidx] = elem;
-    node->hcnt[hidx] += 1;
-    node->tot_elem_cnt += 1;
-
-    set_hash_node *par_node = info->root;
-    while (par_node != node) {
-        par_node->tot_elem_cnt += 1;
-        int par_hidx = SET_GET_HASHIDX(elem->hval, par_node->hdepth);
-        assert(par_node->hcnt[par_hidx] == -1);
-        par_node = par_node->htab[par_hidx];
-    }
-    return ENGINE_SUCCESS;
-}
-
-static ENGINE_ERROR_CODE do_htree_elem_insert(set_meta_info *info, set_elem_item *elem,
-                                              size_t *space_increased)
-{
-    set_hash_node *node;
-    int hidx;
-    /* create the root hash node if it does not exist */
-    if (info->root == NULL) {
-        node = do_set_node_alloc(0);
-        if (node == NULL) {
-            return ENGINE_ENOMEM;
-        }
-        do_set_node_link(info, NULL, 0, node);
-        *space_increased += slabs_space_size(sizeof(set_hash_node));
-
-        hidx = SET_GET_HASHIDX(elem->hval, 0);
-        return do_htree_elem_link(info, node, hidx, elem, space_increased);
-    }
-
-    set_elem_item *find;
-    set_prev_info pinfo;
-
-    find = do_set_elem_find(info, elem->hval, elem->value, elem->nbytes, &pinfo);
-    if (find != NULL) {
-        return ENGINE_ELEM_EEXISTS;
-    }
-
-    node = pinfo.node;
-    hidx = pinfo.hidx;
-    return do_htree_elem_link(info, node, hidx, elem, space_increased);
-}
-
-static void do_set_elem_unlink(set_meta_info *info,
-                               set_hash_node *node, const int hidx,
-                               set_elem_item *prev, set_elem_item *elem)
-{
-    if (prev != NULL) prev->next = elem->next;
-    else              node->htab[hidx] = elem->next;
-    elem->linked--;
-    node->hcnt[hidx] -= 1;
-    node->tot_elem_cnt -= 1;
-}
-
 static void do_set_elem_delete_post(set_meta_info *info,
                                     set_elem_item *elem,
                                     enum elem_delete_cause cause)
@@ -449,55 +181,17 @@ static void do_set_elem_delete_post(set_meta_info *info,
     }
 }
 
-static set_elem_item *do_set_elem_delete_by_value(set_meta_info *info, set_hash_node *node,
-                                                   const int hval, const char *val, const int vlen,
-                                                   size_t *space_decreased)
-{
-    set_elem_item *deleted = NULL;
-    int hidx = SET_GET_HASHIDX(hval, node->hdepth);
-
-    if (node->hcnt[hidx] == -1) {
-        set_hash_node *child_node = node->htab[hidx];
-        deleted = do_set_elem_delete_by_value(info, child_node, hval, val, vlen, space_decreased);
-        if (deleted) {
-            if (child_node->tot_elem_cnt < (SET_MAX_HASHCHAIN_SIZE/2)) {
-                do_set_node_unlink(info, node, hidx);
-                *space_decreased += slabs_space_size(sizeof(set_hash_node));
-            }
-            node->tot_elem_cnt -= 1;
-        }
-    } else {
-        if (node->hcnt[hidx] > 0) {
-            set_elem_item *prev = NULL;
-            set_elem_item *elem = node->htab[hidx];
-            while (elem != NULL) {
-                if (set_hash_eq(hval, val, vlen, elem->hval, elem->value, elem->nbytes)) {
-                    do_set_elem_unlink(info, node, hidx, prev, elem);
-                    deleted = elem;
-                    break;
-                }
-                prev = elem;
-                elem = elem->next;
-            }
-        }
-    }
-    return deleted;
-}
-
 static ENGINE_ERROR_CODE do_set_elem_delete(set_meta_info *info,
                                             const char *val, const int vlen)
 {
+    htree_meta *htree = &info->htree;
     ENGINE_ERROR_CODE ret = ENGINE_ELEM_ENOENT;
-    if (info->root != NULL) {
+    if (htree->root != NULL) {
         int hval = genhash_string_hash(val, vlen);
         size_t space_decreased = 0;
-        set_elem_item *deleted = do_set_elem_delete_by_value(info, info->root, hval, val, vlen, &space_decreased);
+        htree_elem_item *deleted = htree_elem_delete(htree, hval, val, vlen, &space_decreased);
         if (deleted != NULL) {
-            do_set_elem_delete_post(info, deleted, ELEM_DELETE_NORMAL);
-            if (info->root->tot_elem_cnt == 0) {
-                do_set_node_unlink(info, NULL, 0);
-                space_decreased += slabs_space_size(sizeof(set_hash_node));
-            }
+            do_set_elem_delete_post(info, (set_elem_item *)deleted, ELEM_DELETE_NORMAL);
             if (info->stotal > 0 && space_decreased > 0) {
                 do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_SET, space_decreased);
             }
@@ -507,199 +201,11 @@ static ENGINE_ERROR_CODE do_set_elem_delete(set_meta_info *info,
     return ret;
 }
 
-static int do_set_elem_get_all(set_meta_info *info, set_hash_node *node,
-                               const bool delete, set_elem_item **elem_array,
-                               size_t *space_decreased)
-{
-    assert(elem_array != NULL);
-    int hidx;
-    int fcnt = 0; /* found count */
-
-    for (hidx = 0; hidx < SET_HASHTAB_SIZE; hidx++) {
-        if (node->hcnt[hidx] == -1) {
-            set_hash_node *child_node = (set_hash_node *)node->htab[hidx];
-            int ecnt = do_set_elem_get_all(info, child_node, delete, &elem_array[fcnt], space_decreased);
-            fcnt += ecnt;
-            if (delete) {
-                if (child_node->tot_elem_cnt < (SET_MAX_HASHCHAIN_SIZE/2)) {
-                    do_set_node_unlink(info, node, hidx);
-                    *space_decreased += slabs_space_size(sizeof(set_hash_node));
-                }
-                node->tot_elem_cnt -= ecnt;
-            }
-        } else if (node->hcnt[hidx] > 0) {
-            set_elem_item *elem = node->htab[hidx];
-            while (elem != NULL) {
-                elem->refcount++;
-                elem_array[fcnt] = elem;
-                fcnt++;
-                if (delete) do_set_elem_unlink(info, node, hidx, NULL, elem);
-                elem = (delete ? node->htab[hidx] : elem->next);
-            }
-        }
-    }
-    return fcnt;
-}
-
-static int do_set_elem_delete_by_count(set_meta_info *info, set_hash_node *node,
-                                       const uint32_t count, set_elem_item **deleted_head,
-                                       size_t *space_decreased)
-{
-    int hidx;
-    int fcnt = 0;
-
-    for (hidx = 0; hidx < SET_HASHTAB_SIZE; hidx++) {
-        if (node->hcnt[hidx] == -1) {
-            set_hash_node *child_node = (set_hash_node *)node->htab[hidx];
-            int rcnt = (count > 0 ? (count - fcnt) : 0);
-            int ecnt = do_set_elem_delete_by_count(info, child_node, rcnt, deleted_head, space_decreased);
-            fcnt += ecnt;
-            if (child_node->tot_elem_cnt < (SET_MAX_HASHCHAIN_SIZE/2)) {
-                do_set_node_unlink(info, node, hidx);
-                *space_decreased += slabs_space_size(sizeof(set_hash_node));
-            }
-            node->tot_elem_cnt -= ecnt;
-        } else if (node->hcnt[hidx] > 0) {
-            set_elem_item *elem = node->htab[hidx];
-            while (elem != NULL) {
-                fcnt++;
-                do_set_elem_unlink(info, node, hidx, NULL, elem);
-
-                /* link deleted elem into list; returned to caller */
-                elem->next = *deleted_head;
-                *deleted_head = elem;
-
-                if (count > 0 && fcnt >= count) break;
-                elem = node->htab[hidx];
-            }
-        }
-        if (count > 0 && fcnt >= count) break;
-    }
-    return fcnt;
-}
-
-static int do_set_elem_get_sampling(set_meta_info *info, set_hash_node *node,
-                                    uint32_t remain, const uint32_t count,
-                                    set_elem_item **elem_array)
-{
-    int hidx;
-    int fcnt = 0; /* found count */
-
-    for (hidx = 0; hidx < SET_HASHTAB_SIZE; hidx++) {
-        if (node->hcnt[hidx] == -1) {
-            set_hash_node *child_node = (set_hash_node *)node->htab[hidx];
-            fcnt += do_set_elem_get_sampling(info, child_node, remain,
-                                             count - fcnt, &elem_array[fcnt]);
-            remain -= child_node->tot_elem_cnt;
-        } else if (node->hcnt[hidx] > 0) {
-            set_elem_item *elem = node->htab[hidx];
-            while (elem != NULL) {
-                if ((rand() % remain) < (count - fcnt)) {
-                    elem->refcount++;
-                    elem_array[fcnt] = elem;
-                    fcnt++;
-                    if (fcnt >= count) break;
-                }
-                remain -= 1;
-                elem = elem->next;
-            }
-        }
-        if (fcnt >= count) break;
-    }
-    return fcnt;
-}
-
-static set_elem_item *do_set_elem_get_by_offset(set_meta_info *info, set_hash_node *node,
-                                                uint32_t offset, const bool delete,
-                                                size_t *space_decreased)
-{
-    int hidx;
-    for (hidx = 0; hidx < SET_HASHTAB_SIZE; hidx++) {
-        if (node->hcnt[hidx] == -1) {
-            set_hash_node *child_node = (set_hash_node *)node->htab[hidx];
-            if (offset >= child_node->tot_elem_cnt) {
-                offset -= child_node->tot_elem_cnt;
-                continue;
-            }
-            set_elem_item *found = do_set_elem_get_by_offset(info, child_node, offset, delete, space_decreased);
-            if (delete) {
-                if (child_node->tot_elem_cnt < (SET_MAX_HASHCHAIN_SIZE/2)) {
-                    do_set_node_unlink(info, node, hidx);
-                    *space_decreased += slabs_space_size(sizeof(set_hash_node));
-                }
-                node->tot_elem_cnt -= 1;
-            }
-            return found;
-        } else if (node->hcnt[hidx] > 0) {
-            if (offset >= node->hcnt[hidx]) {
-                offset -= node->hcnt[hidx];
-                continue;
-            }
-            set_elem_item *prev = NULL;
-            set_elem_item *elem = node->htab[hidx];
-            while (offset > 0) {
-                prev = elem;
-                elem = elem->next;
-                offset -= 1;
-            }
-            elem->refcount++;
-            if (delete) do_set_elem_unlink(info, node, hidx, prev, elem);
-            return elem;
-        }
-    }
-    return NULL;
-}
-
-static uint32_t do_set_elem_get_rand(set_meta_info *info,
-                                     const uint32_t count, const bool delete,
-                                     set_elem_item **elem_array,
-                                     size_t *space_decreased)
-{
-    assert(elem_array != NULL);
-    uint32_t fcnt = 0;
-
-    if (delete) { /* Deleting partial elements */
-        while (fcnt < count) {
-            int rand_offset = (rand() % info->ccnt);
-            set_elem_item *found = do_set_elem_get_by_offset(info, info->root,
-                                                             rand_offset, delete, space_decreased);
-            assert(found != NULL);
-            elem_array[fcnt++] = found;
-        }
-    } else if (count <= info->ccnt / 10) { /* Use hash table */
-        hash_table offset_ht;
-        if (!hash_init(&offset_ht, count))
-            return 0;
-        while (fcnt < count) {
-            int rand_offset = (rand() % info->ccnt);
-            if (hash_insert(&offset_ht, rand_offset)) {
-                set_elem_item *found = do_set_elem_get_by_offset(info, info->root,
-                                                                 rand_offset, false, NULL);
-                assert(found != NULL);
-                elem_array[fcnt++] = found;
-            }
-        }
-        hash_free(&offset_ht);
-    } else { /* Use sampling */
-        fcnt = do_set_elem_get_sampling(info, info->root, info->ccnt, count,
-                                        elem_array);
-        for (int i = fcnt - 1; i > 0; i--) {
-            int rand_idx = rand() % (i + 1);
-            if (rand_idx != i) {
-                set_elem_item *temp = elem_array[i];
-                elem_array[i] = elem_array[rand_idx];
-                elem_array[rand_idx] = temp;
-            }
-        }
-    }
-    return fcnt;
-}
-
 static uint32_t do_set_elem_get(set_meta_info *info,
                                 const uint32_t count, const bool delete,
                                 set_elem_item **elem_array)
 {
-    assert(info->root);
+    htree_meta *htree = &info->htree;
     uint32_t fcnt;
     enum elem_delete_cause cause = ELEM_DELETE_NORMAL;
 
@@ -708,17 +214,15 @@ static uint32_t do_set_elem_get(set_meta_info *info,
         CLOG_ELEM_DELETE_BEGIN((coll_meta_info*)info, count, cause);
     }
     if (count >= info->ccnt || count == 0) { /* Return all */
-        fcnt = do_set_elem_get_all(info, info->root, delete, elem_array, &space_decreased);
+        fcnt = htree_elem_get_bulk(htree, 0 /* all */,
+                                   delete, (htree_elem_item **)elem_array, &space_decreased);
     } else { /* Return some */
-        fcnt = do_set_elem_get_rand(info, count, delete, elem_array, &space_decreased);
+        fcnt = htree_elem_get_rand(htree, count,
+                                   delete, (htree_elem_item **)elem_array, &space_decreased);
     }
     if (delete) {
         for (int ii = 0; ii < fcnt; ii++) {
             do_set_elem_delete_post(info, elem_array[ii], cause);
-        }
-        if (info->root->tot_elem_cnt == 0) {
-            do_set_node_unlink(info, NULL, 0);
-            space_decreased += slabs_space_size(sizeof(set_hash_node));
         }
         if (info->stotal > 0 && space_decreased > 0) {
             do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_SET, space_decreased);
@@ -752,7 +256,7 @@ static ENGINE_ERROR_CODE do_set_elem_insert(hash_item *it, set_elem_item *elem)
     }
 
     size_t space_increased = 0;
-    ret = do_htree_elem_insert(info, elem, &space_increased);
+    ret = htree_elem_insert(&info->htree, (htree_elem_item *)elem, &space_increased);
     if (ret != ENGINE_SUCCESS) {
         return ret;
     }
@@ -765,30 +269,6 @@ static ENGINE_ERROR_CODE do_set_elem_insert(hash_item *it, set_elem_item *elem)
     }
 
     return ENGINE_SUCCESS;
-}
-
-static void do_set_traverse_advance(set_elem_posi *posi)
-{
-    while (posi->depth >= 0) {
-        set_hash_node *node = posi->path[posi->depth].node;
-        int hidx;
-
-        for (hidx = posi->path[posi->depth].hidx; hidx < SET_HASHTAB_SIZE; hidx++) {
-            if (node->hcnt[hidx] == -1) {
-                posi->path[posi->depth].hidx = hidx + 1;
-                posi->depth++;
-                posi->path[posi->depth].node = (set_hash_node *)node->htab[hidx];
-                posi->path[posi->depth].hidx = 0;
-                break;
-            } else if (node->hcnt[hidx] > 0) {
-                posi->path[posi->depth].hidx = hidx + 1;
-                posi->curr = (set_elem_item *)node->htab[hidx];
-                return;
-            }
-        }
-        if (hidx >= SET_HASHTAB_SIZE) posi->depth--;
-    }
-    posi->curr = NULL;
 }
 
 /*
@@ -938,7 +418,7 @@ ENGINE_ERROR_CODE set_elem_exist(const char *key, const uint32_t nkey,
                 ret = ENGINE_UNREADABLE; break;
             }
             int hval = genhash_string_hash(value, nbytes);
-            if (do_set_elem_find(info, hval, value, nbytes, NULL) != NULL)
+            if (htree_elem_find(&info->htree, hval, value, nbytes, NULL) != NULL)
                 *exist = true;
             else
                 *exist = false;
@@ -1011,25 +491,22 @@ ENGINE_ERROR_CODE set_elem_get(const char *key, const uint32_t nkey,
 
 uint32_t set_elem_delete_with_count(set_meta_info *info, const uint32_t count)
 {
+    htree_meta *htree = &info->htree;
     uint32_t fcnt = 0;
     size_t space_decreased = 0;
 
     // cache_lock is held by caller
-    if (info->root != NULL) {
-        set_elem_item *deleted_head = NULL;
-        fcnt = do_set_elem_delete_by_count(info, info->root, count, &deleted_head, &space_decreased);
+    if (htree->root != NULL) {
+        htree_elem_item *deleted_head = NULL;
+        fcnt = htree_elem_delete_bulk(htree, count, &deleted_head, &space_decreased);
 
-        set_elem_item *deleted = deleted_head;
+        htree_elem_item *deleted = deleted_head;
         while (deleted != NULL) {
-            set_elem_item *next = deleted->next;
-            do_set_elem_delete_post(info, deleted, ELEM_DELETE_COLL);
+            htree_elem_item *next = deleted->next;
+            do_set_elem_delete_post(info, (set_elem_item *)deleted, ELEM_DELETE_COLL);
             deleted = next;
         }
 
-        if (info->root->tot_elem_cnt == 0) {
-            do_set_node_unlink(info, NULL, 0);
-            space_decreased += slabs_space_size(sizeof(set_hash_node));
-        }
         if (info->stotal > 0 && space_decreased > 0) { /* apply memory space */
             do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_SET, space_decreased);
         }
@@ -1040,8 +517,8 @@ uint32_t set_elem_delete_with_count(set_meta_info *info, const uint32_t count)
 void set_elem_get_all(set_meta_info *info, elems_result_t *eresult)
 {
     assert(eresult->elem_arrsz >= info->ccnt && eresult->elem_count == 0);
-    eresult->elem_count = do_set_elem_get_all(info, info->root, false,
-                                              (set_elem_item**)(eresult->elem_array), NULL);
+    eresult->elem_count = htree_elem_get_bulk(&info->htree, 0 /* all */,
+                                              false, (htree_elem_item**)(eresult->elem_array), NULL);
     assert(eresult->elem_count == info->ccnt);
 }
 
@@ -1234,30 +711,12 @@ ENGINE_ERROR_CODE set_apply_elem_delete(void *engine, hash_item *it,
 
 void set_traverse_init(coll_meta_info *info, void *posi)
 {
-    set_elem_posi *sp = (set_elem_posi *)posi;
-    if (((set_meta_info *)info)->root == NULL) {
-        sp->curr = NULL;
-        return;
-    }
-    sp->path[0].node = ((set_meta_info *)info)->root;
-    sp->path[0].hidx = 0;
-    sp->depth = 0;
-    do_set_traverse_advance(sp);
+    htree_traverse_init(&((set_meta_info *)info)->htree, posi);
 }
 
 uint32_t set_traverse_next(void *posi, void **elem_array, uint32_t count)
 {
-    set_elem_posi *sp = (set_elem_posi *)posi;
-    uint32_t fcnt = 0;
-    while (fcnt < count && sp->curr != NULL) {
-        sp->curr->refcount++;
-        elem_array[fcnt++] = sp->curr;
-        if (sp->curr->next != NULL)
-            sp->curr = sp->curr->next;
-        else
-            do_set_traverse_advance(sp);
-    }
-    return fcnt;
+    return htree_traverse_next(posi, elem_array, count);
 }
 
 /*

--- a/engines/default/hash_tree.c
+++ b/engines/default/hash_tree.c
@@ -1,0 +1,757 @@
+/*
+ * arcus-memcached - Arcus memory cache server
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2020 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "hash_tree.h"
+#include "default_engine.h"
+#include <stdlib.h>
+#include <assert.h>
+
+#define HTREE_MAX_DEPTH 8  /* 32-bit hash, 4bits per level */
+#define HTREE_HASHIDX_MASK 0x0000000F
+#define HTREE_MAX_HASHCHAIN_SIZE 64
+
+#define HTREE_GET_HASHIDX(hval, hdepth) \
+        (((hval) & (HTREE_HASHIDX_MASK << ((hdepth)*4))) >> ((hdepth)*4))
+
+static inline int htree_hash_eq(const int h1, const void *k1, size_t nkey1,
+                                const int h2, const void *k2, size_t nkey2)
+{
+    return (h1 == h2 && nkey1 == nkey2 && memcmp(k1, k2, nkey1) == 0);
+}
+
+typedef struct {
+    htree_node *node;
+    int         hidx;
+} htree_path_entry;
+
+typedef struct {
+    htree_elem_item  *curr;
+    htree_path_entry path[HTREE_MAX_DEPTH];
+    int              depth;
+} htree_elem_posi;
+
+/*
+ * Hash table management
+ */
+typedef struct hash_node {
+    int cnt;
+    int keys[3];
+} hash_node;
+
+typedef struct hash_table {
+    hash_node *buckets;
+    int capacity;
+} hash_table;
+
+static bool hash_init(hash_table *ht, int count)
+{
+    ht->capacity = (int)(1.3 * (double)count);
+    ht->buckets = (hash_node*)calloc(ht->capacity, sizeof(hash_node));
+    if (ht->buckets == NULL)
+        return false;
+    return true;
+}
+
+static void hash_free(hash_table *ht)
+{
+    if (ht->buckets) {
+        free(ht->buckets);
+        ht->buckets = NULL;
+        ht->capacity = 0;
+    }
+}
+
+static bool hash_insert(hash_table *ht, int key)
+{
+    size_t idx = key % ht->capacity;
+    hash_node *bucket = &ht->buckets[idx];
+    if (bucket->cnt == 3)
+        return false;
+    for (int i = 0; i < bucket->cnt; i++) {
+        if (bucket->keys[i] == key)
+            return false;
+    }
+    bucket->keys[bucket->cnt] = key;
+    bucket->cnt++;
+    return true;
+}
+
+/*
+ * Hash tree manangement
+ */
+static htree_node *do_htree_node_alloc(uint8_t hash_depth)
+{
+    size_t ntotal = sizeof(htree_node);
+
+    htree_node *node = do_item_mem_alloc(ntotal, LRU_CLSID_FOR_SMALL);
+    if (node != NULL) {
+        node->slabs_clsid = slabs_clsid(ntotal);
+        assert(node->slabs_clsid > 0);
+
+        node->refcount    = 0;
+        node->hdepth      = hash_depth;
+        node->tot_elem_cnt = 0;
+        memset(node->hcnt, 0, HTREE_HASHTAB_SIZE*sizeof(uint16_t));
+        memset(node->htab, 0, HTREE_HASHTAB_SIZE*sizeof(void*));
+    }
+    return node;
+}
+
+static void do_htree_node_free(htree_node *node)
+{
+    do_item_mem_free(node, sizeof(htree_node));
+}
+
+static void do_htree_node_link(htree_meta *htree,
+                             htree_node *par_node, const int par_hidx,
+                             htree_node *node)
+{
+    if (par_node == NULL) {
+        htree->root = node;
+    } else {
+        htree_elem_item *elem;
+        while (par_node->htab[par_hidx] != NULL) {
+            elem = par_node->htab[par_hidx];
+            par_node->htab[par_hidx] = elem->next;
+
+            int hidx = HTREE_GET_HASHIDX(elem->hval, node->hdepth);
+            elem->next = node->htab[hidx];
+            node->htab[hidx] = elem;
+            node->hcnt[hidx] += 1;
+            node->tot_elem_cnt += 1;
+        }
+        assert(node->tot_elem_cnt == par_node->hcnt[par_hidx]);
+        par_node->htab[par_hidx] = node;
+        par_node->hcnt[par_hidx] = -1; /* child hash node */
+    }
+}
+
+static void do_htree_node_unlink(htree_meta *htree,
+                                 htree_node *par_node, const int par_hidx)
+{
+    htree_node *node;
+
+    if (par_node == NULL) {
+        node = htree->root;
+        htree->root = NULL;
+        assert(node->tot_elem_cnt == 0);
+    } else {
+        assert(par_node->hcnt[par_hidx] == -1); /* child hash node */
+        htree_elem_item *head = NULL;
+        htree_elem_item *elem;
+        int hidx, fcnt = 0;
+
+        node = (htree_node *)par_node->htab[par_hidx];
+        assert(node->tot_elem_cnt < (HTREE_MAX_HASHCHAIN_SIZE/2));
+
+        for (hidx = 0; hidx < HTREE_HASHTAB_SIZE; hidx++) {
+            assert(node->hcnt[hidx] >= 0);
+            if (node->hcnt[hidx] > 0) {
+                fcnt += node->hcnt[hidx];
+                while (node->htab[hidx] != NULL) {
+                    elem = node->htab[hidx];
+                    node->htab[hidx] = elem->next;
+                    node->hcnt[hidx] -= 1;
+
+                    elem->next = head;
+                    head = elem;
+                }
+                assert(node->hcnt[hidx] == 0);
+            }
+        }
+        assert(fcnt == node->tot_elem_cnt);
+        node->tot_elem_cnt = 0;
+
+        par_node->htab[par_hidx] = head;
+        par_node->hcnt[par_hidx] = fcnt;
+    }
+
+    /* free the node */
+    do_htree_node_free(node);
+}
+
+static ENGINE_ERROR_CODE do_htree_elem_link(htree_meta *htree,
+                                            htree_node *node, int hidx,
+                                            htree_elem_item *elem, size_t *space_increased)
+{
+    if (node->hcnt[hidx] >= HTREE_MAX_HASHCHAIN_SIZE) {
+        htree_node *n_node = do_htree_node_alloc(node->hdepth+1);
+        if (n_node == NULL) {
+            return ENGINE_ENOMEM;
+        }
+        do_htree_node_link(htree, node, hidx, n_node);
+        *space_increased += slabs_space_size(sizeof(htree_node));
+
+        node = n_node;
+        hidx = HTREE_GET_HASHIDX(elem->hval, node->hdepth);
+    }
+
+    elem->linked++;
+    elem->next = node->htab[hidx];
+    node->htab[hidx] = elem;
+    node->hcnt[hidx] += 1;
+    node->tot_elem_cnt += 1;
+
+    htree_node *par_node = htree->root;
+    while (par_node != node) {
+        par_node->tot_elem_cnt += 1;
+        int par_hidx = HTREE_GET_HASHIDX(elem->hval, par_node->hdepth);
+        assert(par_node->hcnt[par_hidx] == -1);
+        par_node = par_node->htab[par_hidx];
+    }
+    return ENGINE_SUCCESS;
+}
+
+static void do_htree_elem_unlink(htree_node *node, const int hidx,
+                                 htree_elem_item *prev, htree_elem_item *elem)
+{
+    if (prev != NULL) prev->next = elem->next;
+    else              node->htab[hidx] = elem->next;
+    elem->linked--;
+    node->hcnt[hidx] -= 1;
+    node->tot_elem_cnt -= 1;
+}
+
+static htree_elem_item *do_htree_elem_delete(htree_meta *htree, htree_node *node,
+                                             const int hval, const char *key, const int nkey,
+                                             size_t *space_decreased)
+{
+    htree_elem_item *deleted = NULL;
+    int hidx = HTREE_GET_HASHIDX(hval, node->hdepth);
+
+    if (node->hcnt[hidx] == -1) {
+        htree_node *child_node = node->htab[hidx];
+        deleted = do_htree_elem_delete(htree, child_node, hval, key, nkey, space_decreased);
+        if (deleted) {
+            if (child_node->tot_elem_cnt < (HTREE_MAX_HASHCHAIN_SIZE/2)) {
+                do_htree_node_unlink(htree, node, hidx);
+                *space_decreased += slabs_space_size(sizeof(htree_node));
+            }
+            node->tot_elem_cnt -= 1;
+        }
+    } else {
+        if (node->hcnt[hidx] > 0) {
+            htree_elem_item *prev = NULL;
+            htree_elem_item *elem = node->htab[hidx];
+            while (elem != NULL) {
+                uint16_t enkey;
+                const void *ekey = htree->ops->get_key(elem, &enkey);
+                if (htree_hash_eq(hval, key, nkey, elem->hval, ekey, enkey)) {
+                    do_htree_elem_unlink(node, hidx, prev, elem);
+                    deleted = elem;
+                    break;
+                }
+                prev = elem;
+                elem = elem->next;
+            }
+        }
+    }
+    return deleted;
+}
+
+static uint32_t do_htree_elem_delete_bulk(htree_meta *htree, htree_node *node, const uint32_t count,
+                                          htree_elem_item **deleted_head,
+                                          size_t *space_decreased)
+{
+    int hidx;
+    uint32_t fcnt = 0;
+
+    for (hidx = 0; hidx < HTREE_HASHTAB_SIZE; hidx++) {
+        if (node->hcnt[hidx] == -1) {
+            htree_node *child_node = (htree_node *)node->htab[hidx];
+            uint32_t rcnt = (count > 0 ? (count - fcnt) : 0);
+            uint32_t ecnt = do_htree_elem_delete_bulk(htree, child_node, rcnt, deleted_head, space_decreased);
+            fcnt += ecnt;
+            if (child_node->tot_elem_cnt < (HTREE_MAX_HASHCHAIN_SIZE/2)) {
+                do_htree_node_unlink(htree, node, hidx);
+                *space_decreased += slabs_space_size(sizeof(htree_node));
+            }
+            node->tot_elem_cnt -= ecnt;
+        } else if (node->hcnt[hidx] > 0) {
+            htree_elem_item *elem = node->htab[hidx];
+            while (elem != NULL) {
+                fcnt++;
+                do_htree_elem_unlink(node, hidx, NULL, elem);
+
+                /* link deleted elem into list; returned to caller */
+                elem->next = *deleted_head;
+                *deleted_head = elem;
+
+                if (count > 0 && fcnt >= count) break;
+                elem = node->htab[hidx];
+            }
+        }
+        if (count > 0 && fcnt >= count) break;
+    }
+    return fcnt;
+}
+
+static bool do_htree_elem_get(htree_meta *htree, htree_node *node,
+                              const int hval, const void *key, const uint16_t nkey,
+                              const bool delete, htree_elem_item **elem_array,
+                              size_t *space_decreased)
+{
+    assert(elem_array != NULL);
+    bool ret;
+    int hidx = HTREE_GET_HASHIDX(hval, node->hdepth);
+
+    if (node->hcnt[hidx] == -1) {
+        htree_node *child_node = node->htab[hidx];
+        ret = do_htree_elem_get(htree, child_node, hval, key, nkey, delete, elem_array, space_decreased);
+        if (ret && delete) {
+            if (child_node->tot_elem_cnt < (HTREE_MAX_HASHCHAIN_SIZE/2)) {
+                do_htree_node_unlink(htree, node, hidx);
+                *space_decreased += slabs_space_size(sizeof(htree_node));
+            }
+            node->tot_elem_cnt -= 1;
+        }
+    } else {
+        ret = false;
+        if (node->hcnt[hidx] > 0) {
+            htree_elem_item *prev = NULL;
+            htree_elem_item *elem = node->htab[hidx];
+            while (elem != NULL) {
+                uint16_t enkey;
+                const void *ekey = htree->ops->get_key(elem, &enkey);
+                if (htree_hash_eq(hval, key, nkey, elem->hval, ekey, enkey)) {
+                    elem->refcount++;
+                    elem_array[0] = elem;
+                    if (delete) {
+                        do_htree_elem_unlink(node, hidx, prev, elem);
+                    }
+                    ret = true;
+                    break;
+                }
+                prev = elem;
+                elem = elem->next;
+            }
+        }
+    }
+    return ret;
+}
+
+static uint32_t do_htree_elem_get_bulk(htree_meta *htree, htree_node *node, const uint32_t count,
+                                       const bool delete, htree_elem_item **elem_array,
+                                       size_t *space_decreased)
+{
+    assert(elem_array != NULL);
+    int hidx;
+    size_t fcnt = 0; /* found count */
+
+    for (hidx = 0; hidx < HTREE_HASHTAB_SIZE; hidx++) {
+        if (node->hcnt[hidx] == -1) {
+            htree_node *child_node = (htree_node *)node->htab[hidx];
+            size_t rcnt = (count > 0 ? (count - fcnt) : 0);
+            size_t ecnt = do_htree_elem_get_bulk(htree, child_node, rcnt, delete, &elem_array[fcnt], space_decreased);
+            fcnt += ecnt;
+            if (delete) {
+                if (child_node->tot_elem_cnt < (HTREE_MAX_HASHCHAIN_SIZE/2)) {
+                    do_htree_node_unlink(htree, node, hidx);
+                    *space_decreased += slabs_space_size(sizeof(htree_node));
+                }
+                node->tot_elem_cnt -= ecnt;
+            }
+        } else if (node->hcnt[hidx] > 0) {
+            htree_elem_item *elem = node->htab[hidx];
+            while (elem != NULL) {
+                elem->refcount++;
+                elem_array[fcnt] = elem;
+                fcnt++;
+                if (delete) do_htree_elem_unlink(node, hidx, NULL, elem);
+                if (count > 0 && fcnt >= count) break;
+                elem = (delete ? node->htab[hidx] : elem->next);
+            }
+        }
+        if (count > 0 && fcnt >= count) break;
+    }
+    return fcnt;
+}
+
+static htree_elem_item *do_htree_elem_get_by_offset(htree_meta *htree, htree_node *node,
+                                                    uint32_t offset, const bool delete,
+                                                    size_t *space_decreased)
+{
+    int hidx;
+    for (hidx = 0; hidx < HTREE_HASHTAB_SIZE; hidx++) {
+        if (node->hcnt[hidx] == -1) {
+            htree_node *child_node = (htree_node *)node->htab[hidx];
+            if (offset >= child_node->tot_elem_cnt) {
+                offset -= child_node->tot_elem_cnt;
+                continue;
+            }
+            htree_elem_item *found = do_htree_elem_get_by_offset(htree, child_node, offset, delete, space_decreased);
+            if (delete) {
+                if (child_node->tot_elem_cnt < (HTREE_MAX_HASHCHAIN_SIZE/2)) {
+                    do_htree_node_unlink(htree, node, hidx);
+                    *space_decreased += slabs_space_size(sizeof(htree_node));
+                }
+                node->tot_elem_cnt -= 1;
+            }
+            return found;
+        } else if (node->hcnt[hidx] > 0) {
+            if (offset >= node->hcnt[hidx]) {
+                offset -= node->hcnt[hidx];
+                continue;
+            }
+            htree_elem_item *prev = NULL;
+            htree_elem_item *elem = node->htab[hidx];
+            while (offset > 0) {
+                prev = elem;
+                elem = elem->next;
+                offset -= 1;
+            }
+            elem->refcount++;
+            if (delete) do_htree_elem_unlink(node, hidx, prev, elem);
+            return elem;
+        }
+    }
+    return NULL;
+}
+
+static int do_htree_elem_get_sampling(htree_meta *htree, htree_node *node,
+                                      uint32_t remain, const uint32_t count,
+                                      htree_elem_item **elem_array)
+{
+    int hidx;
+    int fcnt = 0; /* found count */
+
+    for (hidx = 0; hidx < HTREE_HASHTAB_SIZE; hidx++) {
+        if (node->hcnt[hidx] == -1) {
+            htree_node *child_node = (htree_node *)node->htab[hidx];
+            fcnt += do_htree_elem_get_sampling(htree, child_node, remain,
+                                               count - fcnt, &elem_array[fcnt]);
+            remain -= child_node->tot_elem_cnt;
+        } else if (node->hcnt[hidx] > 0) {
+            htree_elem_item *elem = node->htab[hidx];
+            while (elem != NULL) {
+                if ((rand() % remain) < (count - fcnt)) {
+                    elem->refcount++;
+                    elem_array[fcnt] = elem;
+                    fcnt++;
+                    if (fcnt >= count) break;
+                }
+                remain -= 1;
+                elem = elem->next;
+            }
+        }
+        if (fcnt >= count) break;
+    }
+    return fcnt;
+}
+
+static uint32_t do_htree_elem_get_rand(htree_meta *htree, const uint32_t count,
+                                       const bool delete, htree_elem_item **elem_array,
+                                       size_t *space_decreased)
+{
+    assert(elem_array != NULL);
+    uint32_t fcnt = 0;
+
+    if (delete) { /* Deleting partial elements */
+        while (fcnt < count) {
+            int rand_offset = (rand() % htree->root->tot_elem_cnt);
+            htree_elem_item *found = do_htree_elem_get_by_offset(htree, htree->root,
+                                                                 rand_offset, delete, space_decreased);
+            assert(found != NULL);
+            elem_array[fcnt++] = found;
+        }
+    } else if (count <= htree->root->tot_elem_cnt / 10) { /* Use hash table */
+        hash_table offset_ht;
+        if (!hash_init(&offset_ht, count))
+            return 0;
+        while (fcnt < count) {
+            int rand_offset = (rand() % htree->root->tot_elem_cnt);
+            if (hash_insert(&offset_ht, rand_offset)) {
+                htree_elem_item *found = do_htree_elem_get_by_offset(htree, htree->root,
+                                                                     rand_offset, false, NULL);
+                assert(found != NULL);
+                elem_array[fcnt++] = found;
+            }
+        }
+        hash_free(&offset_ht);
+    } else { /* Use sampling */
+        fcnt = do_htree_elem_get_sampling(htree, htree->root, htree->root->tot_elem_cnt, count,
+                                          elem_array);
+        for (int i = fcnt - 1; i > 0; i--) {
+            int rand_idx = rand() % (i + 1);
+            if (rand_idx != i) {
+                htree_elem_item *temp = elem_array[i];
+                elem_array[i] = elem_array[rand_idx];
+                elem_array[rand_idx] = temp;
+            }
+        }
+    }
+    return fcnt;
+}
+
+static void do_htree_traverse_advance(htree_elem_posi *posi)
+{
+    while (posi->depth >= 0) {
+        htree_node *node = posi->path[posi->depth].node;
+        int hidx;
+
+        for (hidx = posi->path[posi->depth].hidx; hidx < HTREE_HASHTAB_SIZE; hidx++) {
+            if (node->hcnt[hidx] == -1) {
+                posi->path[posi->depth].hidx = hidx + 1;
+                posi->depth++;
+                posi->path[posi->depth].node = (htree_node *)node->htab[hidx];
+                posi->path[posi->depth].hidx = 0;
+                break;
+            } else if (node->hcnt[hidx] > 0) {
+                posi->path[posi->depth].hidx = hidx + 1;
+                posi->curr = (htree_elem_item *)node->htab[hidx];
+                return;
+            }
+        }
+        if (hidx >= HTREE_HASHTAB_SIZE) posi->depth--;
+    }
+    posi->curr = NULL;
+}
+
+/*
+ * Hash tree Interface Functions
+ */
+void htree_init(htree_meta *htree, htree_ops *ops)
+{
+    htree->root = NULL;
+    htree->ops  = ops;
+}
+
+htree_elem_item *htree_elem_find(htree_meta *htree,
+                                 const int hval,
+                                 const void *key, uint16_t nkey,
+                                 htree_prev_info *pinfo)
+{
+    if (htree->root == NULL) {
+        return NULL;
+    }
+
+    htree_node *node = htree->root;
+    int hidx;
+
+    while (node != NULL) {
+        hidx = HTREE_GET_HASHIDX(hval, node->hdepth);
+        if (node->hcnt[hidx] >= 0)
+            break;
+        node = node->htab[hidx];
+    }
+
+    htree_elem_item *prev = NULL;
+    htree_elem_item *elem;
+    for (elem = node->htab[hidx]; elem != NULL; elem = elem->next) {
+        uint16_t enkey;
+        const void *ekey = htree->ops->get_key(elem, &enkey);
+        if (htree_hash_eq(hval, key, nkey, elem->hval, ekey, enkey))
+            break;
+        prev = elem;
+    }
+
+    if (pinfo != NULL) {
+        pinfo->node = node;
+        pinfo->prev = prev;
+        pinfo->hidx = hidx;
+    }
+
+    return elem;
+}
+
+ENGINE_ERROR_CODE htree_elem_insert(htree_meta *htree, htree_elem_item *elem,
+                                    size_t *space_increased)
+{
+    htree_node *node;
+    int hidx;
+
+    /* create the root hash node if it does not exist */
+    if (htree->root == NULL) {
+        node = do_htree_node_alloc(0);
+        if (node == NULL) {
+            return ENGINE_ENOMEM;
+        }
+        do_htree_node_link(htree, NULL, 0, node);
+        *space_increased += slabs_space_size(sizeof(htree_node));
+
+        hidx = HTREE_GET_HASHIDX(elem->hval, 0);
+        return do_htree_elem_link(htree, node, hidx, elem, space_increased);
+    }
+
+    htree_elem_item *find;
+    htree_prev_info pinfo;
+
+    uint16_t nkey;
+    const void *key = htree->ops->get_key(elem, &nkey);
+    find = htree_elem_find(htree, elem->hval, key, nkey, &pinfo);
+    if (find != NULL) {
+        return ENGINE_ELEM_EEXISTS;
+    }
+
+    node = pinfo.node;
+    hidx = pinfo.hidx;
+    return do_htree_elem_link(htree, node, hidx, elem, space_increased);
+}
+
+ENGINE_ERROR_CODE htree_elem_add(htree_meta *htree, htree_elem_item *elem,
+                                 htree_prev_info *pinfo, size_t *space_increased)
+{
+    htree_node *node;
+    int hidx;
+
+    if (htree->root == NULL) {
+        node = do_htree_node_alloc(0);
+        if (node == NULL) {
+            return ENGINE_ENOMEM;
+        }
+        do_htree_node_link(htree, NULL, 0, node);
+        *space_increased += slabs_space_size(sizeof(htree_node));
+
+        hidx = HTREE_GET_HASHIDX(elem->hval, 0);
+        return do_htree_elem_link(htree, node, hidx, elem, space_increased);
+    }
+
+    node = pinfo->node;
+    hidx = pinfo->hidx;
+    return do_htree_elem_link(htree, node, hidx, elem, space_increased);
+}
+
+htree_elem_item *htree_elem_replace(htree_prev_info *pinfo, htree_elem_item *new_elem)
+{
+    htree_elem_item *prev = pinfo->prev;
+    htree_elem_item *old_elem;
+    int hidx = pinfo->hidx;
+
+    if (prev != NULL) {
+        old_elem = prev->next;
+    } else {
+        old_elem = (htree_elem_item *)pinfo->node->htab[hidx];
+    }
+    assert(new_elem->hval == old_elem->hval);
+
+    new_elem->next = old_elem->next;
+    if (prev != NULL) {
+        prev->next = new_elem;
+    } else {
+        pinfo->node->htab[hidx] = new_elem;
+    }
+    new_elem->linked++;
+
+    old_elem->linked--;
+    assert(old_elem->linked == 0);
+
+    return old_elem;
+}
+
+htree_elem_item *htree_elem_delete(htree_meta *htree,
+                                   const int hval, const char *key, const int nkey,
+                                   size_t *space_decreased)
+{
+    htree_elem_item *deleted = do_htree_elem_delete(htree, htree->root, hval, key, nkey, space_decreased);
+
+    if (deleted != NULL && htree->root->tot_elem_cnt == 0) {
+        do_htree_node_unlink(htree, NULL, 0);
+        *space_decreased += slabs_space_size(sizeof(htree_node));
+    }
+    return deleted;
+}
+
+uint32_t htree_elem_delete_bulk(htree_meta *htree, const uint32_t count,
+                                htree_elem_item **deleted_head,
+                                size_t *space_decreased)
+{
+    int fcnt = do_htree_elem_delete_bulk(htree, htree->root, count, deleted_head, space_decreased);
+
+    if (fcnt > 0 && htree->root->tot_elem_cnt == 0) {
+        do_htree_node_unlink(htree, NULL, 0);
+        *space_decreased += slabs_space_size(sizeof(htree_node));
+    }
+
+    return fcnt;
+}
+
+bool htree_elem_get(htree_meta *htree,
+                    const int hval, const void *key, const uint16_t nkey,
+                    const bool delete, htree_elem_item **elem_array,
+                    size_t *space_decreased)
+{
+    bool ret = do_htree_elem_get(htree, htree->root, hval, key, nkey, delete, elem_array, space_decreased);
+
+    if (delete) {
+        if (ret && htree->root->tot_elem_cnt == 0) {
+            do_htree_node_unlink(htree, NULL, 0);
+            *space_decreased += slabs_space_size(sizeof(htree_node));
+        }
+    }
+
+    return ret;
+}
+
+uint32_t htree_elem_get_bulk(htree_meta *htree, const uint32_t count,
+                             const bool delete, htree_elem_item **elem_array,
+                             size_t *space_decreased)
+{
+    uint32_t fcnt = do_htree_elem_get_bulk(htree, htree->root, count, delete, elem_array, space_decreased);
+
+    if (delete) {
+        if (fcnt > 0 && htree->root->tot_elem_cnt == 0) {
+            do_htree_node_unlink(htree, NULL, 0);
+            *space_decreased += slabs_space_size(sizeof(htree_node));
+        }
+    }
+
+    return fcnt;
+}
+
+uint32_t htree_elem_get_rand(htree_meta *htree, const uint32_t count,
+                             const bool delete, htree_elem_item **elem_array,
+                             size_t *space_decreased)
+{
+    uint32_t fcnt = do_htree_elem_get_rand(htree, count, delete, elem_array, space_decreased);
+
+    if (delete) {
+        if (fcnt > 0 && htree->root->tot_elem_cnt == 0) {
+            do_htree_node_unlink(htree, NULL, 0);
+            *space_decreased += slabs_space_size(sizeof(htree_node));
+        }
+    }
+
+    return fcnt;
+}
+
+void htree_traverse_init(htree_meta *htree, void *posi)
+{
+    htree_elem_posi *ep = (htree_elem_posi *)posi;
+    if (htree->root == NULL) {
+        ep->curr = NULL;
+        return;
+    }
+    ep->path[0].node = htree->root;
+    ep->path[0].hidx = 0;
+    ep->depth = 0;
+    do_htree_traverse_advance(ep);
+}
+
+uint32_t htree_traverse_next(void *posi, void **elem_array, uint32_t count)
+{
+    htree_elem_posi *ep = (htree_elem_posi *)posi;
+    uint32_t fcnt = 0;
+    while (fcnt < count && ep->curr != NULL) {
+        ep->curr->refcount++;
+        elem_array[fcnt++] = ep->curr;
+        if (ep->curr->next != NULL)
+            ep->curr = ep->curr->next;
+        else
+            do_htree_traverse_advance(ep);
+    }
+    return fcnt;
+}

--- a/engines/default/hash_tree.h
+++ b/engines/default/hash_tree.h
@@ -1,0 +1,107 @@
+/*
+ * arcus-memcached - Arcus memory cache server
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2020 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef HASH_TREE_H
+#define HASH_TREE_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include <sys/types.h>
+#include <memcached/engine.h>
+
+#define HTREE_HASHTAB_SIZE 16
+
+extern int genhash_string_hash(const void* p, size_t nkey);
+
+/* Layout contract for hash-tree elements.
+ * Any elem_item used with hash_tree functions must begin with these
+ * fields in this exact order. Fields beyond this point may differ. */
+typedef struct _htree_elem_item {
+    uint16_t refcount;
+    uint8_t  slabs_clsid;          /* which slab class we're in */
+    uint8_t  linked;               /* link count */
+    uint8_t  reserved[4];          /* available for use by the caller's own header fields */
+    struct _htree_elem_item *next; /* hash chain next */
+    uint32_t hval;                 /* hash value */
+} htree_elem_item;
+
+typedef struct _htree_node {
+    uint16_t refcount;
+    uint8_t  slabs_clsid;
+    uint8_t  hdepth;
+    uint32_t tot_elem_cnt;
+    int16_t  hcnt[HTREE_HASHTAB_SIZE];
+    void    *htab[HTREE_HASHTAB_SIZE];
+} htree_node;
+
+/* ops: collection-specific key extraction */
+typedef struct {
+    const void *(*get_key)(const htree_elem_item *elem, uint16_t *nkey);
+} htree_ops;
+
+typedef struct _htree_meta {
+    htree_node *root;
+    htree_ops  *ops;
+} htree_meta;
+
+typedef struct {
+    htree_node      *node;
+    htree_elem_item *prev;
+    int              hidx;
+} htree_prev_info;
+
+void htree_init(htree_meta *htree, htree_ops *ops);
+
+htree_elem_item *htree_elem_find(htree_meta *htree,
+                                 const int hval,
+                                 const void *key, uint16_t nkey,
+                                 htree_prev_info *pinfo);
+
+ENGINE_ERROR_CODE htree_elem_insert(htree_meta *htree, htree_elem_item *elem,
+                                    size_t *space_increased);
+
+ENGINE_ERROR_CODE htree_elem_add(htree_meta *htree, htree_elem_item *elem,
+                                 htree_prev_info *pinfo, size_t *space_increased);
+
+htree_elem_item *htree_elem_replace(htree_prev_info *pinfo, htree_elem_item *new_elem);
+
+htree_elem_item *htree_elem_delete(htree_meta *htree,
+                                   const int hval, const char *key, const int nkey,
+                                   size_t *space_decreased);
+
+uint32_t htree_elem_delete_bulk(htree_meta *htree, const uint32_t count,
+                                htree_elem_item **deleted_head,
+                                size_t *space_decreased);
+
+bool htree_elem_get(htree_meta *htree,
+                    const int hval, const void *key, const uint16_t nkey,
+                    const bool delete, htree_elem_item **elem_array,
+                    size_t *space_decreased);
+
+uint32_t htree_elem_get_bulk(htree_meta *htree, const uint32_t count,
+                             const bool delete, htree_elem_item **elem_array,
+                             size_t *space_decreased);
+
+uint32_t htree_elem_get_rand(htree_meta *htree, const uint32_t count,
+                             const bool delete, htree_elem_item **elem_array,
+                             size_t *space_decreased);
+
+void htree_traverse_init(htree_meta *htree, void *posi);
+uint32_t htree_traverse_next(void *posi, void **elem_array, uint32_t count);
+
+#endif

--- a/engines/default/item_base.h
+++ b/engines/default/item_base.h
@@ -18,6 +18,7 @@
 #ifndef ITEM_BASE_H
 #define ITEM_BASE_H
 
+#include "hash_tree.h"
 #include <memcached/engine.h>
 #include <memcached/util.h>
 #include <memcached/visibility.h>
@@ -225,15 +226,6 @@ typedef struct _list_meta_info {
 #define SET_HASHIDX_MASK 0x0000000F
 #define SET_MAX_HASHCHAIN_SIZE 64
 
-typedef struct _set_hash_node {
-    uint16_t refcount;
-    uint8_t  slabs_clsid;         /* which slab class we're in */
-    uint8_t  hdepth;
-    uint32_t tot_elem_cnt;
-    int16_t  hcnt[SET_HASHTAB_SIZE];
-    void    *htab[SET_HASHTAB_SIZE];
-} set_hash_node;
-
 typedef struct _set_meta_info {
     int32_t  mcnt;      /* maximum count */
     int32_t  ccnt;      /* current count */
@@ -241,22 +233,13 @@ typedef struct _set_meta_info {
     uint8_t  mflags;    /* sticky, readable flags */
     uint16_t itdist;    /* distance from hash item (unit: sizeof(size_t)) */
     uint32_t stotal;    /* total space */
-    set_hash_node *root;
+    htree_meta htree;
 } set_meta_info;
 
 /* map meta info */
 #define MAP_HASHTAB_SIZE 16
 #define MAP_HASHIDX_MASK 0x0000000F
 #define MAP_MAX_HASHCHAIN_SIZE 64
-
-typedef struct _map_hash_node {
-    uint16_t refcount;
-    uint8_t  slabs_clsid;         /* which slab class we're in */
-    uint8_t  hdepth;
-    uint32_t tot_elem_cnt;
-    int16_t  hcnt[MAP_HASHTAB_SIZE];
-    void    *htab[MAP_HASHTAB_SIZE];
-} map_hash_node;
 
 typedef struct _map_meta_info {
     int32_t  mcnt;      /* maximum count */
@@ -265,7 +248,7 @@ typedef struct _map_meta_info {
     uint8_t  mflags;    /* sticky, readable flags */
     uint16_t itdist;    /* distance from hash item (unit: sizeof(size_t)) */
     uint32_t stotal;    /* total space */
-    map_hash_node *root;
+    htree_meta htree;
 } map_meta_info;
 
 /* btree meta info */


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/844#issuecomment-4278095307

### ⌨️ What I did

set / map 컬렉션에서 hash tree 관련 자료구조와 연산을 `hash_tree.c` / `hash_tree.h`로 추출했습니다.
이는 향후 zset(sorted set) 구현 시 hash tree를 재사용하기 위한 준비 작업입니다.

- **구조체 통일 및 타입 마이그레이션**
set_hash_node / map_hash_node를 공통 타입인 `htree_node`로 통일하고,
root 접근을 `info->root` 직접 참조에서 `htree_meta` 구조체를 통한 접근으로 변경했습니다.
단건 탐색/삽입/교체에 사용하는 위치 정보는 `htree_prev_info`로,
순차 순회 상태는 `htree_elem_posi`로 역할을 분리하여 정의했습니다.

- **htree 레이어 함수 분리**
set / map 각각의 insert, get, delete 로직에서 hash tree 순수 연산 부분을 `do_htree_*` 함수로 분리하고,
컬렉션 계층(CLOG 기록, ccnt 관리, space accounting)과 경계를 구분했습니다.