### PR TITLE
INTERNAL: Refactor bkey manipulation macros for maxbkeyrange

### DIFF
--- a/engines/default/cmdlogrec.c
+++ b/engines/default/cmdlogrec.c
@@ -1131,11 +1131,11 @@ static void lrec_bt_elem_delete_logical_write(LogRec *logrec, char *bufptr)
     memcpy(bufptr + offset, log->keyptr, log->body.keylen);
     offset += log->body.keylen;
     /* from bkey copy */
-    memcpy(bufptr + offset, log->bkrangep->from_bkey, real_from_nbkey);
+    memcpy(bufptr + offset, log->bkrangep->from_bkey.val, real_from_nbkey);
     offset += real_from_nbkey;
     /* to bkey copy */
     if (real_to_nbkey != BKEY_NULL) {
-        memcpy(bufptr + offset, log->bkrangep->to_bkey, real_to_nbkey);
+        memcpy(bufptr + offset, log->bkrangep->to_bkey.val, real_to_nbkey);
         offset += real_to_nbkey;
     }
     /* eflag filter copy */
@@ -1163,12 +1163,12 @@ static ENGINE_ERROR_CODE lrec_bt_elem_delete_logical_redo(LogRec *logrec)
 
     /* element range */
     bkey_range bkrange;
-    memcpy(bkrange.from_bkey, from_bkeyptr, real_from_nbkey);
-    bkrange.from_nbkey = body->from_nbkey;
+    memcpy(bkrange.from_bkey.val, from_bkeyptr, real_from_nbkey);
+    bkrange.from_bkey.len = body->from_nbkey;
     if (real_to_nbkey != BKEY_NULL) {
-        memcpy(bkrange.to_bkey, to_bkeyptr, real_to_nbkey);
+        memcpy(bkrange.to_bkey.val, to_bkeyptr, real_to_nbkey);
     }
-    bkrange.to_nbkey = body->to_nbkey;
+    bkrange.to_bkey.len = body->to_nbkey;
 
     /* efilter */
     eflag_filter efilter;
