### PR TITLE
INTERNAL: Extract typed value operations to typed_ops.h

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -165,6 +165,8 @@ default_engine_la_SOURCES= \
                     engines/default/prefix.h \
                     engines/default/assoc.c \
                     engines/default/assoc.h \
+                    engines/default/typed_ops.c \
+                    engines/default/typed_ops.h \
                     engines/default/items.c \
                     engines/default/items.h \
                     engines/default/item_clog.c \

--- a/engines/default/coll_btree.c
+++ b/engines/default/coll_btree.c
@@ -33,6 +33,7 @@
 
 #include "default_engine.h"
 #include "item_clog.h"
+#include "typed_ops.h"
 
 static struct default_engine *engine=NULL;
 static struct engine_config  *config=NULL; // engine config
@@ -374,171 +375,6 @@ static inline void do_btree_get_bkey(btree_elem_item *elem, bkey_t *bkey)
 }
 
 /******************* BKEY COMPARISION CODE *************************/
-static inline int UINT64_COMP(const uint64_t *v1, const uint64_t *v2)
-{
-    if (*v1 == *v2) return  0;
-    if (*v1 <  *v2) return -1;
-    else            return  1;
-}
-
-static inline bool UINT64_ISEQ(const uint64_t *v1, const uint64_t *v2)
-{
-    return ((*v1 == *v2) ? true : false);
-}
-
-static inline bool UINT64_ISNE(const uint64_t *v1, const uint64_t *v2)
-{
-    return ((*v1 != *v2) ? true : false);
-}
-
-static inline bool UINT64_ISLT(const uint64_t *v1, const uint64_t *v2)
-{
-    return ((*v1 <  *v2) ? true : false);
-}
-
-static inline bool UINT64_ISLE(const uint64_t *v1, const uint64_t *v2)
-{
-    return ((*v1 <= *v2) ? true : false);
-}
-
-static inline bool UINT64_ISGT(const uint64_t *v1, const uint64_t *v2)
-{
-    return ((*v1 >  *v2) ? true : false);
-}
-
-static inline bool UINT64_ISGE(const uint64_t *v1, const uint64_t *v2)
-{
-    return ((*v1 >= *v2) ? true : false);
-}
-
-static inline int BINARY_COMP(const unsigned char *v1, const int nv1,
-                              const unsigned char *v2, const int nv2)
-{
-    assert(nv1 > 0 && nv2 > 0);
-    int min_nv = (nv1 < nv2 ? nv1 : nv2);
-    for (int i=0; i < min_nv; i++) {
-        if (v1[i] == v2[i]) continue;
-        if (v1[i] <  v2[i]) return -1;
-        else                return  1;
-    }
-    if (nv1 == nv2) return  0;
-    if (nv1 <  nv2) return -1;
-    else            return  1;
-}
-
-static inline bool BINARY_ISEQ(const unsigned char *v1, const int nv1,
-                               const unsigned char *v2, const int nv2)
-{
-    assert(nv1 > 0 && nv2 > 0);
-    if (nv1 != nv2) return false;
-    for (int i=0; i < nv1; i++) {
-        if (v1[i] != v2[i]) return false;
-    }
-    return true;
-}
-
-static inline bool BINARY_ISNE(const unsigned char *v1, const int nv1,
-                               const unsigned char *v2, const int nv2)
-{
-    assert(nv1 > 0 && nv2 > 0);
-    if (nv1 != nv2) return true;
-    for (int i=0; i < nv1; i++) {
-        if (v1[i] != v2[i]) return true;
-    }
-    return false;
-}
-
-static inline bool BINARY_ISLT(const unsigned char *v1, const int nv1,
-                               const unsigned char *v2, const int nv2)
-{
-    assert(nv1 > 0 && nv2 > 0);
-    int min_nv = (nv1 < nv2 ? nv1 : nv2);
-    for (int i=0; i < min_nv; i++) {
-        if (v1[i] == v2[i]) continue;
-        if (v1[i] <  v2[i]) return true;
-        else                return false;
-    }
-    if (nv1 < nv2) return true;
-    else           return false;
-}
-
-static inline bool BINARY_ISLE(const unsigned char *v1, const int nv1,
-                               const unsigned char *v2, const int nv2)
-{
-    assert(nv1 > 0 && nv2 > 0);
-    int min_nv = (nv1 < nv2 ? nv1 : nv2);
-    for (int i=0; i < min_nv; i++) {
-        if (v1[i] == v2[i]) continue;
-        if (v1[i] <  v2[i]) return true;
-        else                return false;
-    }
-    if (nv1 <= nv2) return true;
-    else            return false;
-}
-
-static inline bool BINARY_ISGT(const unsigned char *v1, const int nv1,
-                               const unsigned char *v2, const int nv2)
-{
-    assert(nv1 > 0 && nv2 > 0);
-    int min_nv = (nv1 < nv2 ? nv1 : nv2);
-    for (int i=0; i < min_nv; i++) {
-        if (v1[i] == v2[i]) continue;
-        if (v1[i] >  v2[i]) return true;
-        else                return false;
-    }
-    if (nv1 > nv2) return true;
-    else           return false;
-}
-
-static inline bool BINARY_ISGE(const unsigned char *v1, const int nv1,
-                               const unsigned char *v2, const int nv2)
-{
-    assert(nv1 > 0 && nv2 > 0);
-    int min_nv = (nv1 < nv2 ? nv1 : nv2);
-    for (int i=0; i < min_nv; i++) {
-        if (v1[i] == v2[i]) continue;
-        if (v1[i] >  v2[i]) return true;
-        else                return false;
-    }
-    if (nv1 >= nv2) return true;
-    else            return false;
-}
-
-static inline void BINARY_AND(const unsigned char *v1, const unsigned char *v2,
-                              const int length, unsigned char *result)
-{
-    for (int i=0; i < length; i++) {
-        result[i] = v1[i] & v2[i];
-    }
-}
-
-static inline void BINARY_OR(const unsigned char *v1, const unsigned char *v2,
-                             const int length, unsigned char *result)
-{
-    for (int i=0; i < length; i++) {
-        result[i] = v1[i] | v2[i];
-    }
-}
-
-static inline void BINARY_XOR(const unsigned char *v1, const unsigned char *v2,
-                              const int length, unsigned char *result)
-{
-    for (int i=0; i < length; i++) {
-        result[i] = v1[i] ^ v2[i];
-    }
-}
-
-static bool (*UINT64_COMPARE_OP[COMPARE_OP_MAX]) (const uint64_t *v1, const uint64_t *v2)
-    = { UINT64_ISEQ, UINT64_ISNE, UINT64_ISLT, UINT64_ISLE, UINT64_ISGT, UINT64_ISGE };
-
-static bool (*BINARY_COMPARE_OP[COMPARE_OP_MAX]) (const unsigned char *v1, const int nv1,
-                                                  const unsigned char *v2, const int nv2)
-    = { BINARY_ISEQ, BINARY_ISNE, BINARY_ISLT, BINARY_ISLE, BINARY_ISGT, BINARY_ISGE };
-
-static void (*BINARY_BITWISE_OP[BITWISE_OP_MAX]) (const unsigned char *v1, const unsigned char *v2,
-                                                  const int length, unsigned char *result)
-    = { BINARY_AND, BINARY_OR, BINARY_XOR };
-
 #define BKEY_COMP(bk1, nbk1, bk2, nbk2) \
         (((nbk1)==0 && (nbk2)==0) ? UINT64_COMP((const uint64_t*)(bk1),(const uint64_t*)(bk2)) \
                                   : BINARY_COMP((bk1),(nbk1),(bk2),(nbk2)))
