### PR TITLE
FIX: Include config.h in hash_tree.c before other headers

### DIFF
--- a/engines/default/hash_tree.c
+++ b/engines/default/hash_tree.c
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "config.h"
 #include "hash_tree.h"
 #include "default_engine.h"
 #include <stdlib.h>


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
-

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
`hash_tree.c`는 `config.h` 없이 `hash_tree.h`를 먼저 include하고 있었습니다.
`hash_tree.h`가 include하는 `engine.h` → `types.h`에서 `hslice_t` 등의 타입이
`#ifdef ENABLE_MIGRATION` 안에 정의되어 있어, `config.h`가 먼저 처리되지 않으면
include guard로 인해 해당 타입이 미정의 상태로 남게 됩니다.

다른 `.c` 파일들과 동일하게 `config.h`를 첫 번째 include로 추가했습니다.

