### PR TITLE
FIX: Replace return false with exit(EXIT_FAILURE) in main on engine init failure

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -16738,7 +16738,7 @@ int main (int argc, char **argv)
     }
 
     if (!init_engine(engine_handle, settings.engine_config, mc_logger)) {
-        return false;
+        exit(EXIT_FAILURE);
     }
 
     if (settings.verbose > 0) {


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
-

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
<img width="1171" height="141" alt="image" src="https://github.com/user-attachments/assets/fae6ce0b-8652-4243-9e3c-f72442a6e9a3" />


`main` 함수에서 엔진 초기화 실패 시 `return false`로 종료하고 있었습니다.
`false`는 0으로 변환되어 정상 종료로 처리되는 버그이며,`-std=gnu23` 환경에서는 bool literal을 `int` 반환 함수에서 반환하는 것으로 `-Wmain` 경고도 함께 발생했습니다.
`exit(EXIT_FAILURE)`로 수정했습니다.