### PR TITLE
INTERNAL: Fix a Cyrussasl installation error on macOS

### DIFF
--- a/deps/install.sh
+++ b/deps/install.sh
@@ -68,7 +68,7 @@ echo "---------------------------------------------------"
 ## Install dependencies
 build_and_install $libevent "$prefix --disable-openssl"
 build_and_install $zookeeper $prefix
-build_and_install $cyrussasl $prefix
+build_and_install $cyrussasl "$prefix --disable-macos-framework"
 
 popd > /dev/null
 


### PR DESCRIPTION
### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- macOS에서 Cyrussasl 라이브러리 빌드 과정에서 발생하는 에러를 수정합니다.
  - 개발 환경이 MacOS인 경우, SASL 기능을 사용할 때 불편함이 있습니다.
  - 해당 원인은 Cyrussasl이 빌드 과정에서 시스템 파일을 수정하려 해서 발생한 것으로 보입니다.
  - Cyrussasl `configure` 과정에 `--disable-macos-framework`를 포함하면 시스템 파일을 건드리는 것을 방지할 수 있습니다.