@@ -586,121 +422,17 @@ static int btree_elem_cmp(const void *bkey, uint32_t nbkey, const btree_elem_ite
 /******************* BKEY COMPARISION CODE *************************/
 
 /**************** MAX BKEY RANGE MANIPULATION **********************/
-static inline void UINT64_COPY(const uint64_t *v, uint64_t *result)
-{
-    *result = *v;
-}
-
-static inline void UINT64_DIFF(const uint64_t *v1, const uint64_t *v2, uint64_t *result)
-{
-    assert(*v1 >= *v2);
-    *result = *v1 - *v2;
-}
-
-#if 0 // OLD_CODE
-static inline void UINT64_INCR(uint64_t *v)
-{
-    assert(*v < UINT64_MAX);
-    *v += 1;
-}
-#endif
-
-static inline void UINT64_DECR(uint64_t *v)
-{
-    assert(*v > 0);
-    *v -= 1;
-}
-
-static inline void BINARY_COPY(const unsigned char *v, const int length,
-                               unsigned char *result)
-{
-    if (length > 0)
-        memcpy(result, v, length);
-}
-
-static inline void BINARY_DIFF(unsigned char *v1, const uint8_t nv1,
-                               unsigned char *v2, const uint8_t nv2,
-                               const int length, unsigned char *result)
-{
-    assert(length > 0);
-    unsigned char bkey1_space[MAX_BKEY_LENG];
-    unsigned char bkey2_space[MAX_BKEY_LENG];
-    int i, subtraction;
-
-    if (nv1 < length) {
-        memcpy(bkey1_space, v1, nv1);
-        for (i=nv1; i<length; i++)
-            bkey1_space[i] = 0x00;
-        v1 = bkey1_space;
-    }
-    if (nv2 < length) {
-        memcpy(bkey2_space, v2, nv2);
-        for (i=nv2; i<length; i++)
-            bkey2_space[i] = 0x00;
-        v2 = bkey2_space;
-    }
-
-    /* assume that the value of v1 >= the value of v2 */
-    subtraction = 0;
-    for (i = (length-1); i >= 0; i--) {
-        if (subtraction == 0) {
-            if (v1[i] >= v2[i]) {
-                result[i] = v1[i] - v2[i];
-            } else {
-                result[i] = 0xFF - v2[i] + v1[i] + 1;
-                subtraction = 1;
-            }
-        } else {
-            if (v1[i] > v2[i]) {
-                result[i] = v1[i] - v2[i] - 1;
-                subtraction = 0;
-            } else {
-                result[i] = 0xFF - v2[i] + v1[i];
-            }
-        }
-    }
-}
-
-#if 0 // OLD_CODE
-static inline void BINARY_INCR(unsigned char *v, const int length)
-{
-    assert(length > 0);
-    int i;
-    for (i = (length-1); i >= 0; i--) {
-        if (v[i] < 0xFF) {
-            v[i] += 1;
-            break;
-        }
-        v[i] = 0x00;
-    }
-    assert(i >= 0);
-}
-#endif
-
-static inline void BINARY_DECR(unsigned char *v, const int length)
-{
-    assert(length > 0);
-    int i;
-    for (i = (length-1); i >= 0; i--) {
-        if (v[i] > 0x00) {
-            v[i] -= 1;
-            break;
-        }
-        v[i] = 0xFF;
-    }
-    assert(i >= 0);
-}
-
 #define BKEY_COPY(bk, nbk, res) \
         ((nbk)==0 ? UINT64_COPY((const uint64_t*)(bk), (uint64_t*)(res)) \
                   : BINARY_COPY((bk), (nbk), (res)))
+
 #define BKEY_DIFF(bk1, nbk1, bk2, nbk2, len, res) \
         ((len)==0 ? UINT64_DIFF((const uint64_t*)(bk1), (const uint64_t*)(bk2), (uint64_t*)(res)) \
                   : BINARY_DIFF((bk1), (nbk1), (bk2), (nbk2), (len), (res)))
-#if 0 // OLD_CODE
+
 #define BKEY_INCR(bk, nbk) \
         ((nbk)==0 ? UINT64_INCR((uint64_t*)(bk)) : BINARY_INCR((bk), (nbk)))
-#endif
+
 #define BKEY_DECR(bk, nbk) \
         ((nbk)==0 ? UINT64_DECR((uint64_t*)(bk)) : BINARY_DECR((bk), (nbk)))
 
@@ -4423,13 +4155,6 @@ ENGINE_ERROR_CODE item_btree_coll_init(void *engine_ptr)
     bkey_binary_min[0] = 0x00;
     for (int i=0; i < MAX_BKEY_LENG; i++) {
         bkey_binary_max[i] = 0xFF;
-    }
-
-    /* remove unused function warnings */
-    if (1) {
-        uint64_t val1 = 10;
-        uint64_t val2 = 20;
-        assert(UINT64_COMPARE_OP[COMPARE_OP_LT](&val1, &val2) == true);
     }
 
     logger->log(EXTENSION_LOG_INFO, NULL, "ITEM btree module initialized.\n");

--- a/engines/default/typed_ops.c
+++ b/engines/default/typed_ops.c
@@ -1,0 +1,31 @@
+/* -*- Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ * arcus-memcached - Arcus memory cache server
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2020 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "typed_ops.h"
+
+bool (*UINT64_COMPARE_OP[COMPARE_OP_MAX]) (const uint64_t *v1, const uint64_t *v2)
+    = { UINT64_ISEQ, UINT64_ISNE, UINT64_ISLT, UINT64_ISLE, UINT64_ISGT, UINT64_ISGE };
+
+bool (*BINARY_COMPARE_OP[COMPARE_OP_MAX]) (const unsigned char *v1, const int nv1,
+                                           const unsigned char *v2, const int nv2)
+    = { BINARY_ISEQ, BINARY_ISNE, BINARY_ISLT, BINARY_ISLE, BINARY_ISGT, BINARY_ISGE };
+
+void (*BINARY_BITWISE_OP[BITWISE_OP_MAX]) (const unsigned char *v1, const unsigned char *v2,
+                                           const int length, unsigned char *result)
+    = { BINARY_AND, BINARY_OR, BINARY_XOR };

--- a/engines/default/typed_ops.h
+++ b/engines/default/typed_ops.h
@@ -1,0 +1,291 @@
+/*
+ * arcus-memcached - Arcus memory cache server
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2020 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TYPED_OPS_H
+#define TYPED_OPS_H
+
+#include "memcached/types.h"
+#include <assert.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <string.h>
+
+static inline int UINT64_COMP(const uint64_t *v1, const uint64_t *v2)
+{
+    if (*v1 == *v2) return  0;
+    if (*v1 <  *v2) return -1;
+    else            return  1;
+}
+
+static inline bool UINT64_ISEQ(const uint64_t *v1, const uint64_t *v2)
+{
+    return ((*v1 == *v2) ? true : false);
+}
+
+static inline bool UINT64_ISNE(const uint64_t *v1, const uint64_t *v2)
+{
+    return ((*v1 != *v2) ? true : false);
+}
+
+static inline bool UINT64_ISLT(const uint64_t *v1, const uint64_t *v2)
+{
+    return ((*v1 <  *v2) ? true : false);
+}
+
+static inline bool UINT64_ISLE(const uint64_t *v1, const uint64_t *v2)
+{
+    return ((*v1 <= *v2) ? true : false);
+}
+
+static inline bool UINT64_ISGT(const uint64_t *v1, const uint64_t *v2)
+{
+    return ((*v1 >  *v2) ? true : false);
+}
+
+static inline bool UINT64_ISGE(const uint64_t *v1, const uint64_t *v2)
+{
+    return ((*v1 >= *v2) ? true : false);
+}
+
+static inline void UINT64_COPY(const uint64_t *v, uint64_t *result)
+{
+    *result = *v;
+}
+
+static inline void UINT64_DIFF(const uint64_t *v1, const uint64_t *v2, uint64_t *result)
+{
+    assert(*v1 >= *v2);
+    *result = *v1 - *v2;
+}
+
+static inline void UINT64_INCR(uint64_t *v)
+{
+    assert(*v < UINT64_MAX);
+    *v += 1;
+}
+
+static inline void UINT64_DECR(uint64_t *v)
+{
+    assert(*v > 0);
+    *v -= 1;
+}
+
+static inline int BINARY_COMP(const unsigned char *v1, const int nv1,
+                              const unsigned char *v2, const int nv2)
+{
+    assert(nv1 > 0 && nv2 > 0);
+    int min_nv = (nv1 < nv2 ? nv1 : nv2);
+    for (int i=0; i < min_nv; i++) {
+        if (v1[i] == v2[i]) continue;
+        if (v1[i] <  v2[i]) return -1;
+        else                return  1;
+    }
+    if (nv1 == nv2) return  0;
+    if (nv1 <  nv2) return -1;
+    else            return  1;
+}
+
+static inline bool BINARY_ISEQ(const unsigned char *v1, const int nv1,
+                               const unsigned char *v2, const int nv2)
+{
+    assert(nv1 > 0 && nv2 > 0);
+    if (nv1 != nv2) return false;
+    for (int i=0; i < nv1; i++) {
+        if (v1[i] != v2[i]) return false;
+    }
+    return true;
+}
+
+static inline bool BINARY_ISNE(const unsigned char *v1, const int nv1,
+                               const unsigned char *v2, const int nv2)
+{
+    assert(nv1 > 0 && nv2 > 0);
+    if (nv1 != nv2) return true;
+    for (int i=0; i < nv1; i++) {
+        if (v1[i] != v2[i]) return true;
+    }
+    return false;
+}
+
+static inline bool BINARY_ISLT(const unsigned char *v1, const int nv1,
+                               const unsigned char *v2, const int nv2)
+{
+    assert(nv1 > 0 && nv2 > 0);
+    int min_nv = (nv1 < nv2 ? nv1 : nv2);
+    for (int i=0; i < min_nv; i++) {
+        if (v1[i] == v2[i]) continue;
+        if (v1[i] <  v2[i]) return true;
+        else                return false;
+    }
+    if (nv1 < nv2) return true;
+    else           return false;
+}
+
+static inline bool BINARY_ISLE(const unsigned char *v1, const int nv1,
+                               const unsigned char *v2, const int nv2)
+{
+    assert(nv1 > 0 && nv2 > 0);
+    int min_nv = (nv1 < nv2 ? nv1 : nv2);
+    for (int i=0; i < min_nv; i++) {
+        if (v1[i] == v2[i]) continue;
+        if (v1[i] <  v2[i]) return true;
+        else                return false;
+    }
+    if (nv1 <= nv2) return true;
+    else            return false;
+}
+
+static inline bool BINARY_ISGT(const unsigned char *v1, const int nv1,
+                               const unsigned char *v2, const int nv2)
+{
+    assert(nv1 > 0 && nv2 > 0);
+    int min_nv = (nv1 < nv2 ? nv1 : nv2);
+    for (int i=0; i < min_nv; i++) {
+        if (v1[i] == v2[i]) continue;
+        if (v1[i] >  v2[i]) return true;
+        else                return false;
+    }
+    if (nv1 > nv2) return true;
+    else           return false;
+}
+
+static inline bool BINARY_ISGE(const unsigned char *v1, const int nv1,
+                               const unsigned char *v2, const int nv2)
+{
+    assert(nv1 > 0 && nv2 > 0);
+    int min_nv = (nv1 < nv2 ? nv1 : nv2);
+    for (int i=0; i < min_nv; i++) {
+        if (v1[i] == v2[i]) continue;
+        if (v1[i] >  v2[i]) return true;
+        else                return false;
+    }
+    if (nv1 >= nv2) return true;
+    else            return false;
+}
+
+static inline void BINARY_COPY(const unsigned char *v, const int length,
+                               unsigned char *result)
+{
+    if (length > 0)
+        memcpy(result, v, length);
+}
+
+static inline void BINARY_DIFF(const unsigned char *v1, const uint8_t nv1,
+                               const unsigned char *v2, const uint8_t nv2,
+                               const int precision, unsigned char *result)
+{
+    assert(precision > 0);
+    unsigned char bkey1_space[MAX_BKEY_LENG];
+    unsigned char bkey2_space[MAX_BKEY_LENG];
+    int i, subtraction;
+
+    if (nv1 < precision) {
+        memcpy(bkey1_space, v1, nv1);
+        for (i=nv1; i<precision; i++)
+            bkey1_space[i] = 0x00;
+        v1 = bkey1_space;
+    }
+    if (nv2 < precision) {
+        memcpy(bkey2_space, v2, nv2);
+        for (i=nv2; i<precision; i++)
+            bkey2_space[i] = 0x00;
+        v2 = bkey2_space;
+    }
+
+    /* assume that the value of v1 >= the value of v2 */
+    subtraction = 0;
+    for (i = (precision-1); i >= 0; i--) {
+        if (subtraction == 0) {
+            if (v1[i] >= v2[i]) {
+                result[i] = v1[i] - v2[i];
+            } else {
+                result[i] = 0xFF - v2[i] + v1[i] + 1;
+                subtraction = 1;
+            }
+        } else {
+            if (v1[i] > v2[i]) {
+                result[i] = v1[i] - v2[i] - 1;
+                subtraction = 0;
+            } else {
+                result[i] = 0xFF - v2[i] + v1[i];
+            }
+        }
+    }
+}
+
+static inline void BINARY_INCR(unsigned char *v, const int length)
+{
+    assert(length > 0);
+    int i;
+    for (i = (length-1); i >= 0; i--) {
+        if (v[i] < 0xFF) {
+            v[i] += 1;
+            break;
+        }
+        v[i] = 0x00;
+    }
+    assert(i >= 0);
+}
+
+static inline void BINARY_DECR(unsigned char *v, const int length)
+{
+    assert(length > 0);
+    int i;
+    for (i = (length-1); i >= 0; i--) {
+        if (v[i] > 0x00) {
+            v[i] -= 1;
+            break;
+        }
+        v[i] = 0xFF;
+    }
+    assert(i >= 0);
+}
+
+static inline void BINARY_AND(const unsigned char *v1, const unsigned char *v2,
+                              const int length, unsigned char *result)
+{
+    for (int i=0; i < length; i++) {
+        result[i] = v1[i] & v2[i];
+    }
+}
+
+static inline void BINARY_OR(const unsigned char *v1, const unsigned char *v2,
+                             const int length, unsigned char *result)
+{
+    for (int i=0; i < length; i++) {
+        result[i] = v1[i] | v2[i];
+    }
+}
+
+static inline void BINARY_XOR(const unsigned char *v1, const unsigned char *v2,
+                              const int length, unsigned char *result)
+{
+    for (int i=0; i < length; i++) {
+        result[i] = v1[i] ^ v2[i];
+    }
+}
+
+extern bool (*UINT64_COMPARE_OP[COMPARE_OP_MAX]) (const uint64_t *v1, const uint64_t *v2);
+
+extern bool (*BINARY_COMPARE_OP[COMPARE_OP_MAX]) (const unsigned char *v1, const int nv1,
+                                                  const unsigned char *v2, const int nv2);
+
+extern void (*BINARY_BITWISE_OP[BITWISE_OP_MAX]) (const unsigned char *v1, const unsigned char *v2,
+                                                  const int length, unsigned char *result);
+
+#endif


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/844#issuecomment-5043688049

### ⌨️ What I did

- btree 리팩토링 사전 작업으로, uint64/binary 타입별 비교·산술·비트 연산(`UINT64_*`, `BINARY_*`)을 `typed_ops.h`로 추출했습니다.
- `coll_btree.c`에서 사용되지 않는 `BKEY_ISEQ`, `BKEY_ISLE`, `BKEY_ISGE` 매크로를 제거했습니다.
- BINARY_DIFF의 `const int length` 인자명을 `precision`으로 변경했습니다.
- 다음으로 btree bkey 조작 관련 매크로들의 리팩토링 PR을 올릴 예정입니다.