@@ -1787,8 +1787,8 @@ int lrec_construct_btree_elem_delete_logical(LogRec *logrec, hash_item *it,
     log->body.drop   = drop;
     log->body.offset = offset;
     log->body.reqcount = reqcount;
-    log->body.from_nbkey = bkrange->from_nbkey;
-    log->body.to_nbkey = bkrange->to_nbkey;
+    log->body.from_nbkey = bkrange->from_bkey.len;
+    log->body.to_nbkey = bkrange->to_bkey.len;
     log->body.filtering = (efilter == NULL ? 0 : 1);
     if (log->body.filtering) {
         log->body.nbitwval = efilter->nbitwval;

--- a/engines/default/coll_btree.c
+++ b/engines/default/coll_btree.c
@@ -363,17 +363,6 @@ static inline btree_indx_node *do_btree_get_last_leaf(btree_indx_node *node,
     return node;
 }
 
-static inline void do_btree_copy_bkey(btree_elem_item *elem, bkey_t *bkey)
-{
-    if (elem->nbkey > 0) {
-        bkey->len = elem->nbkey;
-        memcpy(bkey->val, elem->data, elem->nbkey);
-    } else {
-        bkey->len = 0;
-        memcpy(bkey->val, elem->data, sizeof(uint64_t));
-    }
-}
-
 /******************* BKEY COMPARISION CODE *************************/
 #define BKEY_COMP(bk1, nbk1, bk2, nbk2) \
         (((nbk1)==0 && (nbk2)==0) ? UINT64_COMP((const uint64_t*)(bk1),(const uint64_t*)(bk2)) \
@@ -422,19 +411,47 @@ static int btree_elem_cmp(const void *bkey, uint32_t nbkey, const btree_elem_ite
 /******************* BKEY COMPARISION CODE *************************/
 
 /**************** MAX BKEY RANGE MANIPULATION **********************/
-#define BKEY_COPY(bk, nbk, res) \
-        ((nbk)==0 ? UINT64_COPY((const uint64_t*)(bk), (uint64_t*)(res)) \
-                  : BINARY_COPY((bk), (nbk), (res)))
+static inline bkey_t BKEY_OF(const btree_elem_item *elem) {
+    bkey_t bkey;
+    if (elem->nbkey > 0) {
+        bkey.len = elem->nbkey;
+        memcpy(bkey.val, elem->data, elem->nbkey);
+    } else {
+        bkey.len = 0;
+        memcpy(bkey.val, elem->data, sizeof(uint64_t));
+    }
+    return bkey;
+}
 
-#define BKEY_DIFF(bk1, nbk1, bk2, nbk2, len, res) \
-        ((len)==0 ? UINT64_DIFF((const uint64_t*)(bk1), (const uint64_t*)(bk2), (uint64_t*)(res)) \
-                  : BINARY_DIFF((bk1), (nbk1), (bk2), (nbk2), (len), (res)))
+static inline bkey_t BKEY_DIFF(const unsigned char *bk1, uint8_t nbk1,
+                               const unsigned char *bk2, uint8_t nbk2,
+                               const int precision)
+{
+    bkey_t result;
+    if (nbk1 == 0 && nbk2 == 0) {
+        result.len = 0;
+        UINT64_DIFF((const uint64_t*)bk1, (const uint64_t*)bk2, (uint64_t*)result.val);
+    } else {
+        result.len = precision;
+        BINARY_DIFF(bk1, nbk1, bk2, nbk2, precision, result.val);
+    }
+    return result;
+}
 
-#define BKEY_INCR(bk, nbk) \
-        ((nbk)==0 ? UINT64_INCR((uint64_t*)(bk)) : BINARY_INCR((bk), (nbk)))
+static inline void BKEY_INCR(bkey_t *bk) {
+    if (bk->len == 0)
+        UINT64_INCR((uint64_t*)bk->val);
+    else
+        BINARY_INCR(bk->val, bk->len);
+}
 
-#define BKEY_DECR(bk, nbk) \
-        ((nbk)==0 ? UINT64_DECR((uint64_t*)(bk)) : BINARY_DECR((bk), (nbk)))
+static inline void BKEY_DECR(bkey_t *bk)
+{
+    if (bk->len == 0)
+        UINT64_DECR((uint64_t*)bk->val);
+    else
+        BINARY_DECR(bk->val, bk->len);
+}
 
 /**************** MAX BKEY RANGE MANIPULATION **********************/
 
@@ -1861,9 +1878,9 @@ static ENGINE_ERROR_CODE do_btree_overflow_check(btree_meta_info *info, btree_el
 
         if (BKEY_ISLT(elem->data, elem->nbkey, min_bkey_elem->data, min_bkey_elem->nbkey))
         {
-            newbkeyrange.len = info->maxbkeyrange.len;
-            BKEY_DIFF(max_bkey_elem->data, max_bkey_elem->nbkey, elem->data, elem->nbkey,
-                      newbkeyrange.len, newbkeyrange.val);
+            newbkeyrange = BKEY_DIFF(max_bkey_elem->data, max_bkey_elem->nbkey,
+                                     elem->data, elem->nbkey,
+                                     info->maxbkeyrange.len);
             if (BKEY_ISGT(newbkeyrange.val, newbkeyrange.len, info->maxbkeyrange.val, info->maxbkeyrange.len))
             {
                 if (info->ovflact == OVFL_LARGEST_TRIM || info->ovflact == OVFL_LARGEST_SILENT_TRIM)
@@ -1874,9 +1891,9 @@ static ENGINE_ERROR_CODE do_btree_overflow_check(btree_meta_info *info, btree_el
         }
         else if (BKEY_ISGT(elem->data, elem->nbkey, max_bkey_elem->data, max_bkey_elem->nbkey))
         {
-            newbkeyrange.len = info->maxbkeyrange.len;
-            BKEY_DIFF(elem->data, elem->nbkey, min_bkey_elem->data, min_bkey_elem->nbkey,
-                      newbkeyrange.len, newbkeyrange.val);
+            newbkeyrange = BKEY_DIFF(elem->data, elem->nbkey,
+                                     min_bkey_elem->data, min_bkey_elem->nbkey,
+                                     info->maxbkeyrange.len);
             if (BKEY_ISGT(newbkeyrange.val, newbkeyrange.len, info->maxbkeyrange.val, info->maxbkeyrange.len))
             {
                 if (info->ovflact == OVFL_SMALLEST_TRIM || info->ovflact == OVFL_SMALLEST_SILENT_TRIM)
@@ -1926,15 +1943,12 @@ static void do_btree_build_smallest_trim_range(btree_meta_info *info,
      * => min bkey ~ (new max bkey - maxbkeyrange - 1)
      */
     /* from bkey */
-    btree_elem_item *edge_elem = do_btree_get_first_elem(info->root);
-    bkrange->from_bkey.len = edge_elem->nbkey;
-    BKEY_COPY(edge_elem->data, edge_elem->nbkey, bkrange->from_bkey.val);
+    bkrange->from_bkey = BKEY_OF(do_btree_get_first_elem(info->root));
     /* to bkey */
-    bkrange->to_bkey.len = info->maxbkeyrange.len;
-    BKEY_DIFF(elem->data, elem->nbkey,
-              info->maxbkeyrange.val, info->maxbkeyrange.len,
-              bkrange->to_bkey.len, bkrange->to_bkey.val);
-    BKEY_DECR(bkrange->to_bkey.val, bkrange->to_bkey.len);
+    bkrange->to_bkey = BKEY_DIFF(elem->data, elem->nbkey,
+                                 info->maxbkeyrange.val, info->maxbkeyrange.len,
+                                 info->maxbkeyrange.len);
+    BKEY_DECR(&bkrange->to_bkey);
 }
 
 static void do_btree_build_largest_trim_range(btree_meta_info *info,
@@ -1946,19 +1960,19 @@ static void do_btree_build_largest_trim_range(btree_meta_info *info,
      */
     /* from bkey */
     btree_elem_item *edge_elem = do_btree_get_last_elem(info->root);
-    bkrange->from_bkey.len = info->maxbkeyrange.len;
-    BKEY_DIFF(edge_elem->data, edge_elem->nbkey, elem->data, elem->nbkey,
-              bkrange->from_bkey.len, bkrange->from_bkey.val);
-    BKEY_DIFF(bkrange->from_bkey.val, bkrange->from_bkey.len,
-              info->maxbkeyrange.val, info->maxbkeyrange.len,
-              bkrange->from_bkey.len, bkrange->from_bkey.val);
-    BKEY_DECR(bkrange->from_bkey.val, bkrange->from_bkey.len);
-    BKEY_DIFF(edge_elem->data, edge_elem->nbkey,
-              bkrange->from_bkey.val, bkrange->from_bkey.len,
-              bkrange->from_bkey.len, bkrange->from_bkey.val);
+    bkrange->from_bkey = BKEY_DIFF(edge_elem->data, edge_elem->nbkey,
+                                   elem->data, elem->nbkey,
+                                   info->maxbkeyrange.len);
+    bkrange->from_bkey = BKEY_DIFF(bkrange->from_bkey.val, bkrange->from_bkey.len,
+                                   info->maxbkeyrange.val, info->maxbkeyrange.len,
+                                   info->maxbkeyrange.len);
+    BKEY_DECR(&bkrange->from_bkey);
+
+    bkrange->from_bkey = BKEY_DIFF(edge_elem->data, edge_elem->nbkey,
+                                   bkrange->from_bkey.val, bkrange->from_bkey.len,
+                                   info->maxbkeyrange.len);
     /* to bkey */
-    bkrange->to_bkey.len = edge_elem->nbkey;
-    BKEY_COPY(edge_elem->data, edge_elem->nbkey, bkrange->to_bkey.val);
+    bkrange->to_bkey = BKEY_OF(edge_elem);
 }
 
 static btree_elem_item *do_btree_delete_first_elem(btree_meta_info *info,
@@ -3815,8 +3829,8 @@ ENGINE_ERROR_CODE btree_coll_getattr(hash_item *it, item_attr *attrp,
     if (info->ccnt > 0) {
         btree_elem_item *min_bkey_elem = do_btree_get_first_elem(info->root);
         btree_elem_item *max_bkey_elem = do_btree_get_last_elem(info->root);
-        do_btree_copy_bkey(min_bkey_elem, &attrp->minbkey);
-        do_btree_copy_bkey(max_bkey_elem, &attrp->maxbkey);
+        attrp->minbkey = BKEY_OF(min_bkey_elem);
+        attrp->maxbkey = BKEY_OF(max_bkey_elem);
     }
     return ENGINE_SUCCESS;
 }
@@ -3860,10 +3874,9 @@ ENGINE_ERROR_CODE btree_coll_setattr(hash_item *it, item_attr *attrp,
                     bkey_t curbkeyrange;
                     btree_elem_item *min_bkey_elem = do_btree_get_first_elem(info->root);
                     btree_elem_item *max_bkey_elem = do_btree_get_last_elem(info->root);
-                    curbkeyrange.len = attrp->maxbkeyrange.len;
-                    BKEY_DIFF(max_bkey_elem->data, max_bkey_elem->nbkey,
-                              min_bkey_elem->data, min_bkey_elem->nbkey,
-                              curbkeyrange.len, curbkeyrange.val);
+                    curbkeyrange = BKEY_DIFF(max_bkey_elem->data, max_bkey_elem->nbkey,
+                                             min_bkey_elem->data, min_bkey_elem->nbkey,
+                                             attrp->maxbkeyrange.len);
                     if (BKEY_ISGT(curbkeyrange.val, curbkeyrange.len,
                                   attrp->maxbkeyrange.val, attrp->maxbkeyrange.len)) {
                         return ENGINE_EBADVALUE;

--- a/engines/default/coll_btree.c
+++ b/engines/default/coll_btree.c
@@ -440,11 +440,11 @@ static int btree_elem_cmp(const void *bkey, uint32_t nbkey, const btree_elem_ite
 
 static int do_btree_bkey_range_type(const bkey_range *bkrange)
 {
-    if (bkrange->to_nbkey == BKEY_NULL) {
+    if (bkrange->to_bkey.len == BKEY_NULL) {
         return BKEY_RANGE_TYPE_SIN;
     } else {
-        int comp = BKEY_COMP(bkrange->from_bkey, bkrange->from_nbkey,
-                             bkrange->to_bkey,   bkrange->to_nbkey);
+        int comp = BKEY_COMP(bkrange->from_bkey.val, bkrange->from_bkey.len,
+                             bkrange->to_bkey.val,   bkrange->to_bkey.len);
         if (comp == 0)      return BKEY_RANGE_TYPE_SIN; /* single bkey */
         else if (comp < 0)  return BKEY_RANGE_TYPE_ASC; /* ascending */
         else                return BKEY_RANGE_TYPE_DSC; /* descending */
@@ -622,7 +622,7 @@ static btree_elem_item *ds_btree_find_first(btree_indx_node *root,
     }
 
     /* find leaf node */
-    node = do_btree_find_leaf(root, bkrange->from_bkey, bkrange->from_nbkey,
+    node = do_btree_find_leaf(root, bkrange->from_bkey.val, bkrange->from_bkey.len,
                               (path_flag ? path : NULL), &elem);
     if (elem != NULL) { /* the bkey(from_bkey) is found */
         /* while traversing to leaf node, the bkey can be found.
@@ -642,7 +642,7 @@ static btree_elem_item *ds_btree_find_first(btree_indx_node *root,
         mid  = (left + right) / 2;
         elem = BTREE_GET_ELEM_ITEM(node, mid);
         bkey = btree_get_bkey(elem, &nbkey);
-        comp = BKEY_COMP(bkrange->from_bkey, bkrange->from_nbkey, bkey, nbkey);
+        comp = BKEY_COMP(bkrange->from_bkey.val, bkrange->from_bkey.len, bkey, nbkey);
         if (comp == 0) break;
         if (comp <  0) right = mid-1;
         else           left  = mid+1;
@@ -699,7 +699,7 @@ static btree_elem_item *ds_btree_find_first(btree_indx_node *root,
             } else {
                 elem = BTREE_GET_ELEM_ITEM(path[0].node, path[0].indx);
                 bkey = btree_get_bkey(elem, &nbkey);
-                if (BKEY_ISGT(bkey, nbkey, bkrange->to_bkey, bkrange->to_nbkey))
+                if (BKEY_ISGT(bkey, nbkey, bkrange->to_bkey.val, bkrange->to_bkey.len))
                     elem = NULL;
             }
             break;
@@ -722,7 +722,7 @@ static btree_elem_item *ds_btree_find_first(btree_indx_node *root,
             } else {
                 elem = BTREE_GET_ELEM_ITEM(path[0].node, path[0].indx);
                 bkey = btree_get_bkey(elem, &nbkey);
-                if (BKEY_ISLT(bkey, nbkey, bkrange->to_bkey, bkrange->to_nbkey))
+                if (BKEY_ISLT(bkey, nbkey, bkrange->to_bkey.val, bkrange->to_bkey.len))
                     elem = NULL;
             }
             break;
@@ -748,7 +748,7 @@ static btree_elem_item *ds_btree_find_next(btree_elem_posi *posi,
         uint32_t nbkey;
         int comp;
         bkey = btree_get_bkey(elem, &nbkey);
-        comp = BKEY_COMP(bkey, nbkey, bkrange->to_bkey, bkrange->to_nbkey);
+        comp = BKEY_COMP(bkey, nbkey, bkrange->to_bkey.val, bkrange->to_bkey.len);
         if (comp == 0) {
             posi->bkeq = true;
         } else {
@@ -778,7 +778,7 @@ static btree_elem_item *ds_btree_find_prev(btree_elem_posi *posi,
         uint32_t nbkey;
         int comp;
         bkey = btree_get_bkey(elem, &nbkey);
-        comp = BKEY_COMP(bkey, nbkey, bkrange->to_bkey, bkrange->to_nbkey);
+        comp = BKEY_COMP(bkey, nbkey, bkrange->to_bkey.val, bkrange->to_bkey.len);
         if (comp == 0) {
             posi->bkeq = true;
         } else {
@@ -1821,25 +1821,25 @@ static inline void get_bkey_full_range(const int bktype, const bool ascend, bkey
 {
     if (bktype == BKEY_TYPE_BINARY) {
         if (ascend) {
-            memcpy(bkrange->from_bkey, bkey_binary_min, MIN_BKEY_LENG);
-            memcpy(bkrange->to_bkey,   bkey_binary_max, MAX_BKEY_LENG);
-            bkrange->from_nbkey = MIN_BKEY_LENG;
-            bkrange->to_nbkey   = MAX_BKEY_LENG;
+            memcpy(bkrange->from_bkey.val, bkey_binary_min, MIN_BKEY_LENG);
+            memcpy(bkrange->to_bkey.val,   bkey_binary_max, MAX_BKEY_LENG);
+            bkrange->from_bkey.len = MIN_BKEY_LENG;
+            bkrange->to_bkey.len   = MAX_BKEY_LENG;
         } else {
-            memcpy(bkrange->from_bkey, bkey_binary_max, MAX_BKEY_LENG);
-            memcpy(bkrange->to_bkey,   bkey_binary_min, MIN_BKEY_LENG);
-            bkrange->from_nbkey = MAX_BKEY_LENG;
-            bkrange->to_nbkey   = MIN_BKEY_LENG;
+            memcpy(bkrange->from_bkey.val, bkey_binary_max, MAX_BKEY_LENG);
+            memcpy(bkrange->to_bkey.val,   bkey_binary_min, MIN_BKEY_LENG);
+            bkrange->from_bkey.len = MAX_BKEY_LENG;
+            bkrange->to_bkey.len   = MIN_BKEY_LENG;
         }
     } else { /* bktype == BKEY_TYPE_UINT64 or BKEY_TYPE_UNKNOWN */
         if (ascend) {
-            memcpy(bkrange->from_bkey, (void*)&bkey_uint64_min, sizeof(uint64_t));
-            memcpy(bkrange->to_bkey,   (void*)&bkey_uint64_max, sizeof(uint64_t));
+            memcpy(bkrange->from_bkey.val, (void*)&bkey_uint64_min, sizeof(uint64_t));
+            memcpy(bkrange->to_bkey.val,   (void*)&bkey_uint64_max, sizeof(uint64_t));
         } else {
-            memcpy(bkrange->from_bkey, (void*)&bkey_uint64_max, sizeof(uint64_t));
-            memcpy(bkrange->to_bkey,   (void*)&bkey_uint64_min, sizeof(uint64_t));
+            memcpy(bkrange->from_bkey.val, (void*)&bkey_uint64_max, sizeof(uint64_t));
+            memcpy(bkrange->to_bkey.val,   (void*)&bkey_uint64_min, sizeof(uint64_t));
         }
-        bkrange->from_nbkey = bkrange->to_nbkey = 0;
+        bkrange->from_bkey.len = bkrange->to_bkey.len = 0;
     }
 }
 #endif
@@ -1927,14 +1927,14 @@ static void do_btree_build_smallest_trim_range(btree_meta_info *info,
      */
     /* from bkey */
     btree_elem_item *edge_elem = do_btree_get_first_elem(info->root);
-    bkrange->from_nbkey = edge_elem->nbkey;
-    BKEY_COPY(edge_elem->data, edge_elem->nbkey, bkrange->from_bkey);
+    bkrange->from_bkey.len = edge_elem->nbkey;
+    BKEY_COPY(edge_elem->data, edge_elem->nbkey, bkrange->from_bkey.val);
     /* to bkey */
-    bkrange->to_nbkey = info->maxbkeyrange.len;
+    bkrange->to_bkey.len = info->maxbkeyrange.len;
     BKEY_DIFF(elem->data, elem->nbkey,
               info->maxbkeyrange.val, info->maxbkeyrange.len,
-              bkrange->to_nbkey, bkrange->to_bkey);
-    BKEY_DECR(bkrange->to_bkey, bkrange->to_nbkey);
+              bkrange->to_bkey.len, bkrange->to_bkey.val);
+    BKEY_DECR(bkrange->to_bkey.val, bkrange->to_bkey.len);
 }
 
 static void do_btree_build_largest_trim_range(btree_meta_info *info,
@@ -1946,19 +1946,19 @@ static void do_btree_build_largest_trim_range(btree_meta_info *info,
      */
     /* from bkey */
     btree_elem_item *edge_elem = do_btree_get_last_elem(info->root);
-    bkrange->from_nbkey = info->maxbkeyrange.len;
+    bkrange->from_bkey.len = info->maxbkeyrange.len;
     BKEY_DIFF(edge_elem->data, edge_elem->nbkey, elem->data, elem->nbkey,
-              bkrange->from_nbkey, bkrange->from_bkey);
-    BKEY_DIFF(bkrange->from_bkey, bkrange->from_nbkey,
+              bkrange->from_bkey.len, bkrange->from_bkey.val);
+    BKEY_DIFF(bkrange->from_bkey.val, bkrange->from_bkey.len,
               info->maxbkeyrange.val, info->maxbkeyrange.len,
-              bkrange->from_nbkey, bkrange->from_bkey);
-    BKEY_DECR(bkrange->from_bkey, bkrange->from_nbkey);
+              bkrange->from_bkey.len, bkrange->from_bkey.val);
+    BKEY_DECR(bkrange->from_bkey.val, bkrange->from_bkey.len);
     BKEY_DIFF(edge_elem->data, edge_elem->nbkey,
-              bkrange->from_bkey, bkrange->from_nbkey,
-              bkrange->from_nbkey, bkrange->from_bkey);
+              bkrange->from_bkey.val, bkrange->from_bkey.len,
+              bkrange->from_bkey.len, bkrange->from_bkey.val);
     /* to bkey */
-    bkrange->to_nbkey = edge_elem->nbkey;
-    BKEY_COPY(edge_elem->data, edge_elem->nbkey, bkrange->to_bkey);
+    bkrange->to_bkey.len = edge_elem->nbkey;
+    BKEY_COPY(edge_elem->data, edge_elem->nbkey, bkrange->to_bkey.val);
 }
 
 static btree_elem_item *do_btree_delete_first_elem(btree_meta_info *info,
@@ -2344,14 +2344,14 @@ static uint32_t do_btree_elem_count(btree_meta_info *info,
         btree_elem_item *max_bkey_elem = do_btree_get_last_elem(info->root);
         int min_comp, max_comp;
         if (bkrtype == BKEY_RANGE_TYPE_ASC) {
-            min_comp = BKEY_COMP(bkrange->from_bkey, bkrange->from_nbkey,
+            min_comp = BKEY_COMP(bkrange->from_bkey.val, bkrange->from_bkey.len,
                                  min_bkey_elem->data, min_bkey_elem->nbkey);
-            max_comp = BKEY_COMP(bkrange->to_bkey, bkrange->to_nbkey,
+            max_comp = BKEY_COMP(bkrange->to_bkey.val, bkrange->to_bkey.len,
                                  max_bkey_elem->data, max_bkey_elem->nbkey);
         } else { /* BKEY_RANGE_TYPE_DSC */
-            min_comp = BKEY_COMP(bkrange->to_bkey, bkrange->to_nbkey,
+            min_comp = BKEY_COMP(bkrange->to_bkey.val, bkrange->to_bkey.len,
                                  min_bkey_elem->data, min_bkey_elem->nbkey);
-            max_comp = BKEY_COMP(bkrange->from_bkey, bkrange->from_nbkey,
+            max_comp = BKEY_COMP(bkrange->from_bkey.val, bkrange->from_bkey.len,
                                  max_bkey_elem->data, max_bkey_elem->nbkey);
         }
         if (min_comp <= 0 && max_comp >= 0) {
@@ -2932,8 +2932,8 @@ do_btree_smget_scan_sort(token_t *key_array, const int key_count,
         if (info->ccnt == 0) { /* empty collection */
             do_item_release(it); continue;
         }
-        if ((info->bktype == BKEY_TYPE_UINT64 && bkrange->from_nbkey >  0) ||
-            (info->bktype == BKEY_TYPE_BINARY && bkrange->from_nbkey == 0)) {
+        if ((info->bktype == BKEY_TYPE_UINT64 && bkrange->from_bkey.len >  0) ||
+            (info->bktype == BKEY_TYPE_BINARY && bkrange->from_bkey.len == 0)) {
             do_item_release(it);
             ret = ENGINE_EBADBKEY; break;
         }
@@ -3380,8 +3380,8 @@ ENGINE_ERROR_CODE btree_elem_update(const char *key, const uint32_t nkey, const 
             if (info->ccnt == 0) {
                 ret = ENGINE_ELEM_ENOENT; break;
             }
-            if ((info->bktype == BKEY_TYPE_UINT64 && bkrange->from_nbkey >  0) ||
-                (info->bktype == BKEY_TYPE_BINARY && bkrange->from_nbkey == 0)) {
+            if ((info->bktype == BKEY_TYPE_UINT64 && bkrange->from_bkey.len >  0) ||
+                (info->bktype == BKEY_TYPE_BINARY && bkrange->from_bkey.len == 0)) {
                 ret = ENGINE_EBADBKEY; break;
             }
             ret = do_btree_elem_update(info, bkrtype, bkrange, eupdate, value, nbytes);
@@ -3414,8 +3414,8 @@ ENGINE_ERROR_CODE btree_elem_delete(const char *key, const uint32_t nkey,
             if (info->ccnt == 0) {
                 ret = ENGINE_ELEM_ENOENT; break;
             }
-            if ((info->bktype == BKEY_TYPE_UINT64 && bkrange->from_nbkey >  0) ||
-                (info->bktype == BKEY_TYPE_BINARY && bkrange->from_nbkey == 0)) {
+            if ((info->bktype == BKEY_TYPE_UINT64 && bkrange->from_bkey.len >  0) ||
+                (info->bktype == BKEY_TYPE_BINARY && bkrange->from_bkey.len == 0)) {
                 ret = ENGINE_EBADBKEY; break;
             }
             *del_count = do_btree_elem_delete(info, bkrtype, bkrange, efilter, 0, req_count,
@@ -3457,7 +3457,7 @@ ENGINE_ERROR_CODE btree_elem_arithmetic(const char *key, const uint32_t nkey,
     ret = do_btree_item_find(key, nkey, DONT_UPDATE, &it);
     if (ret == ENGINE_SUCCESS) {
         btree_meta_info *info = (btree_meta_info *)item_get_meta(it);
-        ret = do_btree_elem_arithmetic(info, bkrange->from_bkey, bkrange->from_nbkey,
+        ret = do_btree_elem_arithmetic(info, bkrange->from_bkey.val, bkrange->from_bkey.len,
                                        increment, create, delta, initial, eflagp, result);
         do_item_release(it);
     }
@@ -3494,8 +3494,8 @@ ENGINE_ERROR_CODE btree_elem_get(const char *key, const uint32_t nkey,
             if (info->ccnt == 0 || offset >= info->ccnt) {
                 ret = ENGINE_ELEM_ENOENT; break;
             }
-            if ((info->bktype == BKEY_TYPE_UINT64 && bkrange->from_nbkey >  0) ||
-                (info->bktype == BKEY_TYPE_BINARY && bkrange->from_nbkey == 0)) {
+            if ((info->bktype == BKEY_TYPE_UINT64 && bkrange->from_bkey.len >  0) ||
+                (info->bktype == BKEY_TYPE_BINARY && bkrange->from_bkey.len == 0)) {
                 ret = ENGINE_EBADBKEY; break;
             }
             if (req_count == 0 || info->ccnt < req_count) {
@@ -3559,8 +3559,8 @@ ENGINE_ERROR_CODE btree_elem_count(const char *key, const uint32_t nkey,
             if ((info->mflags & COLL_META_FLAG_READABLE) == 0) {
                 ret = ENGINE_UNREADABLE; break;
             }
-            if ((info->bktype == BKEY_TYPE_UINT64 && bkrange->from_nbkey >  0) ||
-                (info->bktype == BKEY_TYPE_BINARY && bkrange->from_nbkey == 0)) {
+            if ((info->bktype == BKEY_TYPE_UINT64 && bkrange->from_bkey.len >  0) ||
+                (info->bktype == BKEY_TYPE_BINARY && bkrange->from_bkey.len == 0)) {
                 ret = ENGINE_EBADBKEY; break;
             }
             *elem_count = do_btree_elem_count(info, bkrtype, bkrange, efilter, opcost);
@@ -3590,8 +3590,8 @@ ENGINE_ERROR_CODE btree_posi_find(const char *key, const uint32_t nkey, const bk
             if (info->ccnt == 0) {
                 ret = ENGINE_ELEM_ENOENT; break;
             }
-            if ((info->bktype == BKEY_TYPE_UINT64 && bkrange->from_nbkey >  0) ||
-                (info->bktype == BKEY_TYPE_BINARY && bkrange->from_nbkey == 0)) {
+            if ((info->bktype == BKEY_TYPE_UINT64 && bkrange->from_bkey.len >  0) ||
+                (info->bktype == BKEY_TYPE_BINARY && bkrange->from_bkey.len == 0)) {
                 ret = ENGINE_EBADBKEY; break;
             }
             *position = do_btree_posi_find(info, bkrtype, bkrange, order);
@@ -3626,8 +3626,8 @@ ENGINE_ERROR_CODE btree_posi_find_with_get(const char *key, const uint32_t nkey,
             if (info->ccnt == 0) {
                 ret = ENGINE_ELEM_ENOENT; break;
             }
-            if ((info->bktype == BKEY_TYPE_UINT64 && bkrange->from_nbkey >  0) ||
-                (info->bktype == BKEY_TYPE_BINARY && bkrange->from_nbkey == 0)) {
+            if ((info->bktype == BKEY_TYPE_UINT64 && bkrange->from_bkey.len >  0) ||
+                (info->bktype == BKEY_TYPE_BINARY && bkrange->from_bkey.len == 0)) {
                 ret = ENGINE_EBADBKEY; break;
             }
             if ((eresult->elem_array = (eitem **)malloc((2*count+1)*sizeof(eitem*))) == NULL) {
@@ -4022,10 +4022,10 @@ ENGINE_ERROR_CODE btree_apply_elem_delete(void *engine, hash_item *it,
                 PRINT_NKEY(it->nkey), key, it->nkey, nbkey, bkey, nbkey);
 
     /* one-element range */
-    memcpy(bkrange.from_bkey, bkey, BTREE_REAL_NBKEY(nbkey));
-    bkrange.from_nbkey = nbkey;
+    memcpy(bkrange.from_bkey.val, bkey, BTREE_REAL_NBKEY(nbkey));
+    bkrange.from_bkey.len = nbkey;
     /* bkey_range.to_bkey */
-    bkrange.to_nbkey = BKEY_NULL;
+    bkrange.to_bkey.len = BKEY_NULL;
 
     LOCK_CACHE();
     do {
@@ -4041,8 +4041,8 @@ ENGINE_ERROR_CODE btree_apply_elem_delete(void *engine, hash_item *it,
                         " no element.\n");
             ret = ENGINE_ELEM_ENOENT; break;
         }
-        if ((info->bktype == BKEY_TYPE_UINT64 && bkrange.from_nbkey > 0) ||
-            (info->bktype == BKEY_TYPE_BINARY && bkrange.from_nbkey == 0)) {
+        if ((info->bktype == BKEY_TYPE_UINT64 && bkrange.from_bkey.len > 0) ||
+            (info->bktype == BKEY_TYPE_BINARY && bkrange.from_bkey.len == 0)) {
             logger->log(EXTENSION_LOG_WARNING, NULL, "btree_apply_elem_delete failed."
                         " bkey mismatch. key=%.*s nkey=%u bkey=%.*s nbkey=%u\n",
                         PRINT_NKEY(it->nkey), key, it->nkey, nbkey, bkey, nbkey);
@@ -4102,11 +4102,11 @@ ENGINE_ERROR_CODE btree_apply_elem_delete_logical(void *engine, hash_item *it,
                         " no element.\n");
             ret = ENGINE_ELEM_ENOENT; break;
         }
-        if ((info->bktype == BKEY_TYPE_UINT64 && bkrange->from_nbkey > 0) ||
-            (info->bktype == BKEY_TYPE_BINARY && bkrange->from_nbkey == 0)) {
+        if ((info->bktype == BKEY_TYPE_UINT64 && bkrange->from_bkey.len > 0) ||
+            (info->bktype == BKEY_TYPE_BINARY && bkrange->from_bkey.len == 0)) {
             logger->log(EXTENSION_LOG_WARNING, NULL, "btree_apply_elem_delete_logical failed."
                         " bkey mismatch. key=%.*s nkey=%u from_bkey=%.*s\n",
-                        PRINT_NKEY(it->nkey), key, it->nkey, bkrange->from_nbkey, bkrange->from_bkey);
+                        PRINT_NKEY(it->nkey), key, it->nkey, bkrange->from_bkey.len, bkrange->from_bkey.val);
             ret = ENGINE_EBADBKEY; break;
         }
 
@@ -4116,7 +4116,7 @@ ENGINE_ERROR_CODE btree_apply_elem_delete_logical(void *engine, hash_item *it,
             logger->log(EXTENSION_LOG_INFO, NULL, "btree_apply_elem_delete_logical failed."
                         " no element deleted. key=%.*s nkey=%u from_bkey=%.*s to_bkey=%.*s",
                         PRINT_NKEY(it->nkey), key, it->nkey,
-                        bkrange->from_nbkey, bkrange->from_bkey, bkrange->to_nbkey, bkrange->to_bkey);
+                        bkrange->from_bkey.len, bkrange->from_bkey.val, bkrange->to_bkey.len, bkrange->to_bkey.val);
             ret = ENGINE_ELEM_ENOENT; break;
         }
     } while(0);

--- a/include/memcached/types.h
+++ b/include/memcached/types.h
@@ -326,14 +326,8 @@ extern "C" {
 
     /* bkey_range structure */
     typedef struct {
-        /******
         bkey_t   from_bkey;
         bkey_t   to_bkey;
-        ******/
-        unsigned char from_bkey[MAX_BKEY_LENG];
-        unsigned char to_bkey[MAX_BKEY_LENG];
-        uint8_t from_nbkey;
-        uint8_t to_nbkey;
     } bkey_range;
 
     /* eflag_filter structure */

--- a/lqdetect.c
+++ b/lqdetect.c
@@ -188,20 +188,20 @@ static int do_make_bkeystring(char *buffer,
 {
     char *bufptr = buffer;
     /* bkey */
-    if (bkrange->from_nbkey > 0) { /* hexadecimal */
+    if (bkrange->from_bkey.len > 0) { /* hexadecimal */
         memcpy(bufptr, "0x", 2); bufptr += 2;
-        safe_hexatostr(bkrange->from_bkey, bkrange->from_nbkey, bufptr);
+        safe_hexatostr(bkrange->from_bkey.val, bkrange->from_bkey.len, bufptr);
         bufptr += strlen(bufptr);
-        if (bkrange->to_nbkey != BKEY_NULL) { /* range */
+        if (bkrange->to_bkey.len != BKEY_NULL) { /* range */
             memcpy(bufptr, "..0x", 4); bufptr += 4;
-            safe_hexatostr(bkrange->to_bkey, bkrange->to_nbkey, bufptr);
+            safe_hexatostr(bkrange->to_bkey.val, bkrange->to_bkey.len, bufptr);
             bufptr += strlen(bufptr);
         }
     } else { /* 64bit unsigned integer */
-        const unsigned char* bkptr = bkrange->from_bkey;
+        const unsigned char* bkptr = bkrange->from_bkey.val;
         bufptr += sprintf(bufptr, "%"PRIu64"", *(uint64_t*)bkptr);
-        if (bkrange->to_nbkey != BKEY_NULL) { /* range */
-            bkptr = bkrange->to_bkey;
+        if (bkrange->to_bkey.len != BKEY_NULL) { /* range */
+            bkptr = bkrange->to_bkey.val;
             bufptr += sprintf(bufptr, "..%"PRIu64"", *(uint64_t*)bkptr);
         }
     }

--- a/memcached.c
+++ b/memcached.c
@@ -2557,10 +2557,10 @@ static void process_bop_mget_complete(conn *c)
         ret = ENGINE_ENOMEM;
     }
     if (ret == ENGINE_SUCCESS) {
-        if (c->coll_bkrange.to_nbkey == BKEY_NULL) {
-            memcpy(c->coll_bkrange.to_bkey, c->coll_bkrange.from_bkey,
-                   (c->coll_bkrange.from_nbkey==0 ? sizeof(uint64_t) : c->coll_bkrange.from_nbkey));
-            c->coll_bkrange.to_nbkey = c->coll_bkrange.from_nbkey;
+        if (c->coll_bkrange.to_bkey.len == BKEY_NULL) {
+            memcpy(c->coll_bkrange.to_bkey.val, c->coll_bkrange.from_bkey.val,
+                   (c->coll_bkrange.from_bkey.len==0 ? sizeof(uint64_t) : c->coll_bkrange.from_bkey.len));
+            c->coll_bkrange.to_bkey.len = c->coll_bkrange.from_bkey.len;
         }
         for (k = 0; k < c->coll_numkeys; k++) {
             ret = process_bop_mget_single(c, key_tokens[k].value, key_tokens[k].length,
@@ -2782,10 +2782,10 @@ static void process_bop_smget_complete(conn *c)
         ret = ENGINE_ENOMEM;
     }
     if (ret == ENGINE_SUCCESS) {
-        if (c->coll_bkrange.to_nbkey == BKEY_NULL) {
-            memcpy(c->coll_bkrange.to_bkey, c->coll_bkrange.from_bkey,
-                   (c->coll_bkrange.from_nbkey==0 ? sizeof(uint64_t) : c->coll_bkrange.from_nbkey));
-            c->coll_bkrange.to_nbkey = c->coll_bkrange.from_nbkey;
+        if (c->coll_bkrange.to_bkey.len == BKEY_NULL) {
+            memcpy(c->coll_bkrange.to_bkey.val, c->coll_bkrange.from_bkey.val,
+                   (c->coll_bkrange.from_bkey.len==0 ? sizeof(uint64_t) : c->coll_bkrange.from_bkey.len));
+            c->coll_bkrange.to_bkey.len = c->coll_bkrange.from_bkey.len;
         }
         assert(c->coll_numkeys > 0);
         assert(c->coll_rcount > 0);
@@ -5690,9 +5690,9 @@ static void process_bin_bop_update_prepare_nread(conn *c)
         real_nbkey = req->message.body.nbkey;
     }
     /* build bkey range */
-    memcpy(c->coll_bkrange.from_bkey, req->message.body.bkey, real_nbkey);
-    c->coll_bkrange.from_nbkey = req->message.body.nbkey;
-    c->coll_bkrange.to_nbkey   = BKEY_NULL;
+    memcpy(c->coll_bkrange.from_bkey.val, req->message.body.bkey, real_nbkey);
+    c->coll_bkrange.from_bkey.len = req->message.body.nbkey;
+    c->coll_bkrange.to_bkey.len   = BKEY_NULL;
     /* build elem update */
     c->coll_eupdate.offset = req->message.body.offset;
     c->coll_eupdate.bitwop = req->message.body.bitwop;
@@ -5775,19 +5775,19 @@ static void process_bin_bop_delete(conn *c)
     protocol_binary_request_bop_delete* req = binary_get_request(c);
     bkey_range   *bkrange = &req->message.body.bkrange;
     eflag_filter *efilter = &req->message.body.efilter;
-    if (bkrange->from_nbkey == 0) {
+    if (bkrange->from_bkey.len == 0) {
         uint64_t bkey_temp;
-        memcpy((unsigned char*)&bkey_temp, bkrange->from_bkey, sizeof(uint64_t));
+        memcpy((unsigned char*)&bkey_temp, bkrange->from_bkey.val, sizeof(uint64_t));
         bkey_temp = ntohll(bkey_temp);
-        memcpy(bkrange->from_bkey, (unsigned char*)&bkey_temp, sizeof(uint64_t));
-        //*(uint64_t*)bkrange->from_bkey = ntohll(*(uint64_t*)bkrange->from_bkey);
+        memcpy(bkrange->from_bkey.val, (unsigned char*)&bkey_temp, sizeof(uint64_t));
+        //*(uint64_t*)bkrange->from_bkey.val = ntohll(*(uint64_t*)bkrange->from_bkey.val);
     }
-    if (bkrange->to_nbkey   == 0) {
+    if (bkrange->to_bkey.len   == 0) {
         uint64_t bkey_temp;
-        memcpy((unsigned char*)&bkey_temp, bkrange->to_bkey, sizeof(uint64_t));
+        memcpy((unsigned char*)&bkey_temp, bkrange->to_bkey.val, sizeof(uint64_t));
         bkey_temp = ntohll(bkey_temp);
-        memcpy(bkrange->to_bkey, (unsigned char*)&bkey_temp, sizeof(uint64_t));
-        //*(uint64_t*)bkrange->to_bkey   = ntohll(*(uint64_t*)bkrange->to_bkey);
+        memcpy(bkrange->to_bkey.val, (unsigned char*)&bkey_temp, sizeof(uint64_t));
+        //*(uint64_t*)bkrange->to_bkey.val   = ntohll(*(uint64_t*)bkrange->to_bkey.val);
     }
     req->message.body.count = ntohl(req->message.body.count);
 
@@ -5927,19 +5927,19 @@ static void process_bin_bop_get(conn *c)
     protocol_binary_request_bop_get* req = binary_get_request(c);
     bkey_range   *bkrange = &req->message.body.bkrange;
     eflag_filter *efilter = &req->message.body.efilter;
-    if (bkrange->from_nbkey == 0) {
+    if (bkrange->from_bkey.len == 0) {
         uint64_t bkey_temp;
-        memcpy((unsigned char*)&bkey_temp, bkrange->from_bkey, sizeof(uint64_t));
+        memcpy((unsigned char*)&bkey_temp, bkrange->from_bkey.val, sizeof(uint64_t));
         bkey_temp = ntohll(bkey_temp);
-        memcpy(bkrange->from_bkey, (unsigned char*)&bkey_temp, sizeof(uint64_t));
-        //*(uint64_t*)bkrange->from_bkey = ntohll(*(uint64_t*)bkrange->from_bkey);
+        memcpy(bkrange->from_bkey.val, (unsigned char*)&bkey_temp, sizeof(uint64_t));
+        //*(uint64_t*)bkrange->from_bkey.val = ntohll(*(uint64_t*)bkrange->from_bkey.val);
     }
-    if (bkrange->to_nbkey   == 0) {
+    if (bkrange->to_bkey.len   == 0) {
         uint64_t bkey_temp;
-        memcpy((unsigned char*)&bkey_temp, bkrange->to_bkey, sizeof(uint64_t));
+        memcpy((unsigned char*)&bkey_temp, bkrange->to_bkey.val, sizeof(uint64_t));
         bkey_temp = ntohll(bkey_temp);
-        memcpy(bkrange->to_bkey, (unsigned char*)&bkey_temp, sizeof(uint64_t));
-        //*(uint64_t*)bkrange->to_bkey   = ntohll(*(uint64_t*)bkrange->to_bkey);
+        memcpy(bkrange->to_bkey.val, (unsigned char*)&bkey_temp, sizeof(uint64_t));
+        //*(uint64_t*)bkrange->to_bkey.val   = ntohll(*(uint64_t*)bkrange->to_bkey.val);
     }
     req->message.body.offset = ntohl(req->message.body.offset);
     req->message.body.count  = ntohl(req->message.body.count);
@@ -6024,19 +6024,19 @@ static void process_bin_bop_count(conn *c)
     protocol_binary_request_bop_count* req = binary_get_request(c);
     bkey_range   *bkrange = &req->message.body.bkrange;
     eflag_filter *efilter = &req->message.body.efilter;
-    if (bkrange->from_nbkey == 0) {
+    if (bkrange->from_bkey.len == 0) {
         uint64_t bkey_temp;
-        memcpy((unsigned char*)&bkey_temp, bkrange->from_bkey, sizeof(uint64_t));
+        memcpy((unsigned char*)&bkey_temp, bkrange->from_bkey.val, sizeof(uint64_t));
         bkey_temp = ntohll(bkey_temp);
-        memcpy(bkrange->from_bkey, (unsigned char*)&bkey_temp, sizeof(uint64_t));
-        //*(uint64_t*)bkrange->from_bkey = ntohll(*(uint64_t*)bkrange->from_bkey);
+        memcpy(bkrange->from_bkey.val, (unsigned char*)&bkey_temp, sizeof(uint64_t));
+        //*(uint64_t*)bkrange->from_bkey.val = ntohll(*(uint64_t*)bkrange->from_bkey.val);
     }
-    if (bkrange->to_nbkey   == 0) {
+    if (bkrange->to_bkey.len   == 0) {
         uint64_t bkey_temp;
-        memcpy((unsigned char*)&bkey_temp, bkrange->to_bkey, sizeof(uint64_t));
+        memcpy((unsigned char*)&bkey_temp, bkrange->to_bkey.val, sizeof(uint64_t));
         bkey_temp = ntohll(bkey_temp);
-        memcpy(bkrange->to_bkey, (unsigned char*)&bkey_temp, sizeof(uint64_t));
-        //*(uint64_t*)bkrange->to_bkey   = ntohll(*(uint64_t*)bkrange->to_bkey);
+        memcpy(bkrange->to_bkey.val, (unsigned char*)&bkey_temp, sizeof(uint64_t));
+        //*(uint64_t*)bkrange->to_bkey.val   = ntohll(*(uint64_t*)bkrange->to_bkey.val);
     }
 
     if (settings.verbose > 1) {
@@ -6123,19 +6123,19 @@ static void process_bin_bop_prepare_nread_keys(conn *c)
     /* fix byteorder in the request */
     protocol_binary_request_bop_mkeys* req = binary_get_request(c);
     bkey_range   *bkrange = &req->message.body.bkrange;
-    if (bkrange->from_nbkey == 0) {
+    if (bkrange->from_bkey.len == 0) {
         uint64_t bkey_temp;
-        memcpy((unsigned char*)&bkey_temp, bkrange->from_bkey, sizeof(uint64_t));
+        memcpy((unsigned char*)&bkey_temp, bkrange->from_bkey.val, sizeof(uint64_t));
         bkey_temp = ntohll(bkey_temp);
-        memcpy(bkrange->from_bkey, (unsigned char*)&bkey_temp, sizeof(uint64_t));
-        //*(uint64_t*)bkrange->from_bkey = ntohll(*(uint64_t*)bkrange->from_bkey);
+        memcpy(bkrange->from_bkey.val, (unsigned char*)&bkey_temp, sizeof(uint64_t));
+        //*(uint64_t*)bkrange->from_bkey.val = ntohll(*(uint64_t*)bkrange->from_bkey.val);
     }
-    if (bkrange->to_nbkey   == 0) {
+    if (bkrange->to_bkey.len   == 0) {
         uint64_t bkey_temp;
-        memcpy((unsigned char*)&bkey_temp, bkrange->to_bkey, sizeof(uint64_t));
+        memcpy((unsigned char*)&bkey_temp, bkrange->to_bkey.val, sizeof(uint64_t));
         bkey_temp = ntohll(bkey_temp);
-        memcpy(bkrange->to_bkey, (unsigned char*)&bkey_temp, sizeof(uint64_t));
-        //*(uint64_t*)bkrange->to_bkey   = ntohll(*(uint64_t*)bkrange->to_bkey);
+        memcpy(bkrange->to_bkey.val, (unsigned char*)&bkey_temp, sizeof(uint64_t));
+        //*(uint64_t*)bkrange->to_bkey.val   = ntohll(*(uint64_t*)bkrange->to_bkey.val);
     }
     req->message.body.req_offset = ntohl(req->message.body.req_offset);
     req->message.body.req_count  = ntohl(req->message.body.req_count);
@@ -6287,10 +6287,10 @@ static void process_bin_bop_smget_complete(conn *c)
         ret = ENGINE_ENOMEM;
     }
     if (ret == ENGINE_SUCCESS) {
-        if (c->coll_bkrange.to_nbkey == BKEY_NULL) {
-            memcpy(c->coll_bkrange.to_bkey, c->coll_bkrange.from_bkey,
-                   (c->coll_bkrange.from_nbkey==0 ? sizeof(uint64_t) : c->coll_bkrange.from_nbkey));
-            c->coll_bkrange.to_nbkey = c->coll_bkrange.from_nbkey;
+        if (c->coll_bkrange.to_bkey.len == BKEY_NULL) {
+            memcpy(c->coll_bkrange.to_bkey.val, c->coll_bkrange.from_bkey.val,
+                   (c->coll_bkrange.from_bkey.len==0 ? sizeof(uint64_t) : c->coll_bkrange.from_bkey.len));
+            c->coll_bkrange.to_bkey.len = c->coll_bkrange.from_bkey.len;
         }
         assert(c->coll_numkeys > 0);
         assert(c->coll_rcount > 0);
@@ -12092,31 +12092,31 @@ static inline int get_bkey_range_from_str(const char *str, bkey_range *bkrange)
         char *nxt = delimiter + 2;
         *delimiter = '\0';
         if (strncmp(str, "0x", 2) == 0 && strncmp(nxt, "0x", 2) == 0) {
-            if (! safe_strtohexa(str+2, bkrange->from_bkey, MAX_BKEY_LENG) ||
-                ! safe_strtohexa(nxt+2, bkrange->to_bkey,   MAX_BKEY_LENG)) {
+            if (! safe_strtohexa(str+2, bkrange->from_bkey.val, MAX_BKEY_LENG) ||
+                ! safe_strtohexa(nxt+2, bkrange->to_bkey.val,   MAX_BKEY_LENG)) {
                 *delimiter = '.'; return -1;
             }
-            bkrange->from_nbkey = strlen(str+2)/2;
-            bkrange->to_nbkey   = strlen(nxt+2)/2;
+            bkrange->from_bkey.len = strlen(str+2)/2;
+            bkrange->to_bkey.len   = strlen(nxt+2)/2;
         } else {
-            if (! safe_strtoull(str, (uint64_t*)bkrange->from_bkey) ||
-                ! safe_strtoull(nxt, (uint64_t*)bkrange->to_bkey)) {
+            if (! safe_strtoull(str, (uint64_t*)bkrange->from_bkey.val) ||
+                ! safe_strtoull(nxt, (uint64_t*)bkrange->to_bkey.val)) {
                 *delimiter = '.'; return -1;
             }
-            bkrange->from_nbkey = bkrange->to_nbkey = 0;
+            bkrange->from_bkey.len = bkrange->to_bkey.len = 0;
         }
         *delimiter = '.';
     } else { /* single index */
         if (strncmp(str, "0x", 2) == 0) { /* hexadeciaml bkey */
-            if (! safe_strtohexa(str+2, bkrange->from_bkey, MAX_BKEY_LENG))
+            if (! safe_strtohexa(str+2, bkrange->from_bkey.val, MAX_BKEY_LENG))
                 return -1;
-            bkrange->from_nbkey = strlen(str+2)/2;
+            bkrange->from_bkey.len = strlen(str+2)/2;
         } else { /* 64 bit unsigned integer */
-            if (! safe_strtoull(str, (uint64_t*)bkrange->from_bkey))
+            if (! safe_strtoull(str, (uint64_t*)bkrange->from_bkey.val))
                 return -1;
-            bkrange->from_nbkey = 0;
+            bkrange->from_bkey.len = 0;
         }
-        bkrange->to_nbkey = BKEY_NULL;
+        bkrange->to_bkey.len = BKEY_NULL;
     }
     return 0;
 }
@@ -12743,7 +12743,7 @@ static void process_bop_command(conn *c, token_t *tokens, const size_t ntokens)
 
         /* Only single bkey supported */
         if (get_bkey_range_from_str(tokens[BOP_KEY_TOKEN+1].value, &c->coll_bkrange) != 0 ||
-            c->coll_bkrange.to_nbkey != BKEY_NULL) {
+            c->coll_bkrange.to_bkey.len != BKEY_NULL) {
             print_invalid_command(c, tokens, ntokens);
             out_string(c, "CLIENT_ERROR bad command line format");
             return;
@@ -12895,7 +12895,7 @@ static void process_bop_command(conn *c, token_t *tokens, const size_t ntokens)
         set_pipe_noreply_maybe(c, tokens, ntokens);
 
         if ((get_bkey_range_from_str(tokens[BOP_KEY_TOKEN+1].value, &c->coll_bkrange) != 0) ||
-            (c->coll_bkrange.to_nbkey != BKEY_NULL) ||
+            (c->coll_bkrange.to_bkey.len != BKEY_NULL) ||
             (! safe_strtoull(tokens[BOP_KEY_TOKEN+2].value, &delta)) || (delta < 1)) {
             print_invalid_command(c, tokens, ntokens);
             out_string(c, "CLIENT_ERROR bad command line format");
@@ -13135,7 +13135,7 @@ static void process_bop_command(conn *c, token_t *tokens, const size_t ntokens)
         CHECK_NTOKENS_EQ(ntokens, 6);
 
         if ((get_bkey_range_from_str(tokens[BOP_KEY_TOKEN+1].value, &c->coll_bkrange) != 0) ||
-            (c->coll_bkrange.to_nbkey != BKEY_NULL)) {
+            (c->coll_bkrange.to_bkey.len != BKEY_NULL)) {
             print_invalid_command(c, tokens, ntokens);
             out_string(c, "CLIENT_ERROR bad command line format");
             return;
@@ -13160,7 +13160,7 @@ static void process_bop_command(conn *c, token_t *tokens, const size_t ntokens)
         CHECK_NTOKENS(ntokens, 6, 7);
 
         if ((get_bkey_range_from_str(tokens[BOP_KEY_TOKEN+1].value, &c->coll_bkrange) != 0) ||
-            (c->coll_bkrange.to_nbkey != BKEY_NULL)) {
+            (c->coll_bkrange.to_bkey.len != BKEY_NULL)) {
             print_invalid_command(c, tokens, ntokens);
             out_string(c, "CLIENT_ERROR bad command line format");
             return;


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/844#issuecomment-5043688049

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
maxbkeyrange 관련 로직의 가독성을 개선했습니다.

- `bkey_range` 구조체의 `from_bkey`, `to_bkey` 필드를 `bkey_t` 타입으로 변경했습니다.
- maxbkeyrange 계산에 쓰이는 BKEY_* 함수들의 인터페이스를 `bkey_t` 기반으로 리팩토링했습니다.
  - `BKEY_DIFF`: out-param 스타일 → `bkey_t` 반환값으로 전환, `len` 인자명을 `precision`으로 변경했습니다.
  - `BKEY_DECR`: `(bk, nbk)` 분리 인자 → `(bkey_t *)` 단일 인자로 변경했습니다.
  - `BKEY_OF` 추가: elem에서 `bkey_t`를 추출하는 함수로, `BKEY_COPY` 매크로와 `do_btree_copy_bkey`를 대체했습니다.

편의를 위해 bkey_t 타입 변경 커밋과 BKEY_xx 매크로 리팩토링 커밋으로 분리했습니다.
PR이 승인 되면 하나의 커밋으로 합칠 예정입니다.