### PR TITLE
INTERNAL: Cap hash tree node split depth

### DIFF
--- a/engines/default/hash_tree.c
+++ b/engines/default/hash_tree.c
@@ -106,7 +106,7 @@ static htree_node *do_htree_node_alloc(uint8_t hash_depth)
         node->refcount    = 0;
         node->hdepth      = hash_depth;
         node->tot_elem_cnt = 0;
-        memset(node->hcnt, 0, HTREE_HASHTAB_SIZE*sizeof(uint16_t));
+        memset(node->hcnt, 0, HTREE_HASHTAB_SIZE*sizeof(int32_t));
         memset(node->htab, 0, HTREE_HASHTAB_SIZE*sizeof(void*));
     }
     return node;
@@ -189,7 +189,7 @@ static ENGINE_ERROR_CODE do_htree_elem_link(htree_meta *htree,
                                             htree_node *node, int hidx,
                                             htree_elem_item *elem, size_t *space_increased)
 {
-    if (node->hcnt[hidx] >= HTREE_MAX_HASHCHAIN_SIZE) {
+    if (node->hcnt[hidx] >= HTREE_MAX_HASHCHAIN_SIZE && node->hdepth+1 < HTREE_MAX_DEPTH) {
         htree_node *n_node = do_htree_node_alloc(node->hdepth+1);
         if (n_node == NULL) {
             return ENGINE_ENOMEM;

--- a/engines/default/hash_tree.h
+++ b/engines/default/hash_tree.h
@@ -45,7 +45,7 @@ typedef struct _htree_node {
     uint8_t  slabs_clsid;
     uint8_t  hdepth;
     uint32_t tot_elem_cnt;
-    int16_t  hcnt[HTREE_HASHTAB_SIZE];
+    int32_t  hcnt[HTREE_HASHTAB_SIZE];
     void    *htab[HTREE_HASHTAB_SIZE];
 } htree_node;
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/859#issue-5246096593

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
### 배경

기존에는 hash collision이 발생하면 hash chain에 이어서 연결되다가, chain 크기가 `HTREE_MAX_HASHCHAIN_SIZE`를 넘어가면 node를 split하여 depth를 늘리고 elem을 재분배하는 구조였습니다.

문제는 collision이 계속 발생하는 키들의 경우 split한 노드에서도 같은 hash index로 다시 몰려서, 결국 depth가 무한정 늘어나면서 chain에 계속 연결되는 상황이 발생할 수 있습니다. hash tree 탐색 함수들은 depth만큼 재귀 호출을 하는 구조라서, depth가 늘어날수록 stack overflow 위험이 커집니다.

### 변경 사항

- depth가 `HTREE_MAX_DEPTH`에 도달하면 더 이상 node split을 하지 않고, 해당 chain에 그대로 연결되도록 변경했습니다. 이를 통해 재귀 호출 깊이가 `HTREE_MAX_DEPTH`로 고정되어 stack overflow 위험을 없앴습니다.
- 위 변경으로 인해 worst case에서는 하나의 chain에 collection의 maxcount(최대 100만)까지 연결될 수 있습니다. 기존 `hcnt` 타입(`int16_t`, 최대 32767)으로는 이를 감당할 수 없어 `int32_t`로 확장했습니다.