### PR TITLE
INTERNAL: Separate collection layer logic from btree elem unlink

### DIFF
--- a/engines/default/coll_btree.c
+++ b/engines/default/coll_btree.c
@@ -95,6 +95,12 @@ typedef struct _btree_scan_info {
     int32_t          next; /* for free scan link */
 } btree_scan_info;
 
+/* btree delete context */
+typedef struct {
+    btree_meta_info        *info;
+    enum elem_delete_cause  cause;
+} btree_delete_ctx;
+
 /* btree position debugging */
 static bool btree_position_debug = false;
 
@@ -1672,25 +1678,13 @@ static void do_btree_node_merge(btree_meta_info *info, btree_elem_posi *path,
     }
 }
 
-static void do_btree_elem_unlink(btree_meta_info *info, btree_elem_posi *path,
-                                 enum elem_delete_cause cause)
+static void do_btree_elem_unlink(btree_meta_info *info, btree_elem_posi *path)
 {
     btree_elem_posi *posi = &path[0];
     btree_elem_item *elem = BTREE_GET_ELEM_ITEM(posi->node, posi->indx);
     int i;
 
-    if (info->stotal > 0) { /* apply memory space */
-        size_t stotal = slabs_space_size(do_btree_elem_ntotal(elem));
-        do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_BTREE, stotal);
-    }
-
-    CLOG_BTREE_ELEM_DELETE(info, elem, cause);
-
     elem->linked--;
-    assert(elem->linked == 0);
-    if (elem->refcount == 0) {
-        do_btree_elem_free(elem);
-    }
 
     /* remove the element from the leaf node */
     btree_indx_node *node = posi->node;
@@ -1703,10 +1697,26 @@ static void do_btree_elem_unlink(btree_meta_info *info, btree_elem_posi *path,
     for (i = 1; i <= info->root->ndepth; i++) {
         path[i].node->ecnt[path[i].indx]--;
     }
-    info->ccnt--;
-
     if (node->used_count < (BTREE_ITEM_COUNT/2)) {
         do_btree_node_merge(info, path, true, 1);
+    }
+}
+
+static void do_btree_elem_delete_post(btree_elem_item *elem, void *arg)
+{
+    btree_delete_ctx *ctx = (btree_delete_ctx *)arg;
+    btree_meta_info *info = ctx->info;
+    enum elem_delete_cause cause = ctx->cause;
+
+    CLOG_BTREE_ELEM_DELETE(info, elem, cause);
+    info->ccnt--;
+    if (info->stotal > 0) { /* apply memory space */
+        size_t stotal = slabs_space_size(do_btree_elem_ntotal(elem));
+        do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_BTREE, stotal);
+    }
+    assert(elem->linked == 0);
+    if (elem->refcount == 0) {
+        do_btree_elem_free(elem);
     }
 }
 
