### PR TITLE
INTERNAL: Rename do_btree_get_bkey to do_btree_copy_bkey

### DIFF
--- a/engines/default/coll_btree.c
+++ b/engines/default/coll_btree.c
@@ -362,7 +362,7 @@ static inline btree_indx_node *do_btree_get_last_leaf(btree_indx_node *node,
     return node;
 }
 
-static inline void do_btree_get_bkey(btree_elem_item *elem, bkey_t *bkey)
+static inline void do_btree_copy_bkey(btree_elem_item *elem, bkey_t *bkey)
 {
     if (elem->nbkey > 0) {
         bkey->len = elem->nbkey;
@@ -4057,8 +4057,8 @@ ENGINE_ERROR_CODE btree_coll_getattr(hash_item *it, item_attr *attrp,
     if (info->ccnt > 0) {
         btree_elem_item *min_bkey_elem = do_btree_get_first_elem(info->root);
         btree_elem_item *max_bkey_elem = do_btree_get_last_elem(info->root);
-        do_btree_get_bkey(min_bkey_elem, &attrp->minbkey);
-        do_btree_get_bkey(max_bkey_elem, &attrp->maxbkey);
+        do_btree_copy_bkey(min_bkey_elem, &attrp->minbkey);
+        do_btree_copy_bkey(max_bkey_elem, &attrp->maxbkey);
     }
     return ENGINE_SUCCESS;
 }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/844#issuecomment-5043688049

### ⌨️ What I did

- ds_btree ops 콜백으로 등록될 `btree_get_bkey`와의 혼동을 방지하기 위해
  `do_btree_get_bkey`를 `do_btree_copy_bkey`로 변경했습니다.