@@ -1911,6 +1921,7 @@ static uint32_t do_btree_elem_delete(btree_meta_info *info,
                                      const uint32_t count, uint32_t *opcost,
                                      enum elem_delete_cause cause)
 {
+    btree_delete_ctx delete_ctx = {info, cause};
     btree_indx_node *root = info->root;
     btree_elem_item *elem;
     btree_elem_posi path[BTREE_MAX_DEPTH];
@@ -1927,15 +1938,14 @@ static uint32_t do_btree_elem_delete(btree_meta_info *info,
         assert(path[0].bkeq == true);
         if (opcost) *opcost += 1;
         if (offset == 0 && (efilter == NULL || do_btree_elem_filter(elem, efilter))) {
-            /* cause == ELEM_DELETE_NORMAL */
-            do_btree_elem_unlink(info, path, cause);
+            do_btree_elem_unlink(info, path);
+            do_btree_elem_delete_post(elem, &delete_ctx);
             tot_found = 1;
         }
     } else {
         btree_elem_posi upth[BTREE_MAX_DEPTH]; /* upper node path */
         btree_elem_posi c_posi = path[0];
         btree_elem_posi s_posi = c_posi; /* save the current posi */
-        size_t   tot_space = 0;
         uint32_t cur_found = 0;
         uint32_t node_cnt = 1;
         uint32_t skip_cnt = 0;
@@ -1943,6 +1953,7 @@ static uint32_t do_btree_elem_delete(btree_meta_info *info,
         bool forward = (bkrtype == BKEY_RANGE_TYPE_ASC ? true : false);
 
         CLOG_ELEM_DELETE_BEGIN((coll_meta_info*)info, count, cause);
+
         /* prepare upper node path
          * used to incr/decr element counts in upper nodes.
          */
@@ -1958,15 +1969,9 @@ static uint32_t do_btree_elem_delete(btree_meta_info *info,
                 if (skip_cnt < offset) {
                     skip_cnt++;
                 } else {
-                    tot_space += slabs_space_size(do_btree_elem_ntotal(elem));
-
-                    CLOG_BTREE_ELEM_DELETE(info, elem, cause);
                     elem->linked--;
-                    assert(elem->linked == 0);
-                    if (elem->refcount == 0) {
-                        do_btree_elem_free(elem);
-                    }
                     c_posi.node->item[c_posi.indx] = NULL;
+                    do_btree_elem_delete_post(elem, &delete_ctx);
 
                     cur_found++;
                     if (count > 0 && (tot_found+cur_found) >= count) break;
@@ -2012,17 +2017,7 @@ static uint32_t do_btree_elem_delete(btree_meta_info *info,
             }
             tot_found += cur_found;
         }
-
         if (tot_found > 0) {
-            info->ccnt -= tot_found;
-            if (info->stotal > 0) { /* apply memory space */
-                /* The btree might have been unlinked from hash table.
-                 * If then, the btree doesn't have prefix info and has stotal of 0.
-                 * So, do not need to decrease space total info.
-                 */
-                assert(tot_space <= info->stotal);
-                do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_BTREE, tot_space);
-            }
             do_btree_node_merge(info, path, forward, node_cnt);
         }
         CLOG_ELEM_DELETE_END((coll_meta_info*)info, cause);
@@ -2188,12 +2183,12 @@ static void do_btree_overflow_trim(btree_meta_info *info,
         del_count = do_btree_elem_delete(info, bkrtype, &bkrange_space, NULL, 0,
                                          0, NULL, ELEM_DELETE_TRIM);
         assert(del_count > 0);
-        assert(info->ccnt > 0);
         if (info->ovflact == OVFL_SMALLEST_TRIM || info->ovflact == OVFL_LARGEST_TRIM)
             info->mflags &= ~COLL_META_FLAG_TRIMMED; // clear trimmed
     } else { /* overflow_type == OVFL_TYPE_COUNT */
         assert(overflow_type == OVFL_TYPE_COUNT);
 
+        btree_delete_ctx delete_ctx = {info, ELEM_DELETE_TRIM};
         btree_elem_posi delpath[BTREE_MAX_DEPTH];
         assert(info->root->ndepth < BTREE_MAX_DEPTH);
         if (info->ovflact == OVFL_SMALLEST_TRIM || info->ovflact == OVFL_SMALLEST_SILENT_TRIM) {
@@ -2203,13 +2198,17 @@ static void do_btree_overflow_trim(btree_meta_info *info,
             delpath[0].node = do_btree_get_last_leaf(info->root, delpath);
             delpath[0].indx = delpath[0].node->used_count - 1;
         }
+
+        btree_elem_item *edge_elem = BTREE_GET_ELEM_ITEM(delpath[0].node, delpath[0].indx);
         if (trimmed_elems != NULL) {
-            btree_elem_item *edge_elem = BTREE_GET_ELEM_ITEM(delpath[0].node, delpath[0].indx);
             edge_elem->refcount++;
             *trimmed_elems = edge_elem;
             *trimmed_count = 1;
         }
-        do_btree_elem_unlink(info, delpath, ELEM_DELETE_TRIM);
+
+        do_btree_elem_unlink(info, delpath);
+        do_btree_elem_delete_post(edge_elem, &delete_ctx);
+
         if (info->ovflact == OVFL_SMALLEST_TRIM || info->ovflact == OVFL_LARGEST_TRIM)
             info->mflags |= COLL_META_FLAG_TRIMMED; // set trimmed
     }
@@ -2346,6 +2345,7 @@ static uint32_t do_btree_elem_get(btree_meta_info *info,
     btree_elem_item *elem;
     btree_elem_posi path[BTREE_MAX_DEPTH];
     uint32_t tot_found = 0; /* found count */
+    btree_delete_ctx delete_ctx = {info, ELEM_DELETE_NORMAL};
 
     if (opcost) *opcost = 0;
     *potentialbkeytrim = false;
@@ -2367,14 +2367,14 @@ static uint32_t do_btree_elem_get(btree_meta_info *info,
             elem->refcount++;
             elem_array[tot_found++] = elem;
             if (delete) {
-                do_btree_elem_unlink(info, path, ELEM_DELETE_NORMAL);
+                do_btree_elem_unlink(info, path);
+                do_btree_elem_delete_post(elem, &delete_ctx);
             }
         }
     } else {
         btree_elem_posi upth[BTREE_MAX_DEPTH]; /* upper node path */
         btree_elem_posi c_posi = path[0];
         btree_elem_posi s_posi = c_posi; /* save the current posi */
-        size_t   tot_space = 0;
         uint32_t cur_found = 0;
         uint32_t node_cnt = 1;
         uint32_t skip_cnt = 0;
@@ -2408,11 +2408,9 @@ static uint32_t do_btree_elem_get(btree_meta_info *info,
                     elem->refcount++;
                     elem_array[tot_found+cur_found] = elem;
                     if (delete) {
-                        tot_space += slabs_space_size(do_btree_elem_ntotal(elem));
                         elem->linked--;
-                        assert(elem->linked == 0);
                         c_posi.node->item[c_posi.indx] = NULL;
-                        CLOG_BTREE_ELEM_DELETE(info, elem, ELEM_DELETE_NORMAL);
+                        do_btree_elem_delete_post(elem, &delete_ctx);
                     }
                     cur_found++;
                     if (count > 0 && (tot_found+cur_found) >= count) break;
@@ -2463,10 +2461,7 @@ static uint32_t do_btree_elem_get(btree_meta_info *info,
             tot_found += cur_found;
         }
 
-        if (delete && tot_found > 0) { /* apply memory space */
-            info->ccnt -= tot_found;
-            assert(tot_space <= info->stotal);
-            do_coll_space_decr((coll_meta_info *)info, ITEM_TYPE_BTREE, tot_space);
+        if (delete && tot_found > 0) {
             do_btree_node_merge(info, path, forward, node_cnt);
         }
 


### PR DESCRIPTION
### 🔗 Related Issue

- https://github.com/jam2in/arcus-works/issues/844#issuecomment-5043688049

### ⌨️ What I did

`coll_btree.c`의 btree element 삭제 로직에서 순수 자료구조 레이어와 컬렉션 레이어를 분리했습니다.

### 배경

btree element를 삭제할 때는 두 종류의 작업이 필요합니다.

- **자료구조 레이어**: 트리에서 노드 슬롯을 비우고, 상위 노드의 카운트를 갱신하며, 필요하면 노드를 병합하거나 해제하는 순수 트리 로직
- **컬렉션 레이어**: CLOG 기록, `ccnt`/`stotal` 갱신, element 메모리 해제

현재는 이 두 작업이 `coll_btree.c` 안에 뒤섞여 있습니다. 향후 자료구조 레이어를 `ds_btree.c`로 추출할 예정이기에 이를 분리했습니다.

자료구조 레이어에서 element를 unlink 시키고 컬렉션에서 넘겨준 콜백함수를 실행하게 할 예정입니다.

<details>
<summary>
<b>왜 콜백 패턴을 선택했는지</b>
</summary>

insert와 달리 delete는 caller가 어떤 element가 삭제될지 모르는 상태로 함수를 호출합니다.

그렇기 때문에 컬렉션 레이어에서 CLOG 기록, `ccnt`/`stotal` 갱신, element free 처리를 하려면 자료구조 레이어에서 unlink된 element를 돌려받아야 합니다.

가장 단순한 방법은 unlink된 element 포인터를 배열로 반환하는 것입니다.

그러나 range delete처럼 대량 삭제가 발생하는 경우 `deleted_elem[]` 배열을 힙에 할당해야 하는데,
최악의 경우 `MAXIMUM_MAX_COLL_SIZE`(100만 개) × 8바이트 = 약 8MB를 추가로 점유합니다. 할당 실패 위험도 있습니다.

그래서 element가 unlink되는 시점에 바로 콜백을 호출하는 방식을 선택했습니다.
배열 할당 없이 O(1) 공간으로 컬렉션 레이어 작업을 처리할 수 있습니다.

+) Redis의 `dict` 자료구조도 동일한 방식을 사용하고 있었습니다. `dictType`에 `keyDestructor` / `valDestructor`를 등록해두고, entry 삭제 시 내부에서 콜백을 호출하는 구조입니다.

</details>

----

###  변경 내용
#### 1. 콜백 함수 `do_btree_elem_delete_post` 정의

1. CLOG 기록
2. `ccnt` 감소
3. `stotal` 갱신
4. element free

를 하나의 함수로 묶었습니다.

시그니처는 `(btree_elem_item *elem, void *arg)` 로 정의했습니다.

#### 2. 콜백 인자 구조체 `btree_delete_ctx` 정의

콜백 함수가 컬렉션 레이어 작업을 수행하려면 `coll_meta_info *info`와 `enum elem_delete_cause cause`가 필요합니다. 이 두 값을 묶어 `void *arg`로 전달할 수 있도록 구조체를 정의했습니다.

```c
typedef struct {
    btree_meta_info        *info;
    enum elem_delete_cause  cause;
} btree_delete_ctx;
```

----

### 추가 고려 사항

1. 기존 range delete에서는 삭제된 element의 space를 누적해두었다가 루프 종료 후 `do_coll_space_decr`를 한 번만 호출했습니다. `do_btree_elem_delete_post`로 통일하면 element마다 호출됩니다.
  `do_coll_space_decr`는 락을 잡지 않고(내부 구현에 있는 lock 연산이 주석 처리되어 있습니다.) 단순 산술 연산만 수행하기 때문에 element당 호출과 배치 호출 간 성능 차이가 없습니다. 따라서 일관성을 위해 `do_btree_elem_delete_post`로 통일했습니다.

2. 콜백 함수 도입 자체에는 합의가 됐으나, 콜백 함수 인자 구조에 대해서는 아직 모두가 만족하는 방안이 나오지 않은 상태입니다. 일단 현재 구조로 도입하고, 더 나은 아이디어가 나오면 추후 개선하는 것으로 결정했습니다.


----

### 향후 계획

다음 단계로 `do_btree_elem_link`의 컬렉션 레이어와 자료구조 레이어를 분리할 예정입니다. insert, replace 등의 함수가 함께 변경되며, `do_map_elem_insert` 패턴을 따라 리팩토링할 계획입니다. 두 작업을 하나의 PR로 올리려 했으나 diff를 한눈에 파악하기 어려워 별도 PR로 분리해서 올리겠습니다